### PR TITLE
New rule MA0127: Use String.Equals instead of pattern matching (disabled by default)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -41,7 +41,7 @@
 
     <Otherwise>
       <ItemGroup>
-        <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22559.1" />
+        <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
         <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
       </ItemGroup>
       <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -142,5 +142,6 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0124](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0124.md)|Design|Log Parameter type is not valid|⚠️|✔️|❌|
 |[MA0125](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0125.md)|Design|The list of log parameter types contains an invalid type|⚠️|✔️|❌|
 |[MA0126](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0126.md)|Design|The list of log parameter types contains a duplicate|⚠️|✔️|❌|
+|[MA0127](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0127.md)|Usage|Use String.Equals instead of is pattern|⚠️|❌|❌|
 
 <!-- rules -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,7 @@
 |[MA0124](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0124.md)|Design|Log Parameter type is not valid|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0125](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0125.md)|Design|The list of log parameter types contains an invalid type|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0126](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0126.md)|Design|The list of log parameter types contains a duplicate|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0127](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0127.md)|Usage|Use String.Equals instead of is pattern|<span title='Warning'>⚠️</span>|❌|❌|
 
 # .editorconfig - default values
 
@@ -504,6 +505,9 @@ dotnet_diagnostic.MA0125.severity = warning
 
  # MA0126: The list of log parameter types contains a duplicate
 dotnet_diagnostic.MA0126.severity = warning
+
+ # MA0127: Use String.Equals instead of is pattern
+dotnet_diagnostic.MA0127.severity = none
 ```
 
 # .editorconfig - all rules disabled
@@ -883,4 +887,7 @@ dotnet_diagnostic.MA0125.severity = none
 
  # MA0126: The list of log parameter types contains a duplicate
 dotnet_diagnostic.MA0126.severity = none
+
+ # MA0127: Use String.Equals instead of is pattern
+dotnet_diagnostic.MA0127.severity = none
 ```

--- a/docs/Rules/MA0127.md
+++ b/docs/Rules/MA0127.md
@@ -1,0 +1,17 @@
+# MA0127 - Use String.Equals instead of is pattern
+
+Note that this rule is disabled by default and must be enabled manually using an `.editorconfig` file.
+
+You should use `string.Equals` instead of `is`, to make string comparison rules explicit. _Similar to [MA0006](./MA0006.md) but for patterns._
+
+````csharp
+_ str = is "foo";
+
+// Should be
+string.Equals(str, foo, StringComparison.Ordinal);
+````
+
+## Additional resources
+
+- [Best practices for comparing strings in .NET](https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings?WT.mc_id=DT-MVP-5003978#specifying-string-comparisons-explicitly)
+- [String comparisons are harder than it seems](https://www.meziantou.net/string-comparisons-are-harder-than-it-seems.htm)

--- a/src/Meziantou.Analyzer/Meziantou.Analyzer.csproj
+++ b/src/Meziantou.Analyzer/Meziantou.Analyzer.csproj
@@ -25,13 +25,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
 
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.6" Condition="'$(PackageId)' != 'Meziantou.Analyzer'">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.8" Condition="'$(PackageId)' != 'Meziantou.Analyzer'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -9,7 +9,7 @@ internal static class RuleIdentifiers
     public const string UseNamedParameter = "MA0003";
     public const string UseConfigureAwaitFalse = "MA0004";
     public const string UseArrayEmpty = "MA0005";
-    public const string UseStringEquals = "MA0006";
+    public const string UseStringEqualsInsteadOfEqualityOperator = "MA0006";
     public const string MissingCommaInObjectInitializer = "MA0007";
     public const string MissingStructLayoutAttribute = "MA0008";
     public const string MissingTimeoutParameterForRegex = "MA0009";
@@ -129,9 +129,10 @@ internal static class RuleIdentifiers
     public const string LoggerParameterType = "MA0124";
     public const string LoggerParameterType_InvalidType = "MA0125";
     public const string LoggerParameterType_DuplicateRule = "MA0126";
+    public const string UseStringEqualsInsteadOfIsPattern = "MA0127";
 
-    public static string GetHelpUri(string idenfifier)
+    public static string GetHelpUri(string identifier)
     {
-        return string.Format(CultureInfo.InvariantCulture, "https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/{0}.md", idenfifier);
+        return string.Format(CultureInfo.InvariantCulture, "https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/{0}.md", identifier);
     }
 }

--- a/src/Meziantou.Analyzer/Rules/UseStringEqualsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringEqualsAnalyzer.cs
@@ -9,14 +9,14 @@ namespace Meziantou.Analyzer.Rules;
 public sealed class UseStringEqualsAnalyzer : DiagnosticAnalyzer
 {
     private static readonly DiagnosticDescriptor s_rule = new(
-        RuleIdentifiers.UseStringEquals,
+        RuleIdentifiers.UseStringEqualsInsteadOfEqualityOperator,
         title: "Use String.Equals instead of equality operator",
         messageFormat: "Use string.Equals instead of {0}",
         RuleCategories.Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "",
-        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseStringEquals));
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseStringEqualsInsteadOfEqualityOperator));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
 

--- a/src/Meziantou.Analyzer/Rules/UseStringEqualsFixer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringEqualsFixer.cs
@@ -16,7 +16,7 @@ namespace Meziantou.Analyzer.Rules;
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public sealed class UseStringEqualsFixer : CodeFixProvider
 {
-    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.UseStringEquals);
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.UseStringEqualsInsteadOfEqualityOperator);
 
     public override FixAllProvider GetFixAllProvider()
     {

--- a/src/Meziantou.Analyzer/Rules/UseStringEqualsInsteadOfIsPatternAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringEqualsInsteadOfIsPatternAnalyzer.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseStringEqualsInsteadOfIsPatternAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor s_rulePattern = new(
+        RuleIdentifiers.UseStringEqualsInsteadOfIsPattern,
+        title: "Use String.Equals instead of is pattern",
+        messageFormat: "Use string.Equals instead of 'is' pattern",
+        RuleCategories.Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseStringEqualsInsteadOfIsPattern));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rulePattern);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterOperationAction(AnalyzeIsPattern, OperationKind.IsPattern);
+    }
+
+    private static void AnalyzeIsPattern(OperationAnalysisContext context)
+    {
+        var operation = (IIsPatternOperation)context.Operation;
+        AnalyzePattern(context, operation.Pattern);
+
+        static void AnalyzePattern(OperationAnalysisContext context, IPatternOperation pattern)
+        {
+            if (pattern is IConstantPatternOperation { Value.ConstantValue: { HasValue: true, Value: string { Length: > 0 } } })
+            {
+                context.ReportDiagnostic(s_rulePattern, pattern);
+            }
+            else if (pattern is IRecursivePatternOperation recursivePattern)
+            {
+                foreach (var p in recursivePattern.PropertySubpatterns)
+                {
+                    AnalyzePattern(context, p.Pattern);
+                }
+            }
+            else if (pattern is IBinaryPatternOperation binaryPattern)
+            {
+                AnalyzePattern(context, binaryPattern.LeftPattern);
+                AnalyzePattern(context, binaryPattern.RightPattern);
+            }
+        }
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsInsteadOfIsPatternAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsInsteadOfIsPatternAnalyzerTests.cs
@@ -1,0 +1,147 @@
+﻿using System.Threading.Tasks;
+using Meziantou.Analyzer.Rules;
+using TestHelper;
+using Xunit;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class UseStringEqualsInsteadOfIsPatternAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<UseStringEqualsInsteadOfIsPatternAnalyzer>();
+    }
+
+    [Fact]
+    public async Task IsStringEmpty()
+    {
+        const string SourceCode = """
+class TypeName
+{
+    public void Test(string str)
+    {
+        _ = str is "";
+    }
+}
+""";
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task IsNull()
+    {
+        const string SourceCode = """
+class TypeName
+{
+    public void Test(string str)
+    {
+        _ = str is null;
+    }
+}
+""";
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ValidateAsync();
+    }
+    
+    [Fact]
+    public async Task IsNotNull()
+    {
+        const string SourceCode = """
+class TypeName
+{
+    public void Test(string str)
+    {
+        _ = str is not null;
+    }
+}
+""";
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ValidateAsync();
+    }
+    
+    [Fact]
+    public async Task PatternMatching()
+    {
+        const string SourceCode = """
+class TypeName
+{
+    public void Test(string str)
+    {
+        _ = str is [|"b"|];
+    }
+}
+""";
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PatternMatching_Complex1()
+    {
+        const string SourceCode = """
+class TypeName
+{
+    string Value { get; set; }
+
+    public void Test(TypeName obj)
+    {
+        _ = obj is { Value: [|"b"|]};
+    }
+}
+""";
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PatternMatching_Complex2()
+    {
+        const string SourceCode = """
+class TypeName
+{
+    string Value { get; set; }
+
+    public void Test(TypeName obj)
+    {
+        _ = obj is { Value: [|"b"|] or [|"c"|]};
+    }
+}
+""";
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PatternMatching_Complex3()
+    {
+        const string SourceCode = """
+class TypeName
+{
+    string Value { get; set; }
+
+    public void Test(TypeName obj)
+    {
+        _ = obj is { Value: var a and ([|"b"|] or [|"c"|])};
+    }
+}
+""";
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ValidateAsync();
+    }
+}


### PR DESCRIPTION
Fix https://github.com/meziantou/Meziantou.Analyzer/issues/440