### PR TITLE
Add a test that reproduces issue 146 and make changes to address it

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,4 +75,4 @@
 |[MA0074](Rules/MA0074.md)|Usage|Avoid implicit culture-sensitive methods|<span title='Warning'>⚠️</span>|✔️|✔️|
 |[MA0075](Rules/MA0075.md)|Design|Do not use implicit culture-sensitive ToString|<span title='Info'>ℹ️</span>|✔️|❌|
 |[MA0076](Rules/MA0076.md)|Design|Do not use implicit culture-sensitive ToString in interpolated strings|<span title='Info'>ℹ️</span>|✔️|❌|
-|[MA0077](Rules/MA0077.md)|Design|A class that provides Equals(T) should implement IEquatable<T>|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0077](Rules/MA0077.md)|Design|A class that provides Equals(T) should implement IEquatable<T>|<span title='Warning'>⚠️</span>|✔️|✔️|

--- a/src/Meziantou.Analyzer/Internals/DocumentBasedFixAllProvider.cs
+++ b/src/Meziantou.Analyzer/Internals/DocumentBasedFixAllProvider.cs
@@ -1,0 +1,130 @@
+﻿// File initially copied from
+//  https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/DocumentBasedFixAllProvider.cs
+// Original copyright statement:
+//  Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+//  Licensed under the MIT License. See LICENSE in the project root for license information.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Analyzer
+{
+    /// <summary>
+    /// Provides a base class to write a <see cref="FixAllProvider"/> that fixes documents independently.
+    /// </summary>
+    internal abstract class DocumentBasedFixAllProvider : FixAllProvider
+    {
+        protected abstract string CodeActionTitle { get; }
+
+        public override Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+        {
+            CodeAction fixAction;
+            switch (fixAllContext.Scope)
+            {
+                case FixAllScope.Document:
+                    fixAction = CodeAction.Create(
+                        CodeActionTitle,
+                        cancellationToken => GetDocumentFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                        nameof(DocumentBasedFixAllProvider));
+                    break;
+
+                case FixAllScope.Project:
+                    fixAction = CodeAction.Create(
+                        CodeActionTitle,
+                        cancellationToken => GetProjectFixesAsync(fixAllContext.WithCancellationToken(cancellationToken), fixAllContext.Project),
+                        nameof(DocumentBasedFixAllProvider));
+                    break;
+
+                case FixAllScope.Solution:
+                    fixAction = CodeAction.Create(
+                        CodeActionTitle,
+                        cancellationToken => GetSolutionFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                        nameof(DocumentBasedFixAllProvider));
+                    break;
+
+                case FixAllScope.Custom:
+                default:
+                    fixAction = null;
+                    break;
+            }
+
+            return Task.FromResult(fixAction);
+        }
+
+        /// <summary>
+        /// Fixes all occurrences of a diagnostic in a specific document.
+        /// </summary>
+        /// <param name="fixAllContext">The context for the Fix All operation.</param>
+        /// <param name="document">The document to fix.</param>
+        /// <param name="diagnostics">The diagnostics to fix in the document.</param>
+        /// <returns>
+        /// <para>The new <see cref="SyntaxNode"/> representing the root of the fixed document.</para>
+        /// <para>-or-</para>
+        /// <para><see langword="null"/>, if no changes were made to the document.</para>
+        /// </returns>
+        protected abstract Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics);
+
+        private async Task<Document> GetDocumentFixesAsync(FixAllContext fixAllContext)
+        {
+            var documentDiagnosticsToFix = await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
+            if (!documentDiagnosticsToFix.TryGetValue(fixAllContext.Document, out var diagnostics))
+            {
+                return fixAllContext.Document;
+            }
+
+            var newRoot = await FixAllInDocumentAsync(fixAllContext, fixAllContext.Document, diagnostics).ConfigureAwait(false);
+            if (newRoot == null)
+            {
+                return fixAllContext.Document;
+            }
+
+            return fixAllContext.Document.WithSyntaxRoot(newRoot);
+        }
+
+        private async Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext, ImmutableArray<Document> documents)
+        {
+            var documentDiagnosticsToFix = await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
+
+            var solution = fixAllContext.Solution;
+            var newDocuments = new List<Task<SyntaxNode>>(documents.Length);
+            foreach (var document in documents)
+            {
+                if (!documentDiagnosticsToFix.TryGetValue(document, out var diagnostics))
+                {
+                    newDocuments.Add(document.GetSyntaxRootAsync(fixAllContext.CancellationToken));
+                    continue;
+                }
+
+                newDocuments.Add(FixAllInDocumentAsync(fixAllContext, document, diagnostics));
+            }
+
+            for (var i = 0; i < documents.Length; i++)
+            {
+                var newDocumentRoot = await newDocuments[i].ConfigureAwait(false);
+                if (newDocumentRoot == null)
+                {
+                    continue;
+                }
+
+                solution = solution.WithDocumentSyntaxRoot(documents[i].Id, newDocumentRoot);
+            }
+
+            return solution;
+        }
+
+        private Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext, Project project)
+        {
+            return GetSolutionFixesAsync(fixAllContext, project.Documents.ToImmutableArray());
+        }
+
+        private Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext)
+        {
+            var documents = fixAllContext.Solution.Projects.SelectMany(i => i.Documents).ToImmutableArray();
+            return GetSolutionFixesAsync(fixAllContext, documents);
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/Internals/FixAllContextHelper.cs
+++ b/src/Meziantou.Analyzer/Internals/FixAllContextHelper.cs
@@ -1,0 +1,137 @@
+﻿// File initially copied from
+//  https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
+// Original copyright statement:
+//  Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+//  Licensed under the MIT License. See LICENSE in the project root for license information.
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Analyzer
+{
+    internal static class FixAllContextHelper
+    {
+        public static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(FixAllContext fixAllContext)
+        {
+            var allDiagnostics = ImmutableArray<Diagnostic>.Empty;
+            var projectsToFix = ImmutableArray<Project>.Empty;
+
+            var document = fixAllContext.Document;
+            var project = fixAllContext.Project;
+
+            switch (fixAllContext.Scope)
+            {
+                case FixAllScope.Document:
+                    if (document != null)
+                    {
+                        var documentDiagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                        return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty.SetItem(document, documentDiagnostics);
+                    }
+
+                    break;
+
+                case FixAllScope.Project:
+                    projectsToFix = ImmutableArray.Create(project);
+                    allDiagnostics = await GetAllDiagnosticsAsync(fixAllContext, project).ConfigureAwait(false);
+                    break;
+
+                case FixAllScope.Solution:
+                    projectsToFix = project.Solution.Projects
+                        .Where(p => p.Language == project.Language)
+                        .ToImmutableArray();
+
+                    var diagnostics = new ConcurrentDictionary<ProjectId, ImmutableArray<Diagnostic>>();
+                    var tasks = new Task[projectsToFix.Length];
+                    for (var i = 0; i < projectsToFix.Length; i++)
+                    {
+                        fixAllContext.CancellationToken.ThrowIfCancellationRequested();
+                        var projectToFix = projectsToFix[i];
+                        tasks[i] = Task.Run(
+                            async () =>
+                            {
+                                var projectDiagnostics = await GetAllDiagnosticsAsync(fixAllContext, projectToFix).ConfigureAwait(false);
+                                diagnostics.TryAdd(projectToFix.Id, projectDiagnostics);
+                            }, fixAllContext.CancellationToken);
+                    }
+
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+                    allDiagnostics = allDiagnostics.AddRange(diagnostics.SelectMany(i => i.Value.Where(x => fixAllContext.DiagnosticIds.Contains(x.Id))));
+                    break;
+            }
+
+            if (allDiagnostics.IsEmpty)
+            {
+                return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty;
+            }
+
+            return await GetDocumentDiagnosticsToFixAsync(allDiagnostics, projectsToFix, fixAllContext.CancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets all <see cref="Diagnostic"/> instances within a specific <see cref="Project"/> which are relevant to a
+        /// <see cref="FixAllContext"/>.
+        /// </summary>
+        /// <param name="fixAllContext">The context for the Fix All operation.</param>
+        /// <param name="project">The project.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. When the task completes
+        /// successfully, the <see cref="Task{TResult}.Result"/> will contain the requested diagnostics.</returns>
+        private static async Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsAsync(FixAllContext fixAllContext, Project project)
+        {
+            return await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+        }
+
+        private static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(
+            ImmutableArray<Diagnostic> diagnostics,
+            ImmutableArray<Project> projects,
+            CancellationToken cancellationToken)
+        {
+            var treeToDocumentMap = await GetTreeToDocumentMapAsync(projects, cancellationToken).ConfigureAwait(false);
+
+            var builder = ImmutableDictionary.CreateBuilder<Document, ImmutableArray<Diagnostic>>();
+            foreach (var documentAndDiagnostics in diagnostics.GroupBy(d => GetReportedDocument(d, treeToDocumentMap)))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var document = documentAndDiagnostics.Key;
+                var diagnosticsForDocument = documentAndDiagnostics.ToImmutableArray();
+                builder.Add(document, diagnosticsForDocument);
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static async Task<ImmutableDictionary<SyntaxTree, Document>> GetTreeToDocumentMapAsync(ImmutableArray<Project> projects, CancellationToken cancellationToken)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<SyntaxTree, Document>();
+            foreach (var project in projects)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                foreach (var document in project.Documents)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                    builder.Add(tree, document);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static Document GetReportedDocument(Diagnostic diagnostic, ImmutableDictionary<SyntaxTree, Document> treeToDocumentsMap)
+        {
+            var tree = diagnostic.Location.SourceTree;
+            if (tree != null)
+            {
+                if (treeToDocumentsMap.TryGetValue(tree, out var document))
+                {
+                    return document;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseFixAllProvider.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseFixAllProvider.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Analyzer.Rules
+{
+    internal sealed class AvoidUsingRedundantElseFixAllProvider : DocumentBasedFixAllProvider
+    {
+        public static AvoidUsingRedundantElseFixAllProvider Instance { get; } = new AvoidUsingRedundantElseFixAllProvider();
+
+        protected override string CodeActionTitle => "Remove redundant else";
+
+        /// <inheritdoc/>
+        protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
+        {
+            if (diagnostics.IsEmpty)
+                return null;
+
+            var newDocument = await AvoidUsingRedundantElseFixer.RemoveRedundantElseClausesInDocument(document, diagnostics, fixAllContext.CancellationToken).ConfigureAwait(false);
+
+            return await newDocument.GetSyntaxRootAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseFixer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseFixer.cs
@@ -41,7 +41,7 @@ namespace Meziantou.Analyzer.Rules
 
         internal static async Task<Document> RemoveRedundantElseClausesInDocument(Document document, ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
-            foreach (var diagnostic in diagnostics.Reverse())
+            foreach (var diagnostic in diagnostics.OrderByDescending(d => d.Location.SourceSpan))
             {
                 var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var nodeToFix = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
@@ -490,20 +490,16 @@ namespace TestHelper
                 return GetProjectDiagnosticsAsync(project, cancellationToken);
             }
 
-            public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+            public override async Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.FromResult(_diagnostics.Where(diagnostic => IsDiagnosticForDocument(diagnostic, document)));
+                var documentRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
+                return _diagnostics.Where(diagnostic => documentRoot == diagnostic.Location.SourceTree.GetRoot());
             }
 
             public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
             {
                 var diagnostics = project.Documents.SelectMany(doc => GetDocumentDiagnosticsAsync(doc, cancellationToken).Result);
                 return Task.FromResult(diagnostics);
-            }
-
-            private static bool IsDiagnosticForDocument(Diagnostic diagnostic, Document document)
-            {
-                return string.Equals(diagnostic.Location.SourceTree.FilePath, document.FilePath, StringComparison.OrdinalIgnoreCase);
             }
         }
     }

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
@@ -36,6 +36,7 @@ namespace TestHelper
         public IList<DiagnosticResult> ExpectedDiagnosticResults { get; } = new List<DiagnosticResult>();
         public string ExpectedFixedCode { get; private set; }
         public int? CodeFixIndex { get; private set; }
+        public bool UseBatchFixer { get; private set; }
         public string DefaultAnalyzerId { get; set; }
         public string DefaultAnalyzerMessage { get; set; }
 
@@ -273,6 +274,19 @@ namespace TestHelper
         {
             ExpectedFixedCode = codeFix;
             CodeFixIndex = index;
+            return this;
+        }
+
+        public ProjectBuilder ShouldBatchFixCodeWith(string codeFix)
+        {
+            return ShouldBatchFixCodeWith(index: null, codeFix);
+        }
+
+        public ProjectBuilder ShouldBatchFixCodeWith(int? index, string codeFix)
+        {
+            ExpectedFixedCode = codeFix;
+            CodeFixIndex = index;
+            UseBatchFixer = true;
             return this;
         }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/AbstractTypesShouldNotHaveConstructorsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AbstractTypesShouldNotHaveConstructorsAnalyzerTests.cs
@@ -77,5 +77,30 @@ abstract class Test
                     .ShouldFixCodeWith(codeFix)
                     .ValidateAsync();
         }
+
+        [Fact]
+        public async Task InternalCtor_BatchFix()
+        {
+            var sourceCode = @"
+abstract class Test
+{
+    internal [||]Test() { }
+
+    internal [||]Test(int a) { }
+}";
+
+            var codeFix = @"
+abstract class Test
+{
+    protected Test() { }
+
+    protected Test(int a) { }
+}";
+
+            await CreateProjectBuilder()
+                    .WithSourceCode(sourceCode)
+                    .ShouldBatchFixCodeWith(codeFix)
+                    .ValidateAsync();
+        }
     }
 }


### PR DESCRIPTION
This addresses https://github.com/meziantou/Meziantou.Analyzer/issues/146

- Add Test_SeveralNestedIfElseBlocksWithIfsThatJump_AllProblematicElsesRemoved
- Copy over
    - DocumentBasedFixAllProvider.cs, and
    - FixAllContextHelper.cs
  from https://github.com/DotNetAnalyzers/StyleCopAnalyzers
- Implement AvoidUsingRedundantElseFixAllProvider, derived from DocumentBasedFixAllProvider
- Modify AvoidUsingRedundantElseFixer so that:
    - GetFixAllProvider() returns an AvoidUsingRedundantElseFixAllProvider
    - it processes diagnostics per document, in reverse line order so as not to invalidate any of the remaining nodes to fix