### PR TITLE
Update default TargetFramework and adjust test setups

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
@@ -27,7 +27,7 @@ public sealed partial class ProjectBuilder
     public bool IsValidCode { get; private set; } = true;
     public bool IsValidFixCode { get; private set; } = true;
     public LanguageVersion LanguageVersion { get; private set; } = LanguageVersion.Latest;
-    public TargetFramework TargetFramework { get; private set; } = TargetFramework.NetStandard2_0;
+    public TargetFramework TargetFramework { get; private set; } = TargetFramework.NetLatest;
     public IList<MetadataReference> References { get; } = [];
     public IList<string> ApiReferences { get; } = [];
     public IList<DiagnosticAnalyzer> DiagnosticAnalyzer { get; } = [];

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseDirectMethodsTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseDirectMethodsTests.cs
@@ -67,6 +67,7 @@ class Test
 ";
 
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.NetStandard2_0)
               .WithSourceCode(SourceCode)
               .ShouldReportDiagnosticWithMessage("Use 'Find()' instead of 'FirstOrDefault()'")
               .ShouldFixCodeWith(CodeFix)
@@ -119,6 +120,7 @@ class Test
 ";
 
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.NetStandard2_0)
               .WithSourceCode(SourceCode)
               .AddAnalyzerConfiguration("MA0020.report_when_conversion_needed", "true")
               .ShouldReportDiagnosticWithMessage("Use 'Find()' instead of 'FirstOrDefault()'")

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -61,6 +61,7 @@ class Test
     public async Task Append_ReportDiagnostic(string text)
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.NetStandard2_0)
               .WithSourceCode(@"using System.Text;
 class Test
 {
@@ -122,6 +123,7 @@ class Test
     public async Task AppendLine_ReportDiagnostic(string text)
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.NetStandard2_0)
               .WithSourceCode(@"using System.Text;
 class Test
 {
@@ -309,6 +311,7 @@ class Test
     public async Task Append_InterpolatedString()
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.NetStandard2_0)
               .WithSourceCode(@"using System.Text;
 class Test
 {
@@ -332,6 +335,7 @@ class Test
     public async Task AppendLine_InterpolatedString_FinishWithString()
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.NetStandard2_0)
               .WithSourceCode(@"using System.Text;
 class Test
 {
@@ -355,6 +359,7 @@ class Test
     public async Task AppendLine_InterpolatedString_FinishWithChar()
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.NetStandard2_0)
               .WithSourceCode(@"using System.Text;
 class Test
 {
@@ -378,6 +383,7 @@ class Test
     public async Task AppendLine_InterpolatedString_FinishWithObject()
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.NetStandard2_0)
               .WithSourceCode(@"using System.Text;
 class Test
 {
@@ -573,6 +579,7 @@ class Test
     public async Task Append_StringJoin_AppendJoin_OldTargetFramework()
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.NetStandard2_0)
               .WithSourceCode(@"using System.Text;
 class Test
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -725,7 +725,6 @@ class Test
 ";
 
         await CreateProjectBuilder()
-              .AddAsyncInterfaceApi()
               .WithSourceCode(SourceCode)
               .WithCodeFixProvider<UseAnOverloadThatHasCancellationTokenFixer_Argument>()
               .ShouldFixCodeWith(Fix)
@@ -770,7 +769,6 @@ class Test
 ";
 
         await CreateProjectBuilder()
-              .AddAsyncInterfaceApi()
               .WithSourceCode(SourceCode)
               .WithCodeFixProvider<UseAnOverloadThatHasCancellationTokenFixer_AwaitForEach>()
               .ShouldFixCodeWith(Fix)
@@ -798,7 +796,6 @@ class Test
 ";
 
         await CreateProjectBuilder()
-              .AddAsyncInterfaceApi()
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }
@@ -824,7 +821,6 @@ class Test
 ";
 
         await CreateProjectBuilder()
-              .AddAsyncInterfaceApi()
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }
@@ -855,7 +851,6 @@ class Test
 ";
 
         await CreateProjectBuilder()
-              .AddAsyncInterfaceApi()
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }
@@ -884,7 +879,6 @@ class Test : System.IAsyncDisposable
 ";
 
         await CreateProjectBuilder()
-              .AddAsyncInterfaceApi()
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
@@ -257,7 +257,6 @@ class TypeName
 }";
 
         await CreateProjectBuilder()
-              .AddAsyncInterfaceApi()
               .WithSourceCode(SourceCode)
               .ShouldFixCodeWith(CodeFix)
               .ValidateAsync();


### PR DESCRIPTION
Changed ProjectBuilder's default TargetFramework to NetLatest. Updated tests to explicitly set NetStandard2_0 where needed, ensuring consistent test behavior.
This may help catching the most common issues early.