### PR TITLE
MA0042 Generics fix

### DIFF
--- a/src/Meziantou.Analyzer/Internals/OverloadFinder.cs
+++ b/src/Meziantou.Analyzer/Internals/OverloadFinder.cs
@@ -123,7 +123,7 @@ internal sealed class OverloadFinder(Compilation compilation)
                 if (!options.IncludeObsoleteMembers && IsObsolete(method))
                     continue;
 
-                if (HasSimilarParameters(methodSymbol, method, options.AllowOptionalParameters, additionalParameterTypes))
+                if (OverloadFinder.HasSimilarParameters(methodSymbol, method, options.AllowOptionalParameters, additionalParameterTypes))
                     return method;
             }
         }
@@ -150,12 +150,18 @@ internal sealed class OverloadFinder(Compilation compilation)
         if (method.IsEqualTo(otherMethod))
             return false;
 
-        // The new method must have at least the same number of parameters as the old method, plus the number of additional parameters        
+        // The new method must have at least the same number of parameters as the old method, plus the number of additional parameters
         if (otherMethod.Parameters.Length - method.Parameters.Length < additionalParameterTypes.Length)
             return false;
 
         // If allowOptionalParameters is false, the new method must have exactly the same number of parameters as the old method
         if (!allowOptionalParameters && otherMethod.Parameters.Length - method.Parameters.Length != additionalParameterTypes.Length)
+            return false;
+
+        if (method.IsGenericMethod != otherMethod.IsGenericMethod)
+            return false;
+
+        if (method.IsGenericMethod && !HasSimilarGenericParametersInOrder(method, otherMethod))
             return false;
 
         // Most of the time, an overload has the same order for the parameters. Try to match them in order first (faster)
@@ -167,7 +173,8 @@ internal sealed class OverloadFinder(Compilation compilation)
                 var methodParameter = method.Parameters[i];
                 var otherMethodParameter = otherMethod.Parameters[j];
 
-                if (methodParameter.Type.IsEqualTo(otherMethodParameter.Type))
+                if (methodParameter.Type.IsEqualTo(otherMethodParameter.Type) ||
+                    ParametersWithGenericAreEqual(methodParameter, otherMethodParameter))
                 {
                     i++;
                     j++;
@@ -207,7 +214,8 @@ internal sealed class OverloadFinder(Compilation compilation)
                 var found = false;
                 for (var i = 0; i < otherMethodParameters.Length; i++)
                 {
-                    if (otherMethodParameters[i].Type.IsEqualTo(param.Type))
+                    if (otherMethodParameters[i].Type.IsEqualTo(param.Type) ||
+                        ParametersWithGenericAreEqual(param, otherMethodParameters[i]))
                     {
                         otherMethodParameters = otherMethodParameters.RemoveAt(i);
                         found = true;
@@ -254,6 +262,57 @@ internal sealed class OverloadFinder(Compilation compilation)
                 ? left.IsOrInheritFrom(right.Symbol)
                 : left.IsEqualTo(right.Symbol);
         }
+
+        bool ParametersWithGenericAreEqual(IParameterSymbol parameter, IParameterSymbol otherParameter)
+        {
+            if (!method.IsGenericMethod)
+                return false;
+
+            var parameterType = parameter.Type as INamedTypeSymbol;
+            var otherParameterType = otherParameter.Type as INamedTypeSymbol;
+            // has same number of type parameters
+            if (parameterType?.Arity is 0 or null || parameterType.Arity != otherParameterType?.Arity)
+                return false;
+
+            // are same base type, List<> for example
+            if (!parameterType.ConstructedFrom.IsEqualTo(otherParameterType.ConstructedFrom))
+                return false;
+
+            // should reference same type parameter in order
+            for (var j = 0; j < parameterType.TypeParameters.Length; j++)
+                if (parameterType.TypeParameters[j].Ordinal != otherParameterType.TypeParameters[j].Ordinal)
+                    return false;
+
+            return true;
+        }
+    }
+
+    private static bool HasSimilarGenericParametersInOrder(IMethodSymbol method, IMethodSymbol otherMethod)
+    {
+        if (method.Arity != otherMethod.Arity)
+            return false;
+
+        for (var i = 0; i < method.Arity; i++)
+        {
+            var methodParameter = method.TypeParameters[i];
+            var otherMethodParameter = otherMethod.TypeParameters[i];
+
+            if (methodParameter.HasReferenceTypeConstraint != otherMethodParameter.HasReferenceTypeConstraint ||
+                methodParameter.HasValueTypeConstraint != otherMethodParameter.HasValueTypeConstraint ||
+                methodParameter.HasNotNullConstraint != otherMethodParameter.HasNotNullConstraint ||
+                methodParameter.HasUnmanagedTypeConstraint != otherMethodParameter.HasUnmanagedTypeConstraint ||
+                methodParameter.HasConstructorConstraint != otherMethodParameter.HasConstructorConstraint ||
+                methodParameter.Variance != otherMethodParameter.Variance ||
+                methodParameter.ConstraintTypes.Length != otherMethodParameter.ConstraintTypes.Length)
+                return false;
+
+            // implies that generic constrains declared in same order
+            for (var j = 0; j < methodParameter.ConstraintTypes.Length; j++)
+                if (!methodParameter.ConstraintTypes[j].IsEqualTo(otherMethodParameter.ConstraintTypes[j]))
+                    return false;
+        }
+
+        return true;
     }
 
     private bool IsObsolete(IMethodSymbol methodSymbol)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -972,11 +972,11 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
 
                 class Test
                 {
-                    public void A<T>(List<T> test)
+                    public void A<T>(int i, List<T> test)
                     {
                     }
 
-                    public async Task AAsync<T>(List<T> test, CancellationToken token = default)
+                    public async Task AAsync<T>(int i, List<T> test, CancellationToken token = default)
                     {
                     }
                 }
@@ -985,7 +985,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
                 {
                     public async Task a()
                     {
-                        [|new Test().A<int>(new List<int> { 1 })|];
+                        [|new Test().A<int>(1, new List<int> { 1 })|];
                     }
                 }
                 """)
@@ -998,11 +998,11 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
 
                 class Test
                 {
-                    public void A<T>(List<T> test)
+                    public void A<T>(int i, List<T> test)
                     {
                     }
 
-                    public async Task AAsync<T>(List<T> test, CancellationToken token = default)
+                    public async Task AAsync<T>(int i, List<T> test, CancellationToken token = default)
                     {
                     }
                 }
@@ -1011,7 +1011,190 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
                 {
                     public async Task a()
                     {
-                        await new Test().AAsync<int>(new List<int> { 1 });
+                        await new Test().AAsync<int>(1, new List<int> { 1 });
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericMethod_DifferentReferenceTypeConstraint_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+                using System.Diagnostics;
+
+                class Test
+                {
+                    public void A<T>(int i, List<T> test) where T : class
+                    {
+                    }
+
+                    public async Task AAsync<T>(int i, List<T> test, CancellationToken token = default)
+                    {
+                    }
+                }
+
+                class demo
+                {
+                    public async Task a()
+                    {
+                        new Test().A<string>(1, new List<string>());
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericMethod_DifferentValueTypeConstraint_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+                using System.Diagnostics;
+
+                class Test
+                {
+                    public void A<T>(int i, List<T> test) where T : struct
+                    {
+                    }
+
+                    public async Task AAsync<T>(int i, List<T> test, CancellationToken token = default)
+                    {
+                    }
+                }
+
+                class demo
+                {
+                    public async Task a()
+                    {
+                        new Test().A<int>(1, new List<int>());
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericMethod_DifferentTypeConstraint_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+                using System.Diagnostics;
+
+                interface IMark {}
+
+                class Mark : IMark {}
+
+                class Test
+                {
+                    public void A<T>(int i, List<T> test) where T : IMark
+                    {
+                    }
+
+                    public async Task AAsync<T>(int i, List<T> test, CancellationToken token = default)
+                    {
+                    }
+                }
+
+                class demo
+                {
+                    public async Task a()
+                    {
+                        new Test().A<Mark>(1, new List<Mark>());
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericMethod_DifferentTypeConstraintsOrder_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+                using System.Diagnostics;
+
+                interface IMark1 {}
+                interface IMark2 {}
+
+                class Mark : IMark1, IMark2 {}
+
+                class Test
+                {
+                    public void A<T>(int i, List<T> test)
+                        where T : IMark1, IMark2
+                    {
+                    }
+
+                    public async Task AAsync<T>(int i, List<T> test, CancellationToken token = default)
+                        where T : IMark2, IMark1
+                    {
+                    }
+                }
+
+                class demo
+                {
+                    public async Task a()
+                    {
+                        new Test().A<Mark>(1, new List<Mark>());
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericMethod_SameConstraints_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+                using System.Diagnostics;
+
+                interface IMark1 {}
+                interface IMark2 {}
+
+                class Mark : IMark1, IMark2 {}
+
+                class Test
+                {
+                    public void A<T>(int i, List<T> test)
+                        where T : class, IMark1, IMark2
+                    {
+                    }
+
+                    public async Task AAsync<T>(int i, List<T> test, CancellationToken token = default)
+                        where T : class, IMark1, IMark2
+                    {
+                    }
+                }
+
+                class demo
+                {
+                    public async Task a()
+                    {
+                        [|new Test().A<Mark>(1, new List<Mark>())|];
                     }
                 }
                 """)
@@ -1461,6 +1644,170 @@ class Sample
                     {
                         var dir = new TemporaryDirectory();
                         [|dir.CreateTextFile("test.txt", "content")|];
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericArgument_MultipleIncompatibleGenericArguments_ShouldNotReport()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public void A(List<int> a, List<string> b)
+                    {
+                    }
+
+                    public Task AAsync<T>(List<T> a, List<T> b, CancellationToken token = default)
+                    {
+                        return Task.CompletedTask;
+                    }
+                }
+
+                class Demo
+                {
+                    public async Task M()
+                    {
+                        new Test().A(new List<int>(), new List<string>());
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ExtensionMethod_GenericArgumentsIncompatible_ShouldNotReport()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                }
+
+                static class TestExtensions
+                {
+                    public static void A(this Test test, List<int> a, List<string> b)
+                    {
+                    }
+
+                    public static Task AAsync<T>(this Test test, List<T> a, List<T> b, CancellationToken token = default)
+                    {
+                        return Task.CompletedTask;
+                    }
+                }
+
+                class Demo
+                {
+                    public async Task M()
+                    {
+                        new Test().A(new List<int>(), new List<string>());
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericArgument_DifferentGenericTypeDefinitions_ShouldNotReport()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public void A(List<int> value)
+                    {
+                    }
+
+                    public Task AAsync<T>(IEnumerable<T> value, CancellationToken token = default)
+                    {
+                        return Task.CompletedTask;
+                    }
+                }
+
+                class Demo
+                {
+                    public async Task M()
+                    {
+                        new Test().A(new List<int>());
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericArgument_NestedGenericIncompatibility_ShouldNotReport()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public void A(List<List<int>> value)
+                    {
+                    }
+
+                    public Task AAsync(List<List<string>> value, CancellationToken token = default)
+                    {
+                        return Task.CompletedTask;
+                    }
+                }
+
+                class Demo
+                {
+                    public async Task M()
+                    {
+                        new Test().A(new List<List<int>>());
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericArgument_SameOriginalDefinitionButDifferentTypeParameterMapping_ShouldNotReport()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System.Collections.Generic;
+                using System.Threading;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public void A<T1, T2>(Dictionary<T1, T2> value)
+                    {
+                    }
+
+                    public Task AAsync<T>(Dictionary<T, T> value, CancellationToken token = default)
+                    {
+                        return Task.CompletedTask;
+                    }
+                }
+
+                class Demo
+                {
+                    public async Task M()
+                    {
+                        new Test().A<int, string>(new Dictionary<int, string>());
                     }
                 }
                 """)


### PR DESCRIPTION
Hi
There are an issue with sync to async analyzer
It ignore cases when one of arguments is generic. 
Consider this:
```csharp
class Test
{
    public void A<T>(List<T> test)
    {
    }
    public async Task AAsync<T>(List<T> test, CancellationToken token = default)
    {
    }
}

class demo
{
    public async Task a()
    {
        new Test<int>().A([1]);
    }
}
```

When analyzer seraches for overload it compares `List<int> test` parameter from call with `List<T> test` from async overload. This comparison fails. So it is better to compare `OriginalDefinition` ot parameter type, it will return type without concrete type parameter if it is specified and do nothing otherwise