### PR TITLE
Fix code block formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ If you are already using other analyzers, you can check [which rules are duplica
 
 You can set the `<MeziantouAnalysisMode>` MSBuild property to configure the default severity of the rules. The default value is `Default`. You can set it to `None` to disable all rules by default.
 
-````
+```xml
 <Project>
   <PropertyGroup>
     <MeziantouAnalysisMode>None</MeziantouAnalysisMode>
   </PropertyGroup>
 </Project>
-````
+```


### PR DESCRIPTION
This pull request makes a minor documentation improvement by updating the code block formatting in the `README.md` file to use the correct language identifier for XML code snippets. This helps with syntax highlighting and clarity.