### PR TITLE
Rename IncludeCatchExceptionAsInnerException

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@
 |[MA0051](Rules/MA0051.md)|Design|Method is too long|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0052](Rules/MA0052.md)|Performance|Replace with nameof|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0053](Rules/MA0053.md)|Design|Make class sealed|<span title='Info'>ℹ️</span>|✔️|✔️|
-|[MA0054](Rules/MA0054.md)|Design|Preserve the catched exception in the innerException|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0054](Rules/MA0054.md)|Design|Embed caught exception as innerException|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0055](Rules/MA0055.md)|Design|Do not use destructor|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0056](Rules/MA0056.md)|Design|Do not call overridable members in constructor|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0057](Rules/MA0057.md)|Naming|Class name should end with 'Attribute'|<span title='Info'>ℹ️</span>|✔️|❌|

--- a/docs/Rules/MA0054.md
+++ b/docs/Rules/MA0054.md
@@ -1,4 +1,4 @@
-# MA0054 - Include catched exception as inner exception
+# MA0054 - Embed caught exception as inner exception
 
 You should include the original exception when you throw an exception in a `catch` block. This way you don't hide the original exception and this is easier to debug.
 

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -56,7 +56,7 @@ namespace Meziantou.Analyzer
         public const string MethodShouldNotBeTooLong = "MA0051";
         public const string ReplaceEnumToStringWithNameof = "MA0052";
         public const string ClassMustBeSealed = "MA0053";
-        public const string IncludeCatchExceptionAsInnerException = "MA0054";
+        public const string EmbedCaughtExceptionAsInnerException = "MA0054";
         public const string DoNotUseDestructor = "MA0055";
         public const string DoNotCallVirtualMethodInConstructor = "MA0056";
         public const string AttributeNameShouldEndWithAttribute = "MA0057";

--- a/src/Meziantou.Analyzer/Rules/EmbedCaughtExceptionAsInnerExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EmbedCaughtExceptionAsInnerExceptionAnalyzer.cs
@@ -7,12 +7,12 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Meziantou.Analyzer.Rules
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class IncludeCatchExceptionAsInnerExceptionAnalyzer : DiagnosticAnalyzer
+    public sealed class EmbedCaughtExceptionAsInnerExceptionAnalyzer : DiagnosticAnalyzer
     {
         private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(
-            RuleIdentifiers.IncludeCatchExceptionAsInnerException,
-            title: "Preserve the catched exception in the innerException",
-            messageFormat: "Preserve the catched exception in the innerException",
+            RuleIdentifiers.EmbedCaughtExceptionAsInnerException,
+            title: "Embed the caught exception as innerException",
+            messageFormat: "Embed the caught exception as innerException",
             RuleCategories.Design,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,

--- a/tests/Meziantou.Analyzer.Test/Rules/EmbedCaughtExceptionAsInnerExceptionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EmbedCaughtExceptionAsInnerExceptionAnalyzerTests.cs
@@ -5,16 +5,16 @@ using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules
 {
-    public sealed class IncludeCatchExceptionAsInnerExceptionAnalyzerTests
+    public sealed class EmbedCaughtExceptionAsInnerExceptionAnalyzerTests
     {
         private static ProjectBuilder CreateProjectBuilder()
         {
             return new ProjectBuilder()
-                .WithAnalyzer<IncludeCatchExceptionAsInnerExceptionAnalyzer>();
+                .WithAnalyzer<EmbedCaughtExceptionAsInnerExceptionAnalyzer>();
         }
 
         [Fact]
-        public async Task NotInCatchException_ShouldNotReportDiagnostic()
+        public async Task NotInCaughtException_ShouldNotReportDiagnostic()
         {
             const string SourceCode = @"
 class Test
@@ -30,7 +30,7 @@ class Test
         }
 
         [Fact]
-        public async Task InCatchExceptionWithInnerException_ShouldNotReportDiagnostic()
+        public async Task InCaughtExceptionWithInnerException_ShouldNotReportDiagnostic()
         {
             const string SourceCode = @"
 class Test
@@ -52,7 +52,7 @@ class Test
         }
 
         [Fact]
-        public async Task InCatchExceptionWithoutInnerException_ShouldReportDiagnostic()
+        public async Task InCaughtExceptionWithoutInnerException_ShouldReportDiagnostic()
         {
             const string SourceCode = @"
 class Test
@@ -74,7 +74,7 @@ class Test
         }
 
         [Fact]
-        public async Task InCatchExceptionWithoutInnerException_NoConstructorWithInnerException_ShouldNotReportDiagnostic()
+        public async Task InCaughtExceptionWithoutInnerException_NoConstructorWithInnerException_ShouldNotReportDiagnostic()
         {
             const string SourceCode = @"
 class Test


### PR DESCRIPTION
- Rename IncludeCatchExceptionAsInnerException as EmbedCaughtExceptionAsInnerException.
- Make ensuing related changes.