### PR TITLE
Skip NuGet publish steps for fork PRs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
     - name: NuGet login (OIDC → temp API key)
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       uses: NuGet/login@v1
       id: login
       with:
@@ -190,7 +191,7 @@ jobs:
             }
         }
       name: Publish NuGet packages
-      if: always()
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       env:
         NuGetApiKey: ${{steps.login.outputs.NUGET_API_KEY}}
         FeedzApiKey: ${{ secrets.FEEDZ_APIKEY }}


### PR DESCRIPTION
The `deploy` job in CI requires OIDC authentication (`NuGet/login`) and secrets (`FEEDZ_APIKEY`) to publish NuGet packages. Fork PRs don't have access to either, causing the job to fail. Since `deploy` is a required check, this blocks merging any fork contribution.

This adds a condition to the NuGet login and publish steps so they are skipped when the PR comes from a fork, while the `deploy` job itself still runs and succeeds. The condition used is:

```
github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

This ensures publishing runs for pushes to `main`, workflow dispatches, and same-repo PRs — but is safely skipped for fork PRs.