### PR TITLE
Expand documentation for MA0065, MA0066, and MA0069

### DIFF
--- a/docs/Rules/MA0065.md
+++ b/docs/Rules/MA0065.md
@@ -3,7 +3,40 @@
 Source: [DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs)
 <!-- sources -->
 
-The default implementation of `Equals` and `GetHashCode` is not performant. You should override those methods in the type.
+The default implementation of `ValueType.Equals` and `ValueType.GetHashCode` is generic and often expensive for hot paths.
+This rule reports direct equality/hash calls on non-enum structs that still rely on default `ValueType` behavior.
+To avoid the warning and improve runtime behavior, implement your own `Equals(object)` and `GetHashCode()`
+for the struct (ideally with `IEquatable<T>` too).
+
+````csharp
+struct Sample
+{
+    public int Value;
+}
+
+var left = new Sample();
+var right = new Sample();
+_ = left.Equals(right);      // non-compliant (MA0065)
+_ = left.GetHashCode();      // non-compliant (MA0065)
+````
+
+````csharp
+using System;
+
+struct Sample : IEquatable<Sample>
+{
+    public int Value;
+
+    public bool Equals(Sample other) => Value == other.Value;
+    public override bool Equals(object obj) => obj is Sample other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Value);
+}
+
+var left = new Sample();
+var right = new Sample();
+_ = left.Equals(right);      // compliant
+_ = left.GetHashCode();      // compliant
+````
 
 - [Struct equality performance in .NET](https://www.meziantou.net/struct-equality-performance-in-dotnet.htm)
 - [Performance implications of default struct equality in C#](https://devblogs.microsoft.com/premier-developer/performance-implications-of-default-struct-equality-in-c/?WT.mc_id=DT-MVP-5003978)

--- a/docs/Rules/MA0066.md
+++ b/docs/Rules/MA0066.md
@@ -3,6 +3,49 @@
 Source: [DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs)
 <!-- sources -->
 
-The default implementation of `Equals` and `GetHashCode` is not performant. Those methods are used by `HashSet`, `Dictionary`, and similar types. You should override them in the type or use a custom `IEqualityComparer<T>`.
+Hash-based collections call `GetHashCode`/`Equals` frequently. When a struct key or element still uses default
+`ValueType` equality, lookup and insertion can become significantly slower.
+
+This rule reports usage of such structs in:
+
+- `HashSet<T>`, `Dictionary<TKey, TValue>`, `ConcurrentDictionary<TKey, TValue>`
+- immutable hash/dictionary factory methods (`Create`, `CreateBuilder`, `CreateRange`)
+- immutable `.Empty` instances used without `WithComparer` / `WithComparers`
+
+Use one of these fixes:
+
+1. Override equality members on the struct.
+2. Provide an explicit comparer (`IEqualityComparer<T>`).
+
+````csharp
+struct Key
+{
+    public int Value;
+}
+
+_ = new System.Collections.Generic.HashSet<Key>();                              // non-compliant (MA0066)
+_ = new System.Collections.Generic.Dictionary<Key, string>();                   // non-compliant (MA0066)
+_ = System.Collections.Immutable.ImmutableHashSet.Create<Key>();                // non-compliant (MA0066)
+_ = System.Collections.Immutable.ImmutableDictionary<Key, string>.Empty;        // non-compliant (MA0066)
+````
+
+````csharp
+using System.Collections.Generic;
+
+struct Key
+{
+    public int Value;
+}
+
+sealed class KeyComparer : IEqualityComparer<Key>
+{
+    public bool Equals(Key x, Key y) => x.Value == y.Value;
+    public int GetHashCode(Key obj) => obj.Value;
+}
+
+_ = new HashSet<Key>(new KeyComparer());                                        // compliant
+_ = new Dictionary<Key, string>(new KeyComparer());                             // compliant
+_ = System.Collections.Immutable.ImmutableHashSet<Key>.Empty.WithComparer(new KeyComparer()); // compliant
+````
 
 - [Performance implications of default struct equality in C#](https://devblogs.microsoft.com/premier-developer/performance-implications-of-default-struct-equality-in-c/?WT.mc_id=DT-MVP-5003978)

--- a/docs/Rules/MA0069.md
+++ b/docs/Rules/MA0069.md
@@ -3,7 +3,38 @@
 Source: [NonConstantStaticFieldsShouldNotBeVisibleAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/NonConstantStaticFieldsShouldNotBeVisibleAnalyzer.cs)
 <!-- sources -->
 
-Static fields that are neither constant nor read-only are not thread-safe. Access to such fields
-must be carefully controlled and requires advanced programming techniques for synchronizing access
-to the class object. Because these are difficult skills to learn and master, and testing such an
-object poses its own challenges, static fields are best used to store data that does not change.
+Visible mutable static fields are shared global state. They are hard to reason about, are often not
+thread-safe, and can be modified from external code.
+
+This rule reports fields that are:
+
+- `static`
+- not `const`
+- not `readonly`
+- visible outside the assembly
+
+It does **not** report:
+
+- enum members
+- `const` and `static readonly` fields
+- fields that are not visible outside the assembly (for example, fields in internal types)
+
+````csharp
+public class Sample
+{
+    public static int Counter; // non-compliant (MA0069)
+}
+````
+
+````csharp
+public class Sample
+{
+    public const int Limit = 10;                 // compliant
+    public static readonly int Seed = 42;        // compliant
+}
+
+internal class InternalType
+{
+    public static int State;                     // compliant (not visible outside assembly)
+}
+````


### PR DESCRIPTION
## Summary
- expand MA0065 documentation with clearer trigger details and compliant/non-compliant examples
- expand MA0066 documentation with hash-collection scenarios and comparer-based compliant patterns
- expand MA0069 documentation with visibility criteria, exclusions, and examples
- remove the session-generated `meziantou-reimagined-dollop.sln` file from the working tree