### PR TITLE
Fix MA0048 in case when first type is not first node

### DIFF
--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -86,6 +86,9 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
                 var isFirstType = true;
                 foreach (var node in root.DescendantNodesAndSelf(descendIntoChildren: node => !IsTypeDeclaration(node)))
                 {
+                    if (!IsTypeDeclaration(node))
+                        continue;
+
                     if (node.SpanStart < symbolNode.SpanStart)
                     {
                         isFirstType = false;

--- a/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
@@ -247,6 +247,19 @@ class [||]Test0<TKey, TValue>
               .ValidateAsync();
     }
 
+    [Fact]
+    public async Task MatchOnlyFirstType_TypeWithNamespaceDeclaration()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(fileName: "Test0.cs", """
+                  namespace Sample;
+                  struct [||]Foo {}
+                  struct Bar {}
+                  """)
+              .AddAnalyzerConfiguration("MA0048.only_validate_first_type", "true")
+              .ValidateAsync();
+    }
+
     [Theory]
     [InlineData("Sample")]
     [InlineData("T:MyNamespace.Sample")]

--- a/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
@@ -248,7 +248,23 @@ class [||]Test0<TKey, TValue>
     }
 
     [Fact]
-    public async Task MatchOnlyFirstType_TypeWithNamespaceDeclaration()
+    public async Task MatchOnlyFirstType_TypeWithBlockScopedNamespaceDeclaration()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(fileName: "Test0.cs", """
+                  namespace Sample
+                  {
+                      struct [||]Foo {}
+                      struct Bar {}
+                  }
+                  """)
+              .AddAnalyzerConfiguration("MA0048.only_validate_first_type", "true")
+              .ValidateAsync();
+    }
+
+#if CSHARP10_OR_GREATER
+    [Fact]
+    public async Task MatchOnlyFirstType_TypeWithFileScopedNamespaceDeclaration()
     {
         await CreateProjectBuilder()
               .WithSourceCode(fileName: "Test0.cs", """
@@ -259,6 +275,7 @@ class [||]Test0<TKey, TValue>
               .AddAnalyzerConfiguration("MA0048.only_validate_first_type", "true")
               .ValidateAsync();
     }
+#endif
 
     [Theory]
     [InlineData("Sample")]


### PR DESCRIPTION
Option "only_validate_first_type" now works more like "only_validate_first_node".

```
foreach (var node in root.DescendantNodesAndSelf(descendIntoChildren: node => !IsTypeDeclaration(node)))
```

This block of code returns CompilationUnit and `if (node.SpanStart < symbolNode.SpanStart)` always works as `if (0 < symbolNode.SpanStart)`.

PR contains:
- test to confirm this problem (namespace before type).
- fix with comparing only with other type declarations (skip nodes that is not type declaration)