### PR TITLE
Fix MA0004 code fix crash with chained await using

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
@@ -114,15 +114,23 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
                 {
                     // Move statement before using
                     // foreach variable, add
-                    var variablesStatement = SyntaxFactory.LocalDeclarationStatement(SyntaxFactory.VariableDeclaration(usingBlock.Declaration.Type, usingBlock.Declaration.Variables))
-                        .WithLeadingTrivia(usingBlock.GetLeadingTrivia());
+                    var variablesStatement = SyntaxFactory.LocalDeclarationStatement(SyntaxFactory.VariableDeclaration(usingBlock.Declaration.Type, usingBlock.Declaration.Variables));
                     var newUsingBlock = usingBlock
                         .WithDeclaration(null)
-                        .WithExpression(AppendConfigureAwait(SyntaxFactory.IdentifierName(usingBlock.Declaration.Variables[0].Identifier)))
-                        .WithoutLeadingTrivia();
+                        .WithExpression(AppendConfigureAwait(SyntaxFactory.IdentifierName(usingBlock.Declaration.Variables[0].Identifier)));
 
-                    editor.InsertBefore(usingBlock, variablesStatement);
-                    editor.ReplaceNode(usingBlock, newUsingBlock);
+                    if (TryInsertVariableStatementBeforeUsing(variablesStatement.WithLeadingTrivia(usingBlock.GetLeadingTrivia()), usingBlock))
+                    {
+                        editor.ReplaceNode(usingBlock, newUsingBlock);
+                    }
+                    else
+                    {
+                        var newBlock = SyntaxFactory.Block(variablesStatement, newUsingBlock.WithoutLeadingTrivia())
+                            .WithLeadingTrivia(usingBlock.GetLeadingTrivia())
+                            .WithTrailingTrivia(usingBlock.GetTrailingTrivia());
+                        editor.ReplaceNode(usingBlock, newBlock);
+                    }
+
                     return editor.GetChangedDocument();
                 }
             }
@@ -195,6 +203,31 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
         }
 
         return context.Document;
+
+        bool TryInsertVariableStatementBeforeUsing(LocalDeclarationStatementSyntax variableStatement, UsingStatementSyntax usingStatement)
+        {
+            var insertionTarget = usingStatement;
+            while (insertionTarget.Parent is UsingStatementSyntax parentUsing &&
+                   parentUsing.Statement == insertionTarget &&
+                   parentUsing.Declaration is null)
+            {
+                insertionTarget = parentUsing;
+            }
+
+            if (insertionTarget.Parent is BlockSyntax or SwitchSectionSyntax)
+            {
+                editor.InsertBefore(insertionTarget, variableStatement);
+                return true;
+            }
+
+            if (insertionTarget.Parent is GlobalStatementSyntax { Parent: CompilationUnitSyntax } globalStatement)
+            {
+                editor.InsertBefore(globalStatement, SyntaxFactory.GlobalStatement(variableStatement));
+                return true;
+            }
+
+            return false;
+        }
 
         ExpressionSyntax AppendConfigureAwait(SyntaxNode expressionSyntax)
         {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
@@ -740,6 +740,54 @@ class MyClass : System.Windows.Window
     }
 
     [Fact]
+    public async Task AwaitUsing_WithMultipleUsings_ShouldNotThrow()
+    {
+        const string SourceCode = """
+            using System;
+            using System.IO;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    Stream stream = OpenWrite();
+                    await using (stream.ConfigureAwait(false))
+                    await using (var [|streamWriter = new StreamWriter(stream)|])
+                    {
+                        await streamWriter.WriteAsync("test-data").ConfigureAwait(false);
+                    }
+                }
+
+                Stream OpenWrite() => throw null;
+            }
+            """;
+        const string CodeFix = """
+            using System;
+            using System.IO;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    Stream stream = OpenWrite();
+                    var streamWriter = new StreamWriter(stream);
+                    await using (stream.ConfigureAwait(false))
+                    await using (streamWriter.ConfigureAwait(false))
+                    {
+                        await streamWriter.WriteAsync("test-data").ConfigureAwait(false);
+                    }
+                }
+
+                Stream OpenWrite() => throw null;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ShouldFixCodeWith(CodeFix)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task AwaitUsingAwait_NoVariable()
     {
         const string SourceCode = """


### PR DESCRIPTION
## Why
MA0004's code fix could throw `InvalidOperationException` when applying the fix to a second `await using` in a chained `await using` pattern (issue #1093). This happened while extracting the declaration and inserting it before a nested `UsingStatementSyntax`.

## What changed
- Updated `UseConfigureAwaitFixer` to insert extracted declarations at a valid insertion target by walking up nested `using` statements when needed.
- Added a safe fallback: when insertion before the target is not valid, replace the statement with a block containing the declaration and updated `await using`.
- Added a regression test: `AwaitUsing_WithMultipleUsings_ShouldNotThrow` in `UseConfigureAwaitAnalyzerTests`.

## Notes
This preserves the intended fix output while preventing the syntax list replacement exception in chained `await using` scenarios.