### PR TITLE
Handle local variable values in MA0173 analyzer

### DIFF
--- a/src/Meziantou.Analyzer/Rules/UseLazyInitializerEnsureInitializeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLazyInitializerEnsureInitializeAnalyzer.cs
@@ -38,7 +38,14 @@ public class UseLazyInitializerEnsureInitializeAnalyzer : DiagnosticAnalyzer
                 // Interlocked.CompareExchange(ref _instance, new Sample(), null)
                 if (operation.Arguments.Length is 3 && targetMethod.Name is "CompareExchange" && targetMethod.ContainingType.IsEqualTo(interlockedType))
                 {
-                    if (operation.Arguments[2].Value.IsNull() && operation.Arguments[1].Value.UnwrapImplicitConversionOperations() is IObjectCreationOperation)
+                    if (!operation.Arguments[2].Value.IsNull())
+                        return;
+
+                    if (operation.Arguments[0].Value.Type is not { IsReferenceType: true })
+                        return;
+
+                    var value = operation.Arguments[1].Value.UnwrapImplicitConversionOperations();
+                    if (value is IObjectCreationOperation or ILocalReferenceOperation)
                     {
                         context.ReportDiagnostic(Rule, operation);
                     }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseLazyInitializerEnsureInitializeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseLazyInitializerEnsureInitializeAnalyzerTests.cs
@@ -82,6 +82,43 @@ public sealed class UseLazyInitializerEnsureInitializeAnalyzerTests
     }
 
     [Fact]
+    public async Task LocalVariable_Field_Null()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                _ = new Sample().M();
+
+                class Sample
+                {
+                    private static System.Func<string>? s_getDisplayName;
+
+                    public string M()
+                    {
+                        System.Func<string> getDisplayName = () => string.Empty;
+                        [|System.Threading.Interlocked.CompareExchange(ref s_getDisplayName, getDisplayName, comparand: null)|];
+                        return getDisplayName();
+                    }
+                }
+                """)
+              .ShouldFixCodeWith("""
+                _ = new Sample().M();
+
+                class Sample
+                {
+                    private static System.Func<string>? s_getDisplayName;
+
+                    public string M()
+                    {
+                        System.Func<string> getDisplayName = () => string.Empty;
+                        System.Threading.LazyInitializer.EnsureInitialized(ref s_getDisplayName, () => getDisplayName);
+                        return getDisplayName();
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task NewCustomStruct()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
## Why
MA0173 only reported `Interlocked.CompareExchange` when the value argument was an object creation expression. This missed valid cases where the value came from a local variable (for example, a local `Func` assigned to a static field), so the analyzer did not suggest `LazyInitializer.EnsureInitialized` consistently.

## What changed
- Expanded MA0173 detection to also report when the second `CompareExchange` argument is a local reference.
- Kept the null-comparand requirement and added a reference-type check on the target argument to avoid non-applicable value-type cases.
- Added a regression test (`LocalVariable_Field_Null`) covering:
  - `Interlocked.CompareExchange(ref s_getDisplayName, getDisplayName, comparand: null)`
  - expected fix: `LazyInitializer.EnsureInitialized(ref s_getDisplayName, () => getDisplayName)`

## Notes for reviewers
The fixed code intentionally uses `() => getDisplayName` (a factory returning `Func<string>`). Passing `getDisplayName` directly would not match the `EnsureInitialized` overload for this scenario.