### PR TITLE
Add MA0048 option for file-name prefix matching

### DIFF
--- a/docs/Rules/MA0048.md
+++ b/docs/Rules/MA0048.md
@@ -67,6 +67,17 @@ class Foo<TKey, TResult> // compliant
 class Foo<TKey, TResult> // non compliant
 {
 }
+
+// filename: Perk.cs
+class PerkQuery // non compliant (requires MA0048.allow_type_name_prefix = true)
+{
+}
+
+// filename: Perk.cs
+// .editorconfig: MA0048.allow_type_name_prefix = true
+class PerkQuery // compliant
+{
+}
 ````
 
 If a file contains multiple types, you can disable the rule locally by using `#pragma warning disable MA0048` or `[SuppressMessage]`
@@ -91,6 +102,9 @@ MA0048.exclude_file_local_types = true
 
 # Only validate the first type in a file. default: false
 MA0048.only_validate_first_type = false
+
+# Allow type names that start with the file name. default: false
+MA0048.allow_type_name_prefix = false
 
 # Allow "OfT" suffix for generic types with any arity (not just arity 1). default: false
 MA0048.allow_oft_for_all_generic_types = false

--- a/docs/Rules/MA0048.md
+++ b/docs/Rules/MA0048.md
@@ -15,6 +15,8 @@ The diagnostic message includes the type kind and name to provide clear context:
 - `File name must match type name (record MyRecord), expected file name: 'MyRecord'`
 - `File name must match type name (record struct MyRecordStruct), expected file name: 'MyRecordStruct'`
 - `File name must match type name (delegate MyDelegate), expected file name: 'MyDelegate'`
+- `File name must match type name (class MyHandler), expected file name: a prefix of 'MyHandler'` (when `MA0048.mode = Prefix`)
+- `File name must match type name (class MyRequest), expected file name: 'My'` (when `MA0048.mode = LongestCommonPrefix` and the longest common prefix is `My`)
 
 ````csharp
 // filename: Bar.cs
@@ -139,4 +141,6 @@ MA0048.allow_oft_for_all_generic_types = false
 dotnet_diagnostic.MA0048.excluded_symbol_names = Foo*|T:MyNamespace.Bar
 ````
 
-For backward compatibility, `MA0048.allow_type_name_prefix` remains supported and maps to `MA0048.mode = Prefix`.
+For backward compatibility:
+- `MA0048.allow_type_name_prefix = true` maps to `MA0048.mode = Prefix`.
+- `MA0048.allow_type_name_prefix = true` and `MA0048.use_longest_type_name_prefix = true` map to `MA0048.mode = LongestCommonPrefix`.

--- a/docs/Rules/MA0048.md
+++ b/docs/Rules/MA0048.md
@@ -8,13 +8,13 @@ The name of the class must match the name of the file. This rule has two main re
 - When you navigate code without an IDE, such as on GitHub, GitLab, or most web interfaces, you can quickly find the file that you are interested in.
 
 The diagnostic message includes the type kind and name to provide clear context:
-- `File name must match type name (class MyClass)`
-- `File name must match type name (enum MyEnum)`
-- `File name must match type name (interface IMyInterface)`
-- `File name must match type name (struct MyStruct)`
-- `File name must match type name (record MyRecord)`
-- `File name must match type name (record struct MyRecordStruct)`
-- `File name must match type name (delegate MyDelegate)`
+- `File name must match type name (class MyClass), expected file name: 'MyClass'`
+- `File name must match type name (enum MyEnum), expected file name: 'MyEnum'`
+- `File name must match type name (interface IMyInterface), expected file name: 'IMyInterface'`
+- `File name must match type name (struct MyStruct), expected file name: 'MyStruct'`
+- `File name must match type name (record MyRecord), expected file name: 'MyRecord'`
+- `File name must match type name (record struct MyRecordStruct), expected file name: 'MyRecordStruct'`
+- `File name must match type name (delegate MyDelegate), expected file name: 'MyDelegate'`
 
 ````csharp
 // filename: Bar.cs

--- a/docs/Rules/MA0048.md
+++ b/docs/Rules/MA0048.md
@@ -80,7 +80,7 @@ class PerkQuery // compliant
 }
 
 // filename: Sample.cs
-// .editorconfig: MA0048.mode = LongestPrefix
+// .editorconfig: MA0048.mode = LongestCommonPrefix
 class SampleProjectHandler // non compliant
 {
 }
@@ -92,7 +92,7 @@ class SampleProjectResponse // non compliant (longest common prefix is "SamplePr
 }
 
 // filename: SampleProject.cs
-// .editorconfig: MA0048.mode = LongestPrefix
+// .editorconfig: MA0048.mode = LongestCommonPrefix
 class SampleProjectHandler // compliant
 {
 }
@@ -128,7 +128,7 @@ MA0048.exclude_file_local_types = true
 MA0048.only_validate_first_type = false
 
 # File name matching mode. default: Exact
-# Allowed values: Exact, Prefix, LongestPrefix
+# Allowed values: Exact, Prefix, LongestCommonPrefix
 MA0048.mode = Exact
 
 # Allow "OfT" suffix for generic types with any arity (not just arity 1). default: false

--- a/docs/Rules/MA0048.md
+++ b/docs/Rules/MA0048.md
@@ -69,19 +69,18 @@ class Foo<TKey, TResult> // non compliant
 }
 
 // filename: Perk.cs
-class PerkQuery // non compliant (requires MA0048.allow_type_name_prefix = true)
+class PerkQuery // non compliant (requires MA0048.mode = Prefix)
 {
 }
 
 // filename: Perk.cs
-// .editorconfig: MA0048.allow_type_name_prefix = true
+// .editorconfig: MA0048.mode = Prefix
 class PerkQuery // compliant
 {
 }
 
 // filename: Sample.cs
-// .editorconfig: MA0048.allow_type_name_prefix = true
-// .editorconfig: MA0048.use_longest_type_name_prefix = true
+// .editorconfig: MA0048.mode = LongestPrefix
 class SampleProjectHandler // non compliant
 {
 }
@@ -93,8 +92,7 @@ class SampleProjectResponse // non compliant (longest common prefix is "SamplePr
 }
 
 // filename: SampleProject.cs
-// .editorconfig: MA0048.allow_type_name_prefix = true
-// .editorconfig: MA0048.use_longest_type_name_prefix = true
+// .editorconfig: MA0048.mode = LongestPrefix
 class SampleProjectHandler // compliant
 {
 }
@@ -129,11 +127,9 @@ MA0048.exclude_file_local_types = true
 # Only validate the first type in a file. default: false
 MA0048.only_validate_first_type = false
 
-# Allow type names that start with the file name. default: false
-MA0048.allow_type_name_prefix = false
-
-# When using MA0048.allow_type_name_prefix, require the file name to match the longest common prefix of top-level type names. default: false
-MA0048.use_longest_type_name_prefix = false
+# File name matching mode. default: Exact
+# Allowed values: Exact, Prefix, LongestPrefix
+MA0048.mode = Exact
 
 # Allow "OfT" suffix for generic types with any arity (not just arity 1). default: false
 MA0048.allow_oft_for_all_generic_types = false
@@ -142,3 +138,5 @@ MA0048.allow_oft_for_all_generic_types = false
 # Pipe-separated list of wildcard patterns
 dotnet_diagnostic.MA0048.excluded_symbol_names = Foo*|T:MyNamespace.Bar
 ````
+
+For backward compatibility, `MA0048.allow_type_name_prefix` remains supported and maps to `MA0048.mode = Prefix`.

--- a/docs/Rules/MA0048.md
+++ b/docs/Rules/MA0048.md
@@ -78,6 +78,32 @@ class PerkQuery // non compliant (requires MA0048.allow_type_name_prefix = true)
 class PerkQuery // compliant
 {
 }
+
+// filename: Sample.cs
+// .editorconfig: MA0048.allow_type_name_prefix = true
+// .editorconfig: MA0048.use_longest_type_name_prefix = true
+class SampleProjectHandler // non compliant
+{
+}
+class SampleProjectQuery // non compliant
+{
+}
+class SampleProjectResponse // non compliant (longest common prefix is "SampleProject")
+{
+}
+
+// filename: SampleProject.cs
+// .editorconfig: MA0048.allow_type_name_prefix = true
+// .editorconfig: MA0048.use_longest_type_name_prefix = true
+class SampleProjectHandler // compliant
+{
+}
+class SampleProjectQuery // compliant
+{
+}
+class SampleProjectResponse // compliant
+{
+}
 ````
 
 If a file contains multiple types, you can disable the rule locally by using `#pragma warning disable MA0048` or `[SuppressMessage]`
@@ -105,6 +131,9 @@ MA0048.only_validate_first_type = false
 
 # Allow type names that start with the file name. default: false
 MA0048.allow_type_name_prefix = false
+
+# When using MA0048.allow_type_name_prefix, require the file name to match the longest common prefix of top-level type names. default: false
+MA0048.use_longest_type_name_prefix = false
 
 # Allow "OfT" suffix for generic types with any arity (not just arity 1). default: false
 MA0048.allow_oft_for_all_generic_types = false

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Meziantou.Analyzer.Configurations;
@@ -100,11 +101,13 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
             var filePath = location.SourceTree.FilePath;
             var fileName = filePath is not null ? GetFileName(filePath.AsSpan()) : null;
             var allowTypeNamePrefixMatch = context.Options.GetConfigurationValue(location.SourceTree, Rule.Id + ".allow_type_name_prefix", defaultValue: false);
+            var useLongestTypeNamePrefix = context.Options.GetConfigurationValue(location.SourceTree, Rule.Id + ".use_longest_type_name_prefix", defaultValue: false);
 
             if (fileName.Equals(symbolName.AsSpan(), StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            if (allowTypeNamePrefixMatch && !fileName.IsEmpty && symbolName.AsSpan().StartsWith(fileName, StringComparison.OrdinalIgnoreCase))
+            if (allowTypeNamePrefixMatch && !fileName.IsEmpty && symbolName.AsSpan().StartsWith(fileName, StringComparison.OrdinalIgnoreCase) &&
+                (!useLongestTypeNamePrefix || IsLongestTypeNamePrefix(context, location.SourceTree, fileName)))
                 continue;
 
             if (symbol.Arity > 0)
@@ -143,6 +146,89 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
 
         return filePath[..index];
     }
+
+    private static bool IsLongestTypeNamePrefix(SymbolAnalysisContext context, SyntaxTree sourceTree, ReadOnlySpan<char> fileName)
+    {
+        var root = sourceTree.GetRoot(context.CancellationToken);
+        List<string>? typeNames = null;
+
+#if ROSLYN_4_4_OR_GREATER
+        var excludeFileLocalTypes = context.Options.GetConfigurationValue(sourceTree, Rule.Id + ".exclude_file_local_types", defaultValue: true);
+#endif
+
+        foreach (var node in root.DescendantNodesAndSelf(descendIntoChildren: static node => !IsTypeDeclaration(node)))
+        {
+            if (!TryGetTypeDeclarationName(node, out var typeName))
+                continue;
+
+#if ROSLYN_4_4_OR_GREATER
+            if (excludeFileLocalTypes && IsFileLocalType(node))
+                continue;
+#endif
+
+            typeNames ??= new List<string>();
+            typeNames.Add(typeName);
+        }
+
+        if (typeNames is null || typeNames.Count <= 1)
+            return true;
+
+        var commonPrefixLength = typeNames[0].Length;
+        for (var i = 1; i < typeNames.Count; i++)
+        {
+            commonPrefixLength = GetCommonPrefixLength(typeNames[0], typeNames[i], commonPrefixLength);
+            if (commonPrefixLength == 0)
+                return false;
+        }
+
+        return commonPrefixLength == fileName.Length &&
+               typeNames[0].AsSpan(0, commonPrefixLength).Equals(fileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int GetCommonPrefixLength(string left, string right, int maxLength)
+    {
+        var length = Math.Min(maxLength, right.Length);
+        var index = 0;
+        while (index < length && char.ToUpperInvariant(left[index]) == char.ToUpperInvariant(right[index]))
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static bool IsTypeDeclaration(SyntaxNode node)
+    {
+        return node is BaseTypeDeclarationSyntax or DelegateDeclarationSyntax;
+    }
+
+    private static bool TryGetTypeDeclarationName(SyntaxNode node, out string? typeName)
+    {
+        switch (node)
+        {
+            case BaseTypeDeclarationSyntax typeDeclaration:
+                typeName = typeDeclaration.Identifier.ValueText;
+                return true;
+            case DelegateDeclarationSyntax delegateDeclaration:
+                typeName = delegateDeclaration.Identifier.ValueText;
+                return true;
+            default:
+                typeName = null;
+                return false;
+        }
+    }
+
+#if ROSLYN_4_4_OR_GREATER
+    private static bool IsFileLocalType(SyntaxNode node)
+    {
+        return node switch
+        {
+            BaseTypeDeclarationSyntax typeDeclaration => typeDeclaration.Modifiers.Any(SyntaxKind.FileKeyword),
+            DelegateDeclarationSyntax delegateDeclaration => delegateDeclaration.Modifiers.Any(SyntaxKind.FileKeyword),
+            _ => false,
+        };
+    }
+#endif
 
     /// <summary>
     /// Implemented wildcard pattern match

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -12,6 +12,13 @@ namespace Meziantou.Analyzer.Rules;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
 {
+    private enum TypeNameMatchMode
+    {
+        Exact,
+        Prefix,
+        LongestPrefix,
+    }
+
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.FileNameMustMatchTypeName,
         title: "File name must match type name",
@@ -46,6 +53,8 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
             // Nested type
             if (symbol.ContainingType is not null)
                 continue;
+
+            var typeNameMatchMode = GetTypeNameMatchMode(context, location.SourceTree);
 
 #if ROSLYN_4_4_OR_GREATER
             if (symbol.IsFileLocal && context.Options.GetConfigurationValue(location.SourceTree, Rule.Id + ".exclude_file_local_types", defaultValue: true))
@@ -100,14 +109,13 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
 
             var filePath = location.SourceTree.FilePath;
             var fileName = filePath is not null ? GetFileName(filePath.AsSpan()) : null;
-            var allowTypeNamePrefixMatch = context.Options.GetConfigurationValue(location.SourceTree, Rule.Id + ".allow_type_name_prefix", defaultValue: false);
-            var useLongestTypeNamePrefix = context.Options.GetConfigurationValue(location.SourceTree, Rule.Id + ".use_longest_type_name_prefix", defaultValue: false);
 
             if (fileName.Equals(symbolName.AsSpan(), StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            if (allowTypeNamePrefixMatch && !fileName.IsEmpty && symbolName.AsSpan().StartsWith(fileName, StringComparison.OrdinalIgnoreCase) &&
-                (!useLongestTypeNamePrefix || IsLongestTypeNamePrefix(context, location.SourceTree, fileName)))
+            if (!fileName.IsEmpty && symbolName.AsSpan().StartsWith(fileName, StringComparison.OrdinalIgnoreCase) &&
+                (typeNameMatchMode is TypeNameMatchMode.Prefix ||
+                (typeNameMatchMode is TypeNameMatchMode.LongestPrefix && IsLongestTypeNamePrefix(context, location.SourceTree, fileName))))
                 continue;
 
             if (symbol.Arity > 0)
@@ -145,6 +153,27 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
             return filePath;
 
         return filePath[..index];
+    }
+
+    private static TypeNameMatchMode GetTypeNameMatchMode(SymbolAnalysisContext context, SyntaxTree sourceTree)
+    {
+        var mode = context.Options.GetConfigurationValue(sourceTree, Rule.Id + ".mode", defaultValue: string.Empty);
+        if (mode.Equals(nameof(TypeNameMatchMode.Exact), StringComparison.OrdinalIgnoreCase))
+            return TypeNameMatchMode.Exact;
+
+        if (mode.Equals(nameof(TypeNameMatchMode.Prefix), StringComparison.OrdinalIgnoreCase))
+            return TypeNameMatchMode.Prefix;
+
+        if (mode.Equals(nameof(TypeNameMatchMode.LongestPrefix), StringComparison.OrdinalIgnoreCase))
+            return TypeNameMatchMode.LongestPrefix;
+
+        // Backward compatibility
+        if (!context.Options.GetConfigurationValue(sourceTree, Rule.Id + ".allow_type_name_prefix", defaultValue: false))
+            return TypeNameMatchMode.Exact;
+
+        return context.Options.GetConfigurationValue(sourceTree, Rule.Id + ".use_longest_type_name_prefix", defaultValue: false)
+            ? TypeNameMatchMode.LongestPrefix
+            : TypeNameMatchMode.Prefix;
     }
 
     private static bool IsLongestTypeNamePrefix(SymbolAnalysisContext context, SyntaxTree sourceTree, ReadOnlySpan<char> fileName)

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -23,7 +23,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.FileNameMustMatchTypeName,
         title: "File name must match type name",
-        messageFormat: "File name must match type name ({0} {1})",
+        messageFormat: "File name must match type name ({0} {1}), expected file name: {2}",
         RuleCategories.Design,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -137,7 +137,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
                     continue;
             }
 
-            context.ReportDiagnostic(Rule, location, GetTypeKindDisplayString(symbol), symbolName);
+            context.ReportDiagnostic(Rule, location, GetTypeKindDisplayString(symbol), symbolName, GetExpectedFileName(context, symbol, location.SourceTree, typeNameMatchMode));
         }
     }
 
@@ -177,7 +177,42 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
             : TypeNameMatchMode.Prefix;
     }
 
+    private static string GetExpectedFileName(SymbolAnalysisContext context, INamedTypeSymbol symbol, SyntaxTree sourceTree, TypeNameMatchMode typeNameMatchMode)
+    {
+        return typeNameMatchMode switch
+        {
+            TypeNameMatchMode.Exact => "'" + symbol.Name + "'",
+            TypeNameMatchMode.Prefix => "a prefix of '" + symbol.Name + "'",
+            TypeNameMatchMode.LongestCommonPrefix => GetExpectedLongestCommonPrefixFileName(context, sourceTree, symbol.Name),
+            _ => throw new ArgumentOutOfRangeException(nameof(typeNameMatchMode)),
+        };
+    }
+
+    private static string GetExpectedLongestCommonPrefixFileName(SymbolAnalysisContext context, SyntaxTree sourceTree, string fallbackTypeName)
+    {
+        var typeNames = GetTopLevelTypeNames(context, sourceTree);
+        var longestCommonPrefixLength = GetLongestCommonPrefixLength(typeNames);
+        if (longestCommonPrefixLength <= 0)
+            return "'" + fallbackTypeName + "'";
+
+        return "'" + typeNames![0].Substring(0, longestCommonPrefixLength) + "'";
+    }
+
     private static bool IsLongestTypeNamePrefix(SymbolAnalysisContext context, SyntaxTree sourceTree, ReadOnlySpan<char> fileName)
+    {
+        var typeNames = GetTopLevelTypeNames(context, sourceTree);
+        var longestCommonPrefixLength = GetLongestCommonPrefixLength(typeNames);
+        if (longestCommonPrefixLength < 0)
+            return true;
+
+        if (longestCommonPrefixLength == 0)
+            return false;
+
+        return longestCommonPrefixLength == fileName.Length &&
+               typeNames![0].AsSpan(0, longestCommonPrefixLength).Equals(fileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static List<string>? GetTopLevelTypeNames(SymbolAnalysisContext context, SyntaxTree sourceTree)
     {
         var root = sourceTree.GetRoot(context.CancellationToken);
         List<string>? typeNames = null;
@@ -200,19 +235,24 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
             typeNames.Add(typeName);
         }
 
+        return typeNames;
+    }
+
+    // -1: no/one type, 0: no common prefix, >0: prefix length
+    private static int GetLongestCommonPrefixLength(List<string>? typeNames)
+    {
         if (typeNames is null || typeNames.Count <= 1)
-            return true;
+            return -1;
 
         var commonPrefixLength = typeNames[0].Length;
         for (var i = 1; i < typeNames.Count; i++)
         {
             commonPrefixLength = GetCommonPrefixLength(typeNames[0], typeNames[i], commonPrefixLength);
             if (commonPrefixLength == 0)
-                return false;
+                return 0;
         }
 
-        return commonPrefixLength == fileName.Length &&
-               typeNames[0].AsSpan(0, commonPrefixLength).Equals(fileName, StringComparison.OrdinalIgnoreCase);
+        return commonPrefixLength;
     }
 
     private static int GetCommonPrefixLength(string left, string right, int maxLength)

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -99,8 +99,12 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
 
             var filePath = location.SourceTree.FilePath;
             var fileName = filePath is not null ? GetFileName(filePath.AsSpan()) : null;
+            var allowTypeNamePrefixMatch = context.Options.GetConfigurationValue(location.SourceTree, Rule.Id + ".allow_type_name_prefix", defaultValue: false);
 
             if (fileName.Equals(symbolName.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (allowTypeNamePrefixMatch && !fileName.IsEmpty && symbolName.AsSpan().StartsWith(fileName, StringComparison.OrdinalIgnoreCase))
                 continue;
 
             if (symbol.Arity > 0)

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -17,7 +17,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
     {
         Exact,
         Prefix,
-        LongestPrefix,
+        LongestCommonPrefix,
     }
 
     private static readonly DiagnosticDescriptor Rule = new(
@@ -116,7 +116,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
 
             if (!fileName.IsEmpty && symbolName.AsSpan().StartsWith(fileName, StringComparison.OrdinalIgnoreCase) &&
                 (typeNameMatchMode is TypeNameMatchMode.Prefix ||
-                (typeNameMatchMode is TypeNameMatchMode.LongestPrefix && IsLongestTypeNamePrefix(context, location.SourceTree, fileName))))
+                (typeNameMatchMode is TypeNameMatchMode.LongestCommonPrefix && IsLongestTypeNamePrefix(context, location.SourceTree, fileName))))
                 continue;
 
             if (symbol.Arity > 0)
@@ -165,15 +165,15 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
         if (mode.Equals(nameof(TypeNameMatchMode.Prefix), StringComparison.OrdinalIgnoreCase))
             return TypeNameMatchMode.Prefix;
 
-        if (mode.Equals(nameof(TypeNameMatchMode.LongestPrefix), StringComparison.OrdinalIgnoreCase))
-            return TypeNameMatchMode.LongestPrefix;
+        if (mode.Equals(nameof(TypeNameMatchMode.LongestCommonPrefix), StringComparison.OrdinalIgnoreCase))
+            return TypeNameMatchMode.LongestCommonPrefix;
 
         // Backward compatibility
         if (!context.Options.GetConfigurationValue(sourceTree, Rule.Id + ".allow_type_name_prefix", defaultValue: false))
             return TypeNameMatchMode.Exact;
 
         return context.Options.GetConfigurationValue(sourceTree, Rule.Id + ".use_longest_type_name_prefix", defaultValue: false)
-            ? TypeNameMatchMode.LongestPrefix
+            ? TypeNameMatchMode.LongestCommonPrefix
             : TypeNameMatchMode.Prefix;
     }
 

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -231,7 +232,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
         return node is BaseTypeDeclarationSyntax or DelegateDeclarationSyntax;
     }
 
-    private static bool TryGetTypeDeclarationName(SyntaxNode node, out string? typeName)
+    private static bool TryGetTypeDeclarationName(SyntaxNode node, [NotNullWhen(true)] out string? typeName)
     {
         switch (node)
         {

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -195,7 +195,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
         if (longestCommonPrefixLength <= 0)
             return "'" + fallbackTypeName + "'";
 
-        return "'" + typeNames![0].Substring(0, longestCommonPrefixLength) + "'";
+        return "'" + typeNames![0].AsSpan(0, longestCommonPrefixLength).ToString() + "'";
     }
 
     private static bool IsLongestTypeNamePrefix(SymbolAnalysisContext context, SyntaxTree sourceTree, ReadOnlySpan<char> fileName)

--- a/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
@@ -223,6 +223,34 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
     }
 
     [Fact]
+    public async Task MatchFileNamePrefix_LongestPrefix_WithoutLongestPrefixInFileName()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(fileName: "Sample.cs", """
+                class [|SampleProjectHandler|] {}
+                class [|SampleProjectQuery|] {}
+                class [|SampleProjectResponse|] {}
+                """)
+              .AddAnalyzerConfiguration("MA0048.allow_type_name_prefix", "true")
+              .AddAnalyzerConfiguration("MA0048.use_longest_type_name_prefix", "true")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MatchFileNamePrefix_LongestPrefix_WithLongestPrefixInFileName()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(fileName: "SampleProject.cs", """
+                class SampleProjectHandler {}
+                class SampleProjectQuery {}
+                class SampleProjectResponse {}
+                """)
+              .AddAnalyzerConfiguration("MA0048.allow_type_name_prefix", "true")
+              .AddAnalyzerConfiguration("MA0048.use_longest_type_name_prefix", "true")
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task MatchOnlyFirstType_class1()
     {
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
@@ -234,7 +234,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
     }
 
     [Fact]
-    public async Task MatchFileNamePrefix_LongestPrefixMode_WithoutLongestPrefixInFileName()
+    public async Task MatchFileNamePrefix_LongestCommonPrefixMode_WithoutLongestCommonPrefixInFileName()
     {
         await CreateProjectBuilder()
               .WithSourceCode(fileName: "Sample.cs", """
@@ -242,12 +242,12 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
                 class [|SampleProjectQuery|] {}
                 class [|SampleProjectResponse|] {}
                 """)
-              .AddAnalyzerConfiguration("MA0048.mode", "LongestPrefix")
+              .AddAnalyzerConfiguration("MA0048.mode", "LongestCommonPrefix")
               .ValidateAsync();
     }
 
     [Fact]
-    public async Task MatchFileNamePrefix_LongestPrefixMode_WithLongestPrefixInFileName()
+    public async Task MatchFileNamePrefix_LongestCommonPrefixMode_WithLongestCommonPrefixInFileName()
     {
         await CreateProjectBuilder()
               .WithSourceCode(fileName: "SampleProject.cs", """
@@ -255,12 +255,12 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
                 class SampleProjectQuery {}
                 class SampleProjectResponse {}
                 """)
-              .AddAnalyzerConfiguration("MA0048.mode", "LongestPrefix")
+              .AddAnalyzerConfiguration("MA0048.mode", "LongestCommonPrefix")
               .ValidateAsync();
     }
 
     [Fact]
-    public async Task MatchFileNamePrefix_LongestPrefix_WithLegacyConfiguration()
+    public async Task MatchFileNamePrefix_LongestCommonPrefix_WithLegacyConfiguration()
     {
         await CreateProjectBuilder()
               .WithSourceCode(fileName: "SampleProject.cs", """

--- a/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
@@ -209,7 +209,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
     }
 
     [Fact]
-    public async Task MatchFileNamePrefix_WithConfiguration()
+    public async Task MatchFileNamePrefix_WithModeConfiguration()
     {
         await CreateProjectBuilder()
               .WithSourceCode(fileName: "Perk.cs", """
@@ -218,12 +218,23 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
                 class PerkHandler {}
                 class [|DummyHandler|] {}
                 """)
+              .AddAnalyzerConfiguration("MA0048.mode", "Prefix")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MatchFileNamePrefix_WithLegacyConfiguration()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(fileName: "Perk.cs", """
+                class PerkQuery {}
+                """)
               .AddAnalyzerConfiguration("MA0048.allow_type_name_prefix", "true")
               .ValidateAsync();
     }
 
     [Fact]
-    public async Task MatchFileNamePrefix_LongestPrefix_WithoutLongestPrefixInFileName()
+    public async Task MatchFileNamePrefix_LongestPrefixMode_WithoutLongestPrefixInFileName()
     {
         await CreateProjectBuilder()
               .WithSourceCode(fileName: "Sample.cs", """
@@ -231,13 +242,25 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
                 class [|SampleProjectQuery|] {}
                 class [|SampleProjectResponse|] {}
                 """)
-              .AddAnalyzerConfiguration("MA0048.allow_type_name_prefix", "true")
-              .AddAnalyzerConfiguration("MA0048.use_longest_type_name_prefix", "true")
+              .AddAnalyzerConfiguration("MA0048.mode", "LongestPrefix")
               .ValidateAsync();
     }
 
     [Fact]
-    public async Task MatchFileNamePrefix_LongestPrefix_WithLongestPrefixInFileName()
+    public async Task MatchFileNamePrefix_LongestPrefixMode_WithLongestPrefixInFileName()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(fileName: "SampleProject.cs", """
+                class SampleProjectHandler {}
+                class SampleProjectQuery {}
+                class SampleProjectResponse {}
+                """)
+              .AddAnalyzerConfiguration("MA0048.mode", "LongestPrefix")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MatchFileNamePrefix_LongestPrefix_WithLegacyConfiguration()
     {
         await CreateProjectBuilder()
               .WithSourceCode(fileName: "SampleProject.cs", """

--- a/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
@@ -20,7 +20,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
                 {
                 }
                 """)
-              .ShouldReportDiagnosticWithMessage("File name must match type name (class Sample)")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (class Sample), expected file name: 'Sample'")
               .ValidateAsync();
     }
 
@@ -219,6 +219,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
                 class [|DummyHandler|] {}
                 """)
               .AddAnalyzerConfiguration("MA0048.mode", "Prefix")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (class DummyHandler), expected file name: a prefix of 'DummyHandler'")
               .ValidateAsync();
     }
 
@@ -243,6 +244,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
                 class [|SampleProjectResponse|] {}
                 """)
               .AddAnalyzerConfiguration("MA0048.mode", "LongestCommonPrefix")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (class SampleProjectHandler), expected file name: 'SampleProject'")
               .ValidateAsync();
     }
 
@@ -505,7 +507,7 @@ file class [|Sample|]
 }
 """)
               .AddAnalyzerConfiguration("MA0048.exclude_file_local_types", "false")
-              .ShouldReportDiagnosticWithMessage("File name must match type name (class Sample)")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (class Sample), expected file name: 'Sample'")
               .ValidateAsync();
     }
 
@@ -518,7 +520,7 @@ class [|Sample|]
 {
 }
 """)
-              .ShouldReportDiagnosticWithMessage("File name must match type name (class Sample)")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (class Sample), expected file name: 'Sample'")
               .ValidateAsync();
     }
 
@@ -531,7 +533,7 @@ struct [|Sample|]
 {
 }
 """)
-              .ShouldReportDiagnosticWithMessage("File name must match type name (struct Sample)")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (struct Sample), expected file name: 'Sample'")
               .ValidateAsync();
     }
 
@@ -544,7 +546,7 @@ interface [|ISample|]
 {
 }
 """)
-              .ShouldReportDiagnosticWithMessage("File name must match type name (interface ISample)")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (interface ISample), expected file name: 'ISample'")
               .ValidateAsync();
     }
 
@@ -558,7 +560,7 @@ enum [|Sample|]
     Value1
 }
 """)
-              .ShouldReportDiagnosticWithMessage("File name must match type name (enum Sample)")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (enum Sample), expected file name: 'Sample'")
               .ValidateAsync();
     }
 
@@ -569,7 +571,7 @@ enum [|Sample|]
               .WithSourceCode(fileName: "Test.cs", """
 record [|Sample|];
 """)
-              .ShouldReportDiagnosticWithMessage("File name must match type name (record Sample)")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (record Sample), expected file name: 'Sample'")
               .ValidateAsync();
     }
 
@@ -582,7 +584,7 @@ record [|Sample|];
 record struct [|Sample|];
 """)
               .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp11)
-              .ShouldReportDiagnosticWithMessage("File name must match type name (record struct Sample)")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (record struct Sample), expected file name: 'Sample'")
               .ValidateAsync();
     }
 #endif
@@ -594,7 +596,7 @@ record struct [|Sample|];
               .WithSourceCode(fileName: "Test.cs", """
 delegate void [|Sample|]();
 """)
-              .ShouldReportDiagnosticWithMessage("File name must match type name (delegate Sample)")
+              .ShouldReportDiagnosticWithMessage("File name must match type name (delegate Sample), expected file name: 'Sample'")
               .ValidateAsync();
     }
 #endif

--- a/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
@@ -199,6 +199,30 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
     }
 
     [Fact]
+    public async Task DoesNotMatchFileNamePrefix_WithoutConfiguration()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(fileName: "Perk.cs", """
+                class [|PerkQuery|] {}
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MatchFileNamePrefix_WithConfiguration()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(fileName: "Perk.cs", """
+                class PerkQuery {}
+                class PerkResponse {}
+                class PerkHandler {}
+                class [|DummyHandler|] {}
+                """)
+              .AddAnalyzerConfiguration("MA0048.allow_type_name_prefix", "true")
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task MatchOnlyFirstType_class1()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
## Why
MA0048 currently requires an exact type/file-name match (with existing generic exceptions), which makes common patterns like `Perk.cs` plus `PerkQuery` or `PerkHandler` noisy. This change adds an opt-in configuration so teams can keep strict matching by default while allowing a file-name prefix convention when desired.

## What changed
- Added a new analyzer option: `MA0048.allow_type_name_prefix` (default: `false`).
- Updated MA0048 logic to accept top-level types whose names start with the file name when the option is enabled.
- Added tests to cover both behaviors:
  - default behavior still reports `PerkQuery` in `Perk.cs`
  - configured behavior allows `PerkQuery`, `PerkResponse`, `PerkHandler` in `Perk.cs` and still reports `DummyHandler`
- Updated `docs/Rules/MA0048.md` with examples and configuration documentation for the new option.

## Validation
- Ran `FileNameMustMatchTypeNameAnalyzerTests` on default Roslyn.
- Ran `FileNameMustMatchTypeNameAnalyzerTests` with `/p:RoslynVersion=roslyn4.2` and `/p:RoslynVersion=roslyn4.14`.
- Ran `dotnet run --project src/DocumentationGenerator` and confirmed no additional generated doc changes were required.