### PR TITLE
docs: require updating rule docs when rules change

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,7 @@ Do NOT add equivalence/similarity notes directly to individual rule documentatio
 ## Implementing Roslyn analyzers
 
 - When creating a new rule, create a new constant in `src/Meziantou.Analyzer/RuleIdentifiers.cs` using the name of the new rule. The value must be unique and incremented from the last rule.
+- When updating an existing rule, update the corresponding documentation file under `docs/Rules/` to reflect the change.
 - The analyzers must be under `src/Meziantou.Analyzer/Rules/`
 - The code fixers must be under `src/Meziantou.Analyzer.CodeFixers/Rules`
 - The tests must be under `tests/Meziantou.Analyzer.Test/Rules`


### PR DESCRIPTION
## Why
When a rule implementation changes, its rule documentation can become stale if not updated in the same change. This adds an explicit instruction so analyzer behavior and `docs/Rules` stay aligned.

## What changed
- Updated `.github/copilot-instructions.md` to require updating the corresponding file under `docs/Rules/` whenever an existing rule is modified.

## Notes
- Scope is documentation guidance only (no analyzer/code behavior changes).