### PR TITLE
MA0071 rule now handles "using statement" and conflicting local declarations

### DIFF
--- a/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -32,25 +33,62 @@ namespace Meziantou.Analyzer.Rules
 
         private static void AnalyzeElseClause(SyntaxNodeAnalysisContext context)
         {
-            var elseClauseSyntax = (ElseClauseSyntax)context.Node;
-            if (elseClauseSyntax is null)
+            var elseClause = (ElseClauseSyntax)context.Node;
+            if (elseClause is null)
                 return;
 
-            if (!(elseClauseSyntax.Parent is IfStatementSyntax ifStatementSyntax))
+            if (!(elseClause.Parent is IfStatementSyntax ifStatement))
                 return;
 
-            var statementOrBlock = ifStatementSyntax.Statement;
-            if (statementOrBlock is null)
+            var thenStatement = ifStatement.Statement;
+            var elseStatement = elseClause.Statement;
+            if (thenStatement is null || elseStatement is null)
                 return;
 
-            var result = context.SemanticModel.AnalyzeControlFlow(statementOrBlock);
-            if (!result.Succeeded)
+            // If the 'else' clause contains a "using statement local declaration" as direct child, return
+            // NOTE:
+            //  using var charEnumerator = "".GetEnumerator();          => LocalDeclarationStatementSyntax  (will return)
+            //  using (var charEnumerator = "".GetEnumerator()) { }     => UsingStatementSyntax             (will carry on)
+            var elseHasUsingStatementLocalDeclaration = GetElseClauseChildren(elseClause)
+                .OfType<LocalDeclarationStatementSyntax>()
+                .Any(localDeclaration => localDeclaration.UsingKeyword.IsKind(SyntaxKind.UsingKeyword));
+            if (elseHasUsingStatementLocalDeclaration)
                 return;
 
-            if (!result.EndPointIsReachable || result.ExitPoints.Any(ep => IsDirectAccess(ifStatementSyntax, ep)))
+            // If there are conflicting local (variable or function) declarations in 'if' and 'else' blocks, return
+            var thenLocalIdentifiers = FindLocalIdentifiersIn(thenStatement);
+            var elseLocalIdentifiers = FindLocalIdentifiersIn(elseStatement);
+            if (thenLocalIdentifiers.Intersect(elseLocalIdentifiers).Any())
+                return;
+
+            var controlFlowAnalysis = context.SemanticModel.AnalyzeControlFlow(thenStatement);
+            if (!controlFlowAnalysis.Succeeded)
+                return;
+
+            if (!controlFlowAnalysis.EndPointIsReachable || controlFlowAnalysis.ExitPoints.Any(ep => IsDirectAccess(ifStatement, ep)))
             {
-                context.ReportDiagnostic(s_rule, elseClauseSyntax.ElseKeyword);
+                context.ReportDiagnostic(s_rule, elseClause.ElseKeyword);
             }
+        }
+
+        internal static IEnumerable<SyntaxNode> GetElseClauseChildren(ElseClauseSyntax elseClauseSyntax)
+        {
+            return elseClauseSyntax.Statement is BlockSyntax elseBlockSyntax ?
+                elseBlockSyntax.ChildNodes() :
+                new[] { elseClauseSyntax.Statement };
+        }
+
+        private static IEnumerable<string> FindLocalIdentifiersIn(SyntaxNode node)
+        {
+            return node
+                .DescendantNodes()
+                .Where(node => node.IsKind(SyntaxKind.VariableDeclarator) || node.IsKind(SyntaxKind.LocalFunctionStatement))
+                .Select(node => node switch
+                {
+                    VariableDeclaratorSyntax variableDeclarator => variableDeclarator.Identifier.Text,
+                    LocalFunctionStatementSyntax localFunction => localFunction.Identifier.Text,
+                    _ => default
+                });
         }
 
         /// <summary>

--- a/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
@@ -82,11 +82,14 @@ namespace Meziantou.Analyzer.Rules
         {
             return node
                 .DescendantNodes()
-                .Where(node => node.IsKind(SyntaxKind.VariableDeclarator) || node.IsKind(SyntaxKind.LocalFunctionStatement))
+                .Where(node => node.IsKind(SyntaxKind.VariableDeclarator) ||
+                               node.IsKind(SyntaxKind.LocalFunctionStatement) ||
+                               node.IsKind(SyntaxKind.SingleVariableDesignation))   // local declaration in pattern matching
                 .Select(node => node switch
                 {
                     VariableDeclaratorSyntax variableDeclarator => variableDeclarator.Identifier.Text,
                     LocalFunctionStatementSyntax localFunction => localFunction.Identifier.Text,
+                    SingleVariableDesignationSyntax singleVariableDesignation => singleVariableDesignation.Identifier.Text,
                     _ => default
                 });
         }

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUsingRedundantElseAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUsingRedundantElseAnalyzerTests.cs
@@ -158,7 +158,7 @@ class TestClass
                 break;
                 void Increment(ref int val) => val++;
             }
-        [|else|]
+            [|else|]
             {
                 Decrement(ref value);
                 void Decrement(ref int val)
@@ -215,7 +215,7 @@ class TestClass
                     break;
                 }
             }
-        [|else|]
+            [|else|]
                 // Decrement
                 value--;
         }
@@ -266,7 +266,7 @@ class TestClass
                 }
                 void Increment(ref int val) => val++;
             }
-        [|else|]
+            [|else|]
             {
                 {
                     Decrement(ref value);
@@ -328,7 +328,7 @@ class TestClass
             {
                 break;
             }
-        [|else|]
+            [|else|]
             {
                 value--;
             }
@@ -513,6 +513,141 @@ class TestClass
             await CreateProjectBuilder()
                   .WithSourceCode(originalCode)
                   .ShouldBatchFixCodeWith(modifiedCode)
+                  .ValidateAsync();
+        }
+
+        [Fact]
+        public async Task Test_IfThatReturnsButIfAndElseContainConflictingLocalDeclarations_NoDiagnosticReported()
+        {
+            var originalCode = @"
+class TestClass
+{
+    void Test()
+    {
+        var value = -1;
+        if (value < 0)
+        {
+            var value2 = string.Empty;
+            return;
+        }
+        else
+        {
+            int value2() => throw null;
+        }
+    }
+}";
+            await CreateProjectBuilder()
+                  .WithSourceCode(originalCode)
+                  .ValidateAsync();
+        }
+
+        [Fact]
+        public async Task Test_IfThatReturnsAndElseContainsUsingStatementLocalDeclaration_NoDiagnosticReported()
+        {
+            var originalCode = @"
+class TestClass
+{
+    void Test()
+    {
+        var value = -1;
+        if (value < 0)
+        {
+            return;
+        }
+        else
+        {
+            using var charEnumerator = string.Empty.GetEnumerator();
+        }
+    }
+}";
+            await CreateProjectBuilder()
+                  .WithSourceCode(originalCode)
+                  .ValidateAsync();
+        }
+
+        [Fact]
+        public async Task Test_IfThatReturnsAndElseContainsUsingStatementSyntax_ElseRemoved()
+        {
+            var originalCode = @"
+class TestClass
+{
+    void Test()
+    {
+        var value = -1;
+        if (value < 0)
+        {
+            return;
+        }
+        [|else|]
+        {
+            using (var charEnumerator = string.Empty.GetEnumerator())
+            {
+            }
+        }
+    }
+}";
+            var modifiedCode = @"
+class TestClass
+{
+    void Test()
+    {
+        var value = -1;
+        if (value < 0)
+        {
+            return;
+        }
+
+        using (var charEnumerator = string.Empty.GetEnumerator())
+        {
+        }
+    }
+}";
+            await CreateProjectBuilder()
+                  .WithSourceCode(originalCode)
+                  .ShouldFixCodeWith(modifiedCode)
+                  .ValidateAsync();
+        }
+
+        [Fact]
+        public async Task Test_IfThatReturnsAndElseContainsNestedUsingStatementLocalDeclaration_ElseRemoved()
+        {
+            var originalCode = @"
+class TestClass
+{
+    void Test()
+    {
+        var value = -1;
+        if (value < 0)
+        {
+            return;
+        }
+        [|else|]
+        {
+            {
+                using var charEnumerator = string.Empty.GetEnumerator();
+            }
+        }
+    }
+}";
+            var modifiedCode = @"
+class TestClass
+{
+    void Test()
+    {
+        var value = -1;
+        if (value < 0)
+        {
+            return;
+        }
+
+        {
+            using var charEnumerator = string.Empty.GetEnumerator();
+        }
+    }
+}";
+            await CreateProjectBuilder()
+                  .WithSourceCode(originalCode)
+                  .ShouldFixCodeWith(modifiedCode)
                   .ValidateAsync();
         }
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUsingRedundantElseAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUsingRedundantElseAnalyzerTests.cs
@@ -516,26 +516,30 @@ class TestClass
                   .ValidateAsync();
         }
 
-        [Fact]
-        public async Task Test_IfThatReturnsButIfAndElseContainConflictingLocalDeclarations_NoDiagnosticReported()
+        [Theory]
+        [InlineData("var local = string.Empty;")]
+        [InlineData("if (value is string local) {}")]
+        [InlineData("int local() => throw null;")]
+        [InlineData("switch (value) { case string local: break; }")]
+        public async Task Test_IfThatReturnsButIfAndElseContainConflictingLocalDeclarations_NoDiagnosticReported(string localDeclaration)
         {
-            var originalCode = @"
+            var originalCode = $@"
 class TestClass
-{
+{{
     void Test()
-    {
-        var value = -1;
-        if (value < 0)
-        {
-            var value2 = string.Empty;
+    {{
+        object value = string.Empty;
+        if (value != null)
+        {{
+            {localDeclaration}
             return;
-        }
+        }}
         else
-        {
-            int value2() => throw null;
-        }
-    }
-}";
+        {{
+            int local() => throw null;
+        }}
+    }}
+}}";
             await CreateProjectBuilder()
                   .WithSourceCode(originalCode)
                   .ValidateAsync();


### PR DESCRIPTION
- Fix for https://github.com/meziantou/Meziantou.Analyzer/issues/147
- Also, rename local variables in AvoidUsingRedundantElseAnalyzer & Fixer, to simplify them or clarify their purpose. For instance, rename the somewhat vague 'statementOrBlock' (representing an if statement's single or composite statement child) to 'thenStatement', inspired by the C# language reference documentation:
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/if-else