### PR TITLE
MA0116 and MA0122 are disabled on ASP.NET Core 8

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
@@ -204,6 +204,11 @@ public sealed partial class ProjectBuilder
                 AddNuGetReference("Microsoft.NETCore.App.Ref", "7.0.0", "ref/net7.0/");
                 AddNuGetReference("Microsoft.AspNetCore.App.Ref", "7.0.0", "ref/net7.0/");
                 break;
+                
+            case TargetFramework.AspNetCore8_0:
+                AddNuGetReference("Microsoft.NETCore.App.Ref", "8.0.0-preview.6.23329.7", "ref/net8.0/");
+                AddNuGetReference("Microsoft.AspNetCore.App.Ref", "8.0.0-preview.6.23329.11", "ref/net8.0/");
+                break;
 
             case TargetFramework.WindowsDesktop5_0:
                 AddNuGetReference("Microsoft.WindowsDesktop.App.Ref", "5.0.0", "ref/net5.0/");

--- a/tests/Meziantou.Analyzer.Test/Helpers/TargetFramework.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/TargetFramework.cs
@@ -11,5 +11,6 @@ public enum TargetFramework
     AspNetCore5_0,
     AspNetCore6_0,
     AspNetCore7_0,
+    AspNetCore8_0,
     WindowsDesktop5_0,
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/ParameterAttributeForRazorComponentAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ParameterAttributeForRazorComponentAnalyzerTests.cs
@@ -45,6 +45,26 @@ class Test
     }
 
     [Fact]
+    public async Task SupplyParameterFromQuery_MissingParameter_AspNetCore8()
+    {
+        const string SourceCode = """
+using Microsoft.AspNetCore.Components;
+
+[Route("/test")]
+class Test
+{
+    [SupplyParameterFromQuery]
+    public int A { get; set; }
+}
+""";
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .WithTargetFramework(TargetFramework.AspNetCore8_0)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task SupplyParameterFromQuery_WithParameter()
     {
         const string SourceCode = """
@@ -83,7 +103,7 @@ class Test
     }
 
     [Fact]
-    public async Task SupplyParameterFromQuery_NonRoutable ()
+    public async Task SupplyParameterFromQuery_NonRoutable()
     {
         const string SourceCode = """
 using Microsoft.AspNetCore.Components;


### PR DESCRIPTION
https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-6/?WT.mc_id=DT-MVP-5003978#cascade-query-string-values-to-blazor-components