### PR TITLE
Cache IsAwaitable result for the no-SyntaxNode overload

### DIFF
--- a/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
+++ b/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -6,6 +7,7 @@ internal sealed class AwaitableTypes
 {
     private readonly INamedTypeSymbol[] _taskOrValueTaskSymbols;
     private readonly Compilation _compilation;
+    private readonly ConcurrentDictionary<ITypeSymbol, bool> _isAwaitableCache = new(SymbolEqualityComparer.Default);
 
     public AwaitableTypes(Compilation compilation)
     {
@@ -80,6 +82,11 @@ internal sealed class AwaitableTypes
         if (symbol is null)
             return false;
 
+        return _isAwaitableCache.GetOrAdd(symbol, IsAwaitableCore);
+    }
+
+    private bool IsAwaitableCore(ITypeSymbol symbol)
+    {
         if (INotifyCompletionSymbol is null)
             return false;
 


### PR DESCRIPTION
The `IsAwaitable(ITypeSymbol?)` overload on `AwaitableTypes` is called repeatedly for the same type symbols (e.g. by `MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer` for every method in a compilation). Unlike the position-dependent overload, its result depends only on the type symbol itself, making it a good caching candidate.

This adds a `ConcurrentDictionary<ITypeSymbol, bool>` (keyed with `SymbolEqualityComparer.Default`) that memoizes results via `GetOrAdd`, avoiding redundant `GetMembers`, accessibility checks, and awaiter-pattern validation for previously seen types.