### PR TITLE
Extend MA0067 detection for empty Guid patterns

### DIFF
--- a/docs/Rules/MA0067.md
+++ b/docs/Rules/MA0067.md
@@ -5,7 +5,9 @@ Sources: [UseGuidEmptyAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyz
 
 ````csharp
 _ = new Guid(); // non-compliant
-_ = default(Guid); // non-compliant
+_ = new Guid("00000000-0000-0000-0000-000000000000"); // non-compliant
+_ = new Guid(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); // non-compliant
+_ = Guid.Parse("{00000000-0000-0000-0000-000000000000}"); // non-compliant
 
 _ = Guid.Empty; // compliant
 ````

--- a/src/Meziantou.Analyzer/Rules/UseGuidEmptyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseGuidEmptyAnalyzer.cs
@@ -28,17 +28,67 @@ public sealed class UseGuidEmptyAnalyzer : DiagnosticAnalyzer
 
         context.RegisterCompilationStartAction(compilationContext =>
         {
-            compilationContext.RegisterOperationAction(AnalyzeObjectCreationOperation, OperationKind.ObjectCreation);
+            var guidType = compilationContext.Compilation.GetBestTypeByMetadataName("System.Guid");
+            if (guidType is null)
+                return;
+
+            compilationContext.RegisterOperationAction(ctx => AnalyzeObjectCreationOperation(ctx, guidType), OperationKind.ObjectCreation);
+            compilationContext.RegisterOperationAction(ctx => AnalyzeInvocationOperation(ctx, guidType), OperationKind.Invocation);
         });
     }
 
-    private static void AnalyzeObjectCreationOperation(OperationAnalysisContext context)
+    private static void AnalyzeObjectCreationOperation(OperationAnalysisContext context, INamedTypeSymbol guidType)
     {
         var operation = (IObjectCreationOperation)context.Operation;
-        var guidType = context.Compilation.GetBestTypeByMetadataName("System.Guid");
-        if (operation.Type.IsEqualTo(guidType) && operation.Arguments.Length == 0)
+
+        if (operation.Constructor is null || !operation.Constructor.ContainingType.IsEqualTo(guidType))
+            return;
+
+        if (operation.Arguments.Length == 0)
         {
             context.ReportDiagnostic(Rule, operation);
+            return;
+        }
+
+        if (operation.Arguments is [{ Value.Type.SpecialType: SpecialType.System_String, Value.ConstantValue: { HasValue: true, Value: string value } }])
+        {
+            if (System.Guid.TryParse(value, out var guid) && guid == System.Guid.Empty)
+            {
+                context.ReportDiagnostic(Rule, operation);
+            }
+
+            return;
+        }
+
+        if (operation.Arguments.Length == 11 && IsAllZero(operation.Arguments))
+        {
+            context.ReportDiagnostic(Rule, operation);
+        }
+    }
+
+    private static bool IsAllZero(ImmutableArray<IArgumentOperation> arguments)
+    {
+        foreach (var argument in arguments)
+        {
+            if (!argument.Value.ConstantValue.HasValue || !NumericHelpers.IsZero(argument.Value.ConstantValue.Value))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static void AnalyzeInvocationOperation(OperationAnalysisContext context, INamedTypeSymbol guidType)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        if (!invocation.TargetMethod.ContainingType.IsEqualTo(guidType))
+            return;
+
+        if (invocation is { TargetMethod.Name: "Parse", Arguments: [{ Value.Type.SpecialType: SpecialType.System_String, Value.ConstantValue: { HasValue: true, Value: string value } }] })
+        {
+            if (System.Guid.TryParse(value, out var guid) && guid == System.Guid.Empty)
+            {
+                context.ReportDiagnostic(Rule, invocation);
+            }
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseGuidEmptyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseGuidEmptyAnalyzerTests.cs
@@ -14,6 +14,15 @@ public sealed class UseGuidEmptyAnalyzerTests
 
     [Theory]
     [InlineData("new System.Guid()")]
+    [InlineData("new System.Guid(\"00000000-0000-0000-0000-000000000000\")")]
+    [InlineData("new System.Guid(\"{00000000-0000-0000-0000-000000000000}\")")]
+    [InlineData("new System.Guid(\"00000000000000000000000000000000\")")]
+    [InlineData("new System.Guid(\"(00000000-0000-0000-0000-000000000000)\")")]
+    [InlineData("new System.Guid(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)")]
+    [InlineData("System.Guid.Parse(\"00000000-0000-0000-0000-000000000000\")")]
+    [InlineData("System.Guid.Parse(\"{00000000-0000-0000-0000-000000000000}\")")]
+    [InlineData("System.Guid.Parse(\"00000000000000000000000000000000\")")]
+    [InlineData("System.Guid.Parse(\"(00000000-0000-0000-0000-000000000000)\")")]
     public async Task ShouldReportError(string code)
     {
         await CreateProjectBuilder()
@@ -40,6 +49,9 @@ class TestClass
 
     [Theory]
     [InlineData("new System.Guid(\"\")")]
+    [InlineData("new System.Guid(\"10752bc4-c151-50f5-f27b-df92d8af5a61\")")]
+    [InlineData("System.Guid.Parse(\"10752bc4-c151-50f5-f27b-df92d8af5a61\")")]
+    [InlineData("new System.Guid(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)")]
     public async Task ShouldNotReportError(string code)
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
## Why
MA0067 only flagged `new Guid()`, so equivalent empty-Guid constructions were missed. This change makes the rule consistently detect empty GUID values regardless of common constructor or parse syntax.

## What changed
- Extended `UseGuidEmptyAnalyzer` to also report:
  - `new Guid("...")` when the constant string parses to `Guid.Empty`
  - `new Guid(0, 0, 0, ...)` when all numeric constructor arguments are zero
  - `Guid.Parse("...")` when the constant string parses to `Guid.Empty`
- Reused the existing shared helper `NumericHelpers.IsZero` for numeric zero checks.
- Expanded `UseGuidEmptyAnalyzerTests` with positive and negative cases, including multiple supported empty-Guid string formats (dashed, braced, parenthesized, and no-dash).
- Updated MA0067 documentation examples to reflect the broader detection coverage.

## Notes
- Detection for string-based cases relies on `Guid.TryParse`, so it naturally supports all formats accepted by the BCL parser.