### PR TITLE
[#401] Modify method-too-long output for statement count

### DIFF
--- a/src/Meziantou.Analyzer/Rules/MethodShouldNotBeTooLongAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MethodShouldNotBeTooLongAnalyzer.cs
@@ -97,7 +97,7 @@ public sealed class MethodShouldNotBeTooLongAnalyzer : DiagnosticAnalyzer
             var statements = CountStatements(context, node);
             if (statements > maximumStatements)
             {
-                context.ReportDiagnostic(s_rule, reportNode, $"{statements} lines; maximum allowed: {maximumStatements}");
+                context.ReportDiagnostic(s_rule, reportNode, $"{statements} statements; maximum allowed: {maximumStatements}");
                 return;
             }
         }


### PR DESCRIPTION
When the number of statements is exceeded for a method, the Diagnostic for `MA0051` outputs:

> warning MA0051: Method is too long (41 lines; maximum allowed: 40)

This can be confusing if the environment has been set up to ignore `MA0051` for maximum number of _lines_. The output should probably read:

> warning MA0051: Method is too long (41 statements; maximum allowed: 40)

Addresses #401