### PR TITLE
Implement Analyzer to add sealed keyword to public records

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/PublicSealedRecordCodeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/PublicSealedRecordCodeFixer.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Meziantou.Analyzer.Rules
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PublicRecordCodeFixer)), Shared]
+    public class PublicRecordCodeFixer : CodeFixProvider
+    {
+        private const string SealedRecordTitle = "Annotate public record with 'sealed'";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => [RuleIdentifiers.PublicRecordShouldBeSealed];
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf()
+                .OfType<RecordDeclarationSyntax>().First();
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    SealedRecordTitle,
+                    _ => AddSealedKeyword(context.Document, declaration),
+                    SealedRecordTitle),
+                diagnostic);
+        }
+
+        private static async Task<Document> AddSealedKeyword(Document document, RecordDeclarationSyntax expression)
+        {
+            var newexpression = expression.AddModifiers(SyntaxFactory.Token(SyntaxKind.SealedKeyword));
+            var root = await document.GetSyntaxRootAsync();
+            return document.WithSyntaxRoot(root.ReplaceNode(expression, newexpression));
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -168,6 +168,7 @@ internal static class RuleIdentifiers
     public const string UseShellExecuteMustBeFalse = "MA0163";
     public const string NotPatternShouldBeParenthesized = "MA0164";
     public const string MakeInterpolatedString = "MA0165";
+    public const string PublicRecordShouldBeSealed = "MA0166";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/PublicRecordAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/PublicRecordAnalyzer.cs
@@ -1,0 +1,42 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Analyzer.Rules
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class PublicRecordAnalyzer : DiagnosticAnalyzer
+    {
+        private const string SealedRecordTitle = "Annotate public record with 'sealed'";
+        private const string SealedRecordMessageFormat = "Public record '{0}' should be annotated with 'sealed'.";
+        private const string SealedRecordDescription = "Eyooo, annotate public record with 'sealed.'";
+        private const string Category = "Convention";
+
+        private static readonly DiagnosticDescriptor SealedRecordRule = new DiagnosticDescriptor(RuleIdentifiers.PublicRecordShouldBeSealed,
+            SealedRecordTitle, SealedRecordMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: SealedRecordDescription);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(SealedRecordRule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeRecordDeclaration, SyntaxKind.RecordDeclaration);
+        }
+
+        private void AnalyzeRecordDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var recordDeclaration = (RecordDeclarationSyntax)context.Node;
+
+            if (recordDeclaration.Modifiers.Any(SyntaxKind.PublicKeyword) &&
+                !recordDeclaration.Modifiers.Any(SyntaxKind.SealedKeyword))
+            {
+                var diagnostic = Diagnostic.Create(SealedRecordRule, recordDeclaration.Identifier.GetLocation(),
+                    recordDeclaration.Identifier.Text);
+
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Meziantou.Analyzer.Rules;
+using Meziantou.Analyzer.Test.Helpers;
 using TestHelper;
 using Xunit;
 
@@ -55,6 +56,23 @@ sealed class Test2 : Test
               .WithSourceCode(SourceCode)
               .ShouldFixCodeWith(CodeFix)
               .ValidateAsync();
+    }
+
+
+    [Fact]
+    public async Task GivenPublicRecord_CodeFix_ReturnsPublicRecord()
+    {
+        var violation = "public record [||]SomeRecord(int Id);";
+
+        var fix = "public sealed record SomeRecord(int Id);";
+
+        await CreateProjectBuilder()
+            .WithSourceCode(violation)
+            .WithTargetFramework(TargetFramework.Net8_0)
+            .AddAnalyzerConfiguration("MA0053.public_class_should_be_sealed", "true")
+            .ShouldFixCodeWith(fix)
+            .ShouldReportDiagnosticWithMessage("Public record 'SomeRecord' should be annotated with 'sealed'.")
+            .ValidateAsync();
     }
 
     [Fact]

--- a/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
@@ -70,8 +70,9 @@ sealed class Test2 : Test
             .WithSourceCode(violation)
             .WithTargetFramework(TargetFramework.Net8_0)
             .AddAnalyzerConfiguration("MA0053.public_class_should_be_sealed", "true")
+            .AddAnalyzerConfiguration("MA0053.class_with_virtual_member_should_be_sealed", "true")
             .ShouldFixCodeWith(fix)
-            .ShouldReportDiagnosticWithMessage("Public record 'SomeRecord' should be annotated with 'sealed'.")
+            .ShouldReportDiagnosticWithMessage("Make class sealed")
             .ValidateAsync();
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/PublicRecordAnalyzerTest.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/PublicRecordAnalyzerTest.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using Meziantou.Analyzer.Rules;
+using Meziantou.Analyzer.Test.Helpers;
+using TestHelper;
+using Xunit;
+
+namespace Meziantou.Analyzer.Test.Rules
+{
+    public class PublicRecordAnalyzerTest
+    {
+        private static ProjectBuilder CreateProjectBuilder()
+        {
+            return new ProjectBuilder()
+                .WithAnalyzer<PublicRecordAnalyzer>();
+        }
+
+        [Fact]
+        public async Task GivenPublicRecord_CodeFix_ReturnsPublicRecord()
+        {
+            var violation = @"
+using System.Runtime;
+public record [||]SomeRecord(int Id);";
+
+            var fix = @"
+using System.Runtime;
+public sealed record SomeRecord(int Id);";
+
+            await CreateProjectBuilder()
+                .WithSourceCode(violation)
+                .WithCodeFixProvider<PublicRecordCodeFixer>()
+                .ShouldReportDiagnosticWithMessage("Public record 'SomeRecord' should be annotated with 'sealed'.")
+                .ShouldFixCodeWith(fix)
+                .WithTargetFramework(TargetFramework.Net8_0)
+#if CSHARP10_OR_GREATER
+                .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp10)
+#endif
+                .ValidateAsync();
+        }
+    }
+}


### PR DESCRIPTION
The PublicRecordAnalyzer ensures that all public records in the codebase are annotated with the sealed keyword. This practice prevents other classes from inheriting from these records, which can help maintain the integrity and immutability of the data structures, reduce potential security risks, and improve performance by enabling certain compiler optimizations.