### PR TITLE
MA0050: improve Throw* argument validation detection

### DIFF
--- a/docs/Rules/MA0050.md
+++ b/docs/Rules/MA0050.md
@@ -4,6 +4,7 @@ Sources: [ValidateArgumentsCorrectlyAnalyzer.cs](https://github.com/meziantou/Me
 <!-- sources -->
 
 When a method contains a `yield` statement, the evaluation of the method is deferred until the first enumeration. This rule ensures that arguments are validated immediately, while execution of the rest of the method is still deferred.
+This includes explicit `throw` statements for `ArgumentException`-derived exceptions and static `Throw*` helpers on `ArgumentException`-derived types (for example `ArgumentNullException.ThrowIfNull`).
 
 ````csharp
 IEnumerable<int> Sample(string a)

--- a/src/Meziantou.Analyzer/Rules/ValidateArgumentsCorrectlyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ValidateArgumentsCorrectlyAnalyzer.cs
@@ -107,7 +107,7 @@ public sealed class ValidateArgumentsCorrectlyAnalyzer : DiagnosticAnalyzer
                     var targetMethod = operation.TargetMethod;
                     return targetMethod.IsStatic &&
                         targetMethod.ContainingType.IsOrInheritFrom(_argumentExceptionSymbol) &&
-                        targetMethod.Name.Contains("Throw", System.StringComparison.Ordinal);
+                        targetMethod.Name.StartsWith("Throw", System.StringComparison.Ordinal);
                 }
             }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
@@ -222,6 +222,124 @@ class TypeName
     }
 
     [Fact]
+    public async Task ValidValidation_ArgumentExceptionThrowIfNullOrEmpty()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            class TypeName
+            {
+                IEnumerable<int> A(string a)
+                {
+                    System.ArgumentException.ThrowIfNullOrEmpty(a);
+
+                    return A();
+
+                    IEnumerable<int> A()
+                    {
+                        yield return 0;
+                        if (a == null)
+                        {
+                            yield return 1;
+                        }
+                    }
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_ArgumentExceptionThrowIfNullOrEmpty()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            class TypeName
+            {
+                IEnumerable<int> [|A|](string a)
+                {
+                    System.ArgumentException.ThrowIfNullOrEmpty(a);
+                    yield return 0;
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_CustomArgumentExceptionThrowIf()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            class CustomArgumentException : System.ArgumentException
+            {
+                public static void ThrowIf(bool condition, string paramName)
+                {
+                    if (condition)
+                        throw new CustomArgumentException(paramName);
+                }
+
+                public CustomArgumentException(string paramName) : base(paramName)
+                {
+                }
+            }
+
+            class TypeName
+            {
+                IEnumerable<int> [|A|](string a)
+                {
+                    CustomArgumentException.ThrowIf(a is null, nameof(a));
+                    yield return 0;
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_CustomArgumentExceptionThrow()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            class CustomArgumentException : System.ArgumentException
+            {
+                public static void Throw(bool condition, string paramName)
+                {
+                    if (condition)
+                        throw new CustomArgumentException(paramName);
+                }
+
+                public CustomArgumentException(string paramName) : base(paramName)
+                {
+                }
+            }
+
+            class TypeName
+            {
+                IEnumerable<int> [|A|](string a)
+                {
+                    CustomArgumentException.Throw(a is null, nameof(a));
+                    yield return 0;
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task ReportDiagnostic_IAsyncEnumerable()
     {
         const string SourceCode = @"using System.Collections.Generic;


### PR DESCRIPTION
## Why
MA0050 should recognize modern argument-validation helpers used before iterator execution. The previous check matched any method name containing `Throw`, which was broader than needed and could match unrelated method names.

## What changed
- Updated MA0050 invocation detection to require static methods on `ArgumentException` (or derived types) whose names start with `Throw`.
- Added test coverage for:
  - `ArgumentException.ThrowIfNullOrEmpty`
  - custom `ArgumentException`-derived `ThrowIf(...)`
  - custom `ArgumentException`-derived `Throw(...)`
- Updated MA0050 rule documentation to describe support for static `Throw*` helpers on `ArgumentException`-derived types.

## Notes
This keeps support for `ArgumentNullException.ThrowIfNull` and related helpers, while avoiding the old `Contains("Throw")` behavior.

## Validation
`dotnet` CLI is not available in this environment, so tests and doc generation could not be executed locally in this session.