### PR TITLE
Add naming rules for Attribute, EventArgs, and Exception

### DIFF
--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -60,6 +60,9 @@ namespace Meziantou.Analyzer
         public const string IncludeCatchExceptionAsInnerException = "MA0054";
         public const string DoNotUseDestructor = "MA0055";
         public const string DoNotCallVirtualMethodInConstructor = "MA0056";
+        public const string AttributeNameShouldEndWithAttribute = "MA0057";
+        public const string ExceptionNameShouldEndWithException = "MA0058";
+        public const string EventArgsNameShouldEndWithEventArgs = "MA0059";
 
         public static string GetHelpUri(string idenfifier)
         {

--- a/src/Meziantou.Analyzer/Rules/AttributeNameShouldEndWithAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AttributeNameShouldEndWithAttributeAnalyzer.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Analyzer.Rules
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class AttributeNameShouldEndWithAttributeAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(
+            RuleIdentifiers.AttributeNameShouldEndWithAttribute,
+            title: "Class name should end with 'Attribute'",
+            messageFormat: "Class name should end with 'Attribute'",
+            RuleCategories.Naming,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "",
+            helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.AttributeNameShouldEndWithAttribute));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = (INamedTypeSymbol)context.Symbol;
+            if (symbol.Name == null)
+                return;
+
+            if (!symbol.Name.EndsWith("Attribute", System.StringComparison.Ordinal) && symbol.InheritsFrom(context.Compilation.GetTypeByMetadataName("System.Attribute")))
+            {
+                context.ReportDiagnostic(s_rule, symbol);
+            }
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/EventArgsNameShouldEndWithEventArgsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventArgsNameShouldEndWithEventArgsAnalyzer.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Analyzer.Rules
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class EventArgsNameShouldEndWithEventArgsAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(
+            RuleIdentifiers.EventArgsNameShouldEndWithEventArgs,
+            title: "Class name should end with 'EventArgs'",
+            messageFormat: "Class name should end with 'EventArgs'",
+            RuleCategories.Naming,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "",
+            helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.EventArgsNameShouldEndWithEventArgs));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = (INamedTypeSymbol)context.Symbol;
+            if (symbol.Name == null)
+                return;
+
+            if (!symbol.Name.EndsWith("EventArgs", System.StringComparison.Ordinal) && symbol.InheritsFrom(context.Compilation.GetTypeByMetadataName("System.EventArgs")))
+            {
+                context.ReportDiagnostic(s_rule, symbol);
+            }
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/ExceptionNameShouldEndWithExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ExceptionNameShouldEndWithExceptionAnalyzer.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Analyzer.Rules
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ExceptionNameShouldEndWithExceptionAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(
+            RuleIdentifiers.ExceptionNameShouldEndWithException,
+            title: "Class name should end with 'Exception'",
+            messageFormat: "Class name should end with 'Exception'",
+            RuleCategories.Naming,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "",
+            helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.ExceptionNameShouldEndWithException));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var symbol = (INamedTypeSymbol)context.Symbol;
+            if (symbol.Name == null)
+                return;
+
+            if (!symbol.Name.EndsWith("Exception", System.StringComparison.Ordinal) && symbol.InheritsFrom(context.Compilation.GetTypeByMetadataName("System.Exception")))
+            {
+                context.ReportDiagnostic(s_rule, symbol);
+            }
+        }
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/AttributeNameShouldEndWithAttributeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AttributeNameShouldEndWithAttributeAnalyzerTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using Meziantou.Analyzer.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules
+{
+    [TestClass]
+    public sealed class AttributeNameShouldEndWithAttributeAnalyzerTests
+    {
+        private static ProjectBuilder CreateProjectBuilder()
+        {
+            return new ProjectBuilder()
+                .WithAnalyzer<AttributeNameShouldEndWithAttributeAnalyzer>();
+        }
+
+        [TestMethod]
+        public async Task NameEndsWithAttribute()
+        {
+            const string SourceCode = @"
+class CustomAttribute : System.Attribute
+{
+}
+";
+            await CreateProjectBuilder()
+                  .WithSourceCode(SourceCode)
+                  .ValidateAsync();
+        }
+
+        [TestMethod]
+        public async Task NameDoesNotEndWithAttribute()
+        {
+            const string SourceCode = @"
+class [|]CustomAttr : System.Attribute
+{
+}
+";
+            await CreateProjectBuilder()
+                  .WithSourceCode(SourceCode)
+                  .ValidateAsync();
+        }
+
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/EventArgsNameShouldEndWithEventArgsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EventArgsNameShouldEndWithEventArgsAnalyzerTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using Meziantou.Analyzer.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules
+{
+    [TestClass]
+    public sealed class EventArgsNameShouldEndWithEventArgsAnalyzerTests
+    {
+        private static ProjectBuilder CreateProjectBuilder()
+        {
+            return new ProjectBuilder()
+                .WithAnalyzer<EventArgsNameShouldEndWithEventArgsAnalyzer>();
+        }
+
+        [TestMethod]
+        public async Task NameEndsWithEventArgs()
+        {
+            const string SourceCode = @"
+class CustomEventArgs : System.EventArgs
+{
+}
+";
+            await CreateProjectBuilder()
+                  .WithSourceCode(SourceCode)
+                  .ValidateAsync();
+        }
+
+        [TestMethod]
+        public async Task NameDoesNotEndWithEventArgs()
+        {
+            const string SourceCode = @"
+class [|]CustomArgs : System.EventArgs
+{
+}
+";
+            await CreateProjectBuilder()
+                  .WithSourceCode(SourceCode)
+                  .ValidateAsync();
+        }
+
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/ExceptionNameShouldEndWithExceptionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ExceptionNameShouldEndWithExceptionAnalyzerTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using Meziantou.Analyzer.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules
+{
+    [TestClass]
+    public sealed class ExceptionNameShouldEndWithExceptionAnalyzerTests
+    {
+        private static ProjectBuilder CreateProjectBuilder()
+        {
+            return new ProjectBuilder()
+                .WithAnalyzer<ExceptionNameShouldEndWithExceptionAnalyzer>();
+        }
+
+        [TestMethod]
+        public async Task NameEndsWithException()
+        {
+            const string SourceCode = @"
+class CustomException : System.Exception
+{
+}
+";
+            await CreateProjectBuilder()
+                  .WithSourceCode(SourceCode)
+                  .ValidateAsync();
+        }
+
+        [TestMethod]
+        public async Task NameDoesNotEndWithAttribute()
+        {
+            const string SourceCode = @"
+class [|]CustomEx : System.Exception
+{
+}
+";
+            await CreateProjectBuilder()
+                  .WithSourceCode(SourceCode)
+                  .ValidateAsync();
+        }
+
+    }
+}


### PR DESCRIPTION
/fix #31 

- Add MA0057: Attribute name should end with 'Attribute'
- Add MA0058: Exception name should end with 'Exception'
- Add MA0059: EventArgs name should end with 'EventArgs'