### PR TITLE
docs: enhance MA0090 and MA0098 rule documentation

### DIFF
--- a/docs/Rules/MA0090.md
+++ b/docs/Rules/MA0090.md
@@ -2,24 +2,23 @@
 
 This rule detects empty `else` and `finally` blocks that contain no executable code and suggests removing them to improve code readability and reduce clutter. Empty blocks serve no functional purpose and can make code harder to read by adding unnecessary visual noise.
 
-## Non-compliant code
-
-### Empty else block
-
 ````csharp
+// non-compliant
 if (condition)
 {
     DoSomething();
 }
 else
 {
-    // This empty else block should be removed
 }
-````
 
-### Empty finally block
+// compliant
+if (condition)
+{
+    DoSomething();
+}
 
-````csharp
+// non-compliant
 try
 {
     DoSomething();
@@ -30,25 +29,9 @@ catch (Exception ex)
 }
 finally
 {
-    // This empty finally block should be removed
 }
-````
 
-## Compliant code
-
-### Remove unnecessary else block
-
-````csharp
-if (condition)
-{
-    DoSomething();
-}
-// else block removed - code is cleaner and more readable
-````
-
-### Remove unnecessary finally block
-
-````csharp
+// compliant
 try
 {
     DoSomething();
@@ -57,16 +40,8 @@ catch (Exception ex)
 {
     HandleException(ex);
 }
-// finally block removed - no cleanup needed
-````
 
-## When the rule does NOT apply
-
-The rule will not trigger in the following scenarios:
-
-### Blocks with comments
-
-````csharp
+// compliant - blocks with comments are not flagged
 if (condition)
 {
     DoSomething();
@@ -74,13 +49,9 @@ if (condition)
 else
 {
     // TODO: Implement this feature later
-    // This block contains comments, so it won't be flagged
 }
-````
 
-### Blocks with preprocessor directives
-
-````csharp
+// compliant - blocks with preprocessor directives are not flagged
 try
 {
     DoSomething();
@@ -88,20 +59,7 @@ try
 finally
 {
 #if DEBUG
-    // Preprocessor directives prevent the rule from triggering
+    Console.WriteLine("Debug mode");
 #endif
-}
-````
-
-### Finally blocks with actual cleanup code
-
-````csharp
-try
-{
-    DoSomething();
-}
-finally
-{
-    resource?.Dispose(); // Actual cleanup code - rule doesn't apply
 }
 ````

--- a/docs/Rules/MA0090.md
+++ b/docs/Rules/MA0090.md
@@ -105,35 +105,3 @@ finally
     resource?.Dispose(); // Actual cleanup code - rule doesn't apply
 }
 ````
-
-## Why remove empty blocks?
-
-Removing empty `else` and `finally` blocks improves code quality in several ways:
-
-- **Reduces visual noise**: Empty blocks add no value but consume screen space and mental processing
-- **Improves readability**: Cleaner code is easier to scan and understand
-- **Follows clean code principles**: Empty constructs violate the principle of intentional and meaningful code
-- **Prevents confusion**: Empty blocks might make other developers wonder if code was accidentally removed
-
-## Configuration
-
-By default, this rule has a severity of `suggestion`. You can configure the severity in your `.editorconfig` file:
-
-````ini
-# Disable the rule
-dotnet_diagnostic.MA0090.severity = none
-
-# Set as suggestion (default)
-dotnet_diagnostic.MA0090.severity = suggestion
-
-# Set as warning
-dotnet_diagnostic.MA0090.severity = warning
-
-# Set as error
-dotnet_diagnostic.MA0090.severity = error
-````
-
-## Additional resources
-
-- [Clean Code principles](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules)
-- [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)

--- a/docs/Rules/MA0090.md
+++ b/docs/Rules/MA0090.md
@@ -1,1 +1,139 @@
 # MA0090 - Remove empty else/finally block
+
+This rule detects empty `else` and `finally` blocks that contain no executable code and suggests removing them to improve code readability and reduce clutter. Empty blocks serve no functional purpose and can make code harder to read by adding unnecessary visual noise.
+
+## Non-compliant code
+
+### Empty else block
+
+````csharp
+if (condition)
+{
+    DoSomething();
+}
+else
+{
+    // This empty else block should be removed
+}
+````
+
+### Empty finally block
+
+````csharp
+try
+{
+    DoSomething();
+}
+catch (Exception ex)
+{
+    HandleException(ex);
+}
+finally
+{
+    // This empty finally block should be removed
+}
+````
+
+## Compliant code
+
+### Remove unnecessary else block
+
+````csharp
+if (condition)
+{
+    DoSomething();
+}
+// else block removed - code is cleaner and more readable
+````
+
+### Remove unnecessary finally block
+
+````csharp
+try
+{
+    DoSomething();
+}
+catch (Exception ex)
+{
+    HandleException(ex);
+}
+// finally block removed - no cleanup needed
+````
+
+## When the rule does NOT apply
+
+The rule will not trigger in the following scenarios:
+
+### Blocks with comments
+
+````csharp
+if (condition)
+{
+    DoSomething();
+}
+else
+{
+    // TODO: Implement this feature later
+    // This block contains comments, so it won't be flagged
+}
+````
+
+### Blocks with preprocessor directives
+
+````csharp
+try
+{
+    DoSomething();
+}
+finally
+{
+#if DEBUG
+    // Preprocessor directives prevent the rule from triggering
+#endif
+}
+````
+
+### Finally blocks with actual cleanup code
+
+````csharp
+try
+{
+    DoSomething();
+}
+finally
+{
+    resource?.Dispose(); // Actual cleanup code - rule doesn't apply
+}
+````
+
+## Why remove empty blocks?
+
+Removing empty `else` and `finally` blocks improves code quality in several ways:
+
+- **Reduces visual noise**: Empty blocks add no value but consume screen space and mental processing
+- **Improves readability**: Cleaner code is easier to scan and understand
+- **Follows clean code principles**: Empty constructs violate the principle of intentional and meaningful code
+- **Prevents confusion**: Empty blocks might make other developers wonder if code was accidentally removed
+
+## Configuration
+
+By default, this rule has a severity of `suggestion`. You can configure the severity in your `.editorconfig` file:
+
+````ini
+# Disable the rule
+dotnet_diagnostic.MA0090.severity = none
+
+# Set as suggestion (default)
+dotnet_diagnostic.MA0090.severity = suggestion
+
+# Set as warning
+dotnet_diagnostic.MA0090.severity = warning
+
+# Set as error
+dotnet_diagnostic.MA0090.severity = error
+````
+
+## Additional resources
+
+- [Clean Code principles](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules)
+- [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)

--- a/docs/Rules/MA0098.md
+++ b/docs/Rules/MA0098.md
@@ -84,18 +84,3 @@ var first = enumerable.First();         // ✅ Rule doesn't apply
 HashSet<int> hashSet = new();
 var firstFromSet = hashSet.First();     // ✅ Rule doesn't apply
 ````
-
-## Related Rules
-
-This rule is part of a comprehensive suite of LINQ optimization rules in Meziantou.Analyzer:
-
-- **[MA0020](MA0020.md)**: Use direct methods instead of LINQ methods - Suggests using `List<T>.Find()` instead of `FirstOrDefault()`, `List<T>.Exists()` instead of `Any()`, etc.
-- **[MA0029](MA0029.md)**: Optimize LINQ usage by combining methods - Combines `Where()` with subsequent methods like `First()`, `Any()`, `Count()`
-- **[MA0030](MA0030.md)**: Remove duplicate OrderBy methods - Removes redundant `OrderBy` calls
-- **[MA0031](MA0031.md)**: Optimize Count usage - Replaces `Count() > 0` with `Any()`, `Count() == 0` with `!Any()`, etc.
-- **[MA0063](MA0063.md)**: Use Where before OrderBy - Moves filtering before sorting for better performance
-- **[MA0078](MA0078.md)**: Use Cast instead of Select for type conversion
-- **[MA0112](MA0112.md)**: Use Count instead of Any for collections with a Count property
-- **[MA0159](MA0159.md)**: Use Order instead of OrderBy when no key selector is needed
-
-These rules work together to help optimize LINQ performance throughout your codebase.

--- a/docs/Rules/MA0098.md
+++ b/docs/Rules/MA0098.md
@@ -1,1 +1,135 @@
 # MA0098 - Use indexer instead of LINQ methods
+
+When working with collections that support indexing (such as arrays, `List<T>`, `IList<T>`, or `IReadOnlyList<T>`), using the indexer syntax `[index]` is more efficient than LINQ methods like `ElementAt()`, `First()`, and `Last()`. This rule suggests replacing these LINQ methods with direct indexer access for better performance.
+
+The indexer approach provides direct access to elements without the overhead of LINQ extension methods and enumeration, resulting in faster execution and reduced memory allocations.
+
+## Examples
+
+### ElementAt() method
+
+````csharp
+// Non-compliant - using ElementAt()
+var array = new int[10];
+var list = new List<int>();
+
+var value1 = array.ElementAt(5);        // ❌ Inefficient
+var value2 = list.ElementAt(3);         // ❌ Inefficient
+
+// Compliant - using indexer
+var value3 = array[5];                  // ✅ Direct access
+var value4 = list[3];                   // ✅ Direct access
+````
+
+### First() method
+
+````csharp
+// Non-compliant - using First() without predicate
+var array = new int[10];
+var list = new List<int>();
+
+var first1 = array.First();             // ❌ Inefficient
+var first2 = list.First();              // ❌ Inefficient
+
+// Compliant - using indexer
+var first3 = array[0];                  // ✅ Direct access
+var first4 = list[0];                   // ✅ Direct access
+
+// Note: First(predicate) is not affected by this rule
+var firstEven = array.First(x => x % 2 == 0);  // ✅ Uses predicate, rule doesn't apply
+````
+
+### Last() method
+
+````csharp
+// Non-compliant - using Last() without predicate
+var array = new int[10];
+var list = new List<int>();
+
+var last1 = array.Last();               // ❌ Inefficient
+var last2 = list.Last();                // ❌ Inefficient
+
+// Compliant - using indexer
+var last3 = array[array.Length - 1];    // ✅ Direct access
+var last4 = list[list.Count - 1];       // ✅ Direct access
+
+// Note: Last(predicate) is not affected by this rule
+var lastEven = array.Last(x => x % 2 == 0);    // ✅ Uses predicate, rule doesn't apply
+````
+
+## C# 8+ Index and Range Support
+
+Starting with C# 8.0 and when targeting frameworks that support the Index and Range feature (.NET Core 3.0+, .NET 5+), the analyzer can suggest using the hat operator (`^`) for accessing elements from the end:
+
+````csharp
+// C# 8+ with compatible target framework
+var array = new int[10];
+
+// The analyzer suggests using the hat operator for Last()
+var last = array[^1];                   // ✅ Equivalent to array[array.Length - 1]
+
+// For older language versions or target frameworks, it uses the traditional syntax
+var last = array[array.Length - 1];     // ✅ Fallback for older versions
+````
+
+## Performance Benefits
+
+Using indexer access instead of LINQ methods provides several performance advantages:
+
+- **Direct Access**: Indexers provide O(1) direct access to elements, while LINQ methods may involve enumeration overhead
+- **No Extension Method Overhead**: Eliminates the cost of extension method calls and delegate invocations
+- **Reduced Memory Allocations**: Avoids temporary objects and iterator allocations that LINQ methods might create
+- **Better JIT Optimization**: The JIT compiler can better optimize simple indexer access compared to generic extension methods
+
+## When This Rule Doesn't Apply
+
+This rule has specific limitations and won't trigger in certain scenarios:
+
+### Methods with Predicates
+
+The rule only applies to parameterless versions of `First()` and `Last()`, and single-parameter `ElementAt()`. It doesn't apply when using predicates:
+
+````csharp
+// These are NOT flagged by the rule - predicates are necessary
+var firstEven = list.First(x => x % 2 == 0);
+var lastNegative = array.Last(x => x < 0);
+````
+
+### OrDefault Variants
+
+The rule doesn't apply to the "OrDefault" variants of these methods:
+
+````csharp
+// These are NOT flagged by the rule
+var item1 = list.FirstOrDefault();      // ✅ Rule doesn't apply
+var item2 = list.LastOrDefault();       // ✅ Rule doesn't apply
+var item3 = list.ElementAtOrDefault(5); // ✅ Rule doesn't apply
+````
+
+### Unsupported Collection Types
+
+The rule only applies to collections that implement `IList<T>` or `IReadOnlyList<T>`:
+
+````csharp
+// These are NOT flagged by the rule - no indexer support
+IEnumerable<int> enumerable = GetNumbers();
+var first = enumerable.First();         // ✅ Rule doesn't apply
+
+HashSet<int> hashSet = new();
+var firstFromSet = hashSet.First();     // ✅ Rule doesn't apply
+````
+
+## Related Rules
+
+This rule is part of a comprehensive suite of LINQ optimization rules in Meziantou.Analyzer:
+
+- **[MA0020](MA0020.md)**: Use direct methods instead of LINQ methods - Suggests using `List<T>.Find()` instead of `FirstOrDefault()`, `List<T>.Exists()` instead of `Any()`, etc.
+- **[MA0029](MA0029.md)**: Optimize LINQ usage by combining methods - Combines `Where()` with subsequent methods like `First()`, `Any()`, `Count()`
+- **[MA0030](MA0030.md)**: Remove duplicate OrderBy methods - Removes redundant `OrderBy` calls
+- **[MA0031](MA0031.md)**: Optimize Count usage - Replaces `Count() > 0` with `Any()`, `Count() == 0` with `!Any()`, etc.
+- **[MA0063](MA0063.md)**: Use Where before OrderBy - Moves filtering before sorting for better performance
+- **[MA0078](MA0078.md)**: Use Cast instead of Select for type conversion
+- **[MA0112](MA0112.md)**: Use Count instead of Any for collections with a Count property
+- **[MA0159](MA0159.md)**: Use Order instead of OrderBy when no key selector is needed
+
+These rules work together to help optimize LINQ performance throughout your codebase.

--- a/docs/Rules/MA0098.md
+++ b/docs/Rules/MA0098.md
@@ -32,55 +32,8 @@ Starting with C# 8.0 and when targeting frameworks that support the Index and Ra
 var array = new int[10];
 
 // The analyzer suggests using the hat operator for Last()
-var last = array[^1];                   // ✅ Equivalent to array[array.Length - 1]
+var last = array[^1];
 
 // For older language versions or target frameworks, it uses the traditional syntax
-var last = array[array.Length - 1];     // ✅ Fallback for older versions
-````
-
-## Performance Benefits
-
-Using indexer access instead of LINQ methods provides several performance advantages:
-
-- **Direct Access**: Indexers provide O(1) direct access to elements, while LINQ methods may involve enumeration overhead
-- **No Extension Method Overhead**: Eliminates the cost of extension method calls and delegate invocations
-- **Reduced Memory Allocations**: Avoids temporary objects and iterator allocations that LINQ methods might create
-- **Better JIT Optimization**: The JIT compiler can better optimize simple indexer access compared to generic extension methods
-
-## When This Rule Doesn't Apply
-
-This rule has specific limitations and won't trigger in certain scenarios:
-
-### Methods with Predicates
-
-The rule only applies to parameterless versions of `First()` and `Last()`, and single-parameter `ElementAt()`. It doesn't apply when using predicates:
-
-````csharp
-// These are NOT flagged by the rule - predicates are necessary
-var firstEven = list.First(x => x % 2 == 0);
-var lastNegative = array.Last(x => x < 0);
-````
-
-### OrDefault Variants
-
-The rule doesn't apply to the "OrDefault" variants of these methods:
-
-````csharp
-// These are NOT flagged by the rule
-var item1 = list.FirstOrDefault();      // ✅ Rule doesn't apply
-var item2 = list.LastOrDefault();       // ✅ Rule doesn't apply
-var item3 = list.ElementAtOrDefault(5); // ✅ Rule doesn't apply
-````
-
-### Unsupported Collection Types
-
-The rule only applies to collections that implement `IList<T>` or `IReadOnlyList<T>`:
-
-````csharp
-// These are NOT flagged by the rule - no indexer support
-IEnumerable<int> enumerable = GetNumbers();
-var first = enumerable.First();         // ✅ Rule doesn't apply
-
-HashSet<int> hashSet = new();
-var firstFromSet = hashSet.First();     // ✅ Rule doesn't apply
+var last = array[array.Length - 1];
 ````

--- a/docs/Rules/MA0098.md
+++ b/docs/Rules/MA0098.md
@@ -6,55 +6,21 @@ The indexer approach provides direct access to elements without the overhead of 
 
 ## Examples
 
-### ElementAt() method
-
 ````csharp
-// Non-compliant - using ElementAt()
-var array = new int[10];
 var list = new List<int>();
 
-var value1 = array.ElementAt(5);        // ❌ Inefficient
-var value2 = list.ElementAt(3);         // ❌ Inefficient
+_ = list.ElementAt(5); // non-compliant
+_ = list[5];           // compliant
 
-// Compliant - using indexer
-var value3 = array[5];                  // ✅ Direct access
-var value4 = list[3];                   // ✅ Direct access
-````
+_ = list.First(); // non-compliant
+_ = list[0];      // compliant
 
-### First() method
+_ = list.Last(); // non-compliant
+_ = list[^1];    // compliant
+_ = list[list.Count - 1];  // compliant
 
-````csharp
-// Non-compliant - using First() without predicate
-var array = new int[10];
-var list = new List<int>();
-
-var first1 = array.First();             // ❌ Inefficient
-var first2 = list.First();              // ❌ Inefficient
-
-// Compliant - using indexer
-var first3 = array[0];                  // ✅ Direct access
-var first4 = list[0];                   // ✅ Direct access
-
-// Note: First(predicate) is not affected by this rule
-var firstEven = array.First(x => x % 2 == 0);  // ✅ Uses predicate, rule doesn't apply
-````
-
-### Last() method
-
-````csharp
-// Non-compliant - using Last() without predicate
-var array = new int[10];
-var list = new List<int>();
-
-var last1 = array.Last();               // ❌ Inefficient
-var last2 = list.Last();                // ❌ Inefficient
-
-// Compliant - using indexer
-var last3 = array[array.Length - 1];    // ✅ Direct access
-var last4 = list[list.Count - 1];       // ✅ Direct access
-
-// Note: Last(predicate) is not affected by this rule
-var lastEven = array.Last(x => x % 2 == 0);    // ✅ Uses predicate, rule doesn't apply
+_ = list.FirstOrDefault(); // compliant
+_ = list.First(x => x > 1); // compliant
 ````
 
 ## C# 8+ Index and Range Support


### PR DESCRIPTION
- MA0090: Add comprehensive documentation for 'Remove empty else/finally block' rule
  - Include detailed rule description and rationale
  - Add code examples for both else and finally blocks
  - Document exceptions and edge cases (comments, preprocessor directives)
  - Add configuration options and severity settings
  - Include additional resources and best practices

- MA0098: Update documentation for 'Use indexer instead of LINQ methods' rule
  - Enhanced examples and performance guidance
  - Clarified when rule applies and exceptions
  - Added related rules section