### PR TITLE
Fix typo in MA0050.md

### DIFF
--- a/docs/Rules/MA0050.md
+++ b/docs/Rules/MA0050.md
@@ -20,7 +20,7 @@ IEnumerable<int> Sample(string a)
     if (a == null)
         throw new System.ArgumentNullException(nameof(a));
 
-    Sample();
+    return Sample();
     IEnumerable<int> Sample()
     {
         yield return 0;


### PR DESCRIPTION
Did you meant `return Sample();` ?