### PR TITLE
Fix branch name from master to main

### DIFF
--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -107,7 +107,7 @@ namespace Meziantou.Analyzer
 
         public static string GetHelpUri(string idenfifier)
         {
-            return string.Format(CultureInfo.InvariantCulture, "https://github.com/meziantou/Meziantou.Analyzer/blob/master/docs/Rules/{0}.md", idenfifier);
+            return string.Format(CultureInfo.InvariantCulture, "https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/{0}.md", idenfifier);
         }
     }
 }


### PR DESCRIPTION
Simple fix that avoid the "branch not found" message from github when clicking on rule link in Visual Studio