### PR TITLE
Add MA0015 test for ThrowIfNullOrWhiteSpace member access option

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests.cs
@@ -1000,6 +1000,32 @@ public sealed class ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests
     }
 
     [Fact]
+    public async Task ThrowIfNullOrWhiteSpace_MemberAccess_OptionEnabled_ShouldNotReportError()
+    {
+        var sourceCode = """
+            using System;
+            class Sample
+            {
+                public static void ToSvg(string qrCode, QRCodeSvgOptions options)
+                {
+                    ArgumentNullException.ThrowIfNull(qrCode);
+                    ArgumentException.ThrowIfNullOrWhiteSpace(options.DarkColor);
+                }
+            }
+
+            class QRCodeSvgOptions
+            {
+                public string DarkColor { get; set; }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .AddAnalyzerConfiguration("MA0015.consider_member_access_as_parameter", "true")
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task ThrowIfNull_DeepMemberAccess_OptionEnabled_ShouldNotReportError()
     {
         var sourceCode = """


### PR DESCRIPTION
## Why
The MA0015 option `consider_member_access_as_parameter` should also cover `ArgumentException.ThrowIfNullOrWhiteSpace` calls using member access expressions. This adds coverage to prevent regressions in that scenario.

## What changed
- Added a new test: `ThrowIfNullOrWhiteSpace_MemberAccess_OptionEnabled_ShouldNotReportError`
- The test uses a `ToSvg` sample with `options.DarkColor` and verifies no diagnostic is reported when `MA0015.consider_member_access_as_parameter` is set to `true`.

## Notes
- This is a focused test-only change in `ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests`.