### PR TITLE
MA0007 and MA0048 have equivalent rules in StyleCopAnalyzers.

### DIFF
--- a/docs/comparison-with-other-analyzers.md
+++ b/docs/comparison-with-other-analyzers.md
@@ -36,6 +36,8 @@
 | [S3442](https://rules.sonarsource.com/csharp/RSPEC-3442/)                                                                  | [MA0017](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0017.md) |
 | [S3450](https://rules.sonarsource.com/csharp/RSPEC-3450/)                                                                  | [MA0087](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0087.md) |
 | [S3903](https://rules.sonarsource.com/csharp/RSPEC-3903/)                                                                  | [MA0047](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0047.md) |
+| [SA1413](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md)                         | [MA0007](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0007.md) |
+| [SA1649](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md)                         | [MA0048](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) |
 
 ## Similar rules
 


### PR DESCRIPTION
**MA0007** and **MA0048** have equivalent rules in **StyleCopAnalyzers**.