### PR TITLE
Add test for issue #353.

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -167,6 +167,28 @@ class TypeName
     }
 
     [Fact]
+    public async Task Int32_WithOptions_ShouldNotReportDiagnosticForArrayIndexer()
+    {
+        const string SourceCode = @"
+class TypeName
+{
+    public void Test()
+    {
+        int[] array = new[] {5, 4};
+
+        if (array[0] == 5)
+        {
+            array[0] = 6;
+        }
+    }
+}";
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .AddAnalyzerConfiguration("MA0003.expression_kinds", "numeric")
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task Int32_ExcludedMethod_ShouldNotReportDiagnostic()
     {
         const string SourceCode = @"


### PR DESCRIPTION
Adds a test for #353 that should confirm that MA0003 is reported for an array indexer (both getter and setter) when it should not.