### PR TITLE
Improve MA0148/MA0149 fixer to merge compatible conditions

### DIFF
--- a/docs/Rules/MA0148.md
+++ b/docs/Rules/MA0148.md
@@ -7,4 +7,8 @@ Sources: [UsePatternMatchingForEqualityComparisonsAnalyzer.cs](https://github.co
 value == 1; // not compliant
 
 value is 1; // ok
+
+value == 0 || value == 1; // not compliant
+
+value is 0 or 1; // ok
 ````

--- a/docs/Rules/MA0149.md
+++ b/docs/Rules/MA0149.md
@@ -7,4 +7,8 @@ Sources: [UsePatternMatchingForEqualityComparisonsAnalyzer.cs](https://github.co
 value != 1; // not compliant
 
 value is not 1; // ok
+
+value != 0 && value != 1; // not compliant
+
+value is not (0 or 1); // ok
 ````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixAllProvider.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixAllProvider.cs
@@ -1,0 +1,38 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Meziantou.Analyzer.Rules;
+
+internal sealed class UsePatternMatchingForEqualityComparisonsFixAllProvider : DocumentBasedFixAllProvider
+{
+    public static UsePatternMatchingForEqualityComparisonsFixAllProvider Instance { get; } = new();
+
+    protected override string GetFixAllTitle(FixAllContext fixAllContext) => "Use pattern matching";
+
+    protected override async Task<Document?> FixAllAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
+    {
+        if (diagnostics.IsEmpty)
+            return null;
+
+        var newDocument = await FixDocumentAsync(document, diagnostics, fixAllContext.CancellationToken).ConfigureAwait(false);
+        return newDocument;
+    }
+
+    private static async Task<Document> FixDocumentAsync(Document document, ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
+    {
+        foreach (var diagnostic in diagnostics.OrderByDescending(diagnostic => diagnostic.Location.SourceSpan.Start))
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var nodeToFix = root?.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            if (nodeToFix is not BinaryExpressionSyntax binaryExpression)
+                continue;
+
+            document = await UsePatternMatchingForEqualityComparisonsFixer.UpdateDocumentAsync(document, binaryExpression, cancellationToken).ConfigureAwait(false);
+        }
+
+        return document;
+    }
+}

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using Meziantou.Analyzer.Internals;
@@ -8,7 +10,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Operations;
-using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;
@@ -19,82 +20,272 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
     public override ImmutableArray<string> FixableDiagnosticIds =>
         ImmutableArray.Create(RuleIdentifiers.UsePatternMatchingForNullCheck, RuleIdentifiers.UsePatternMatchingForNullEquality, RuleIdentifiers.UsePatternMatchingForEqualityComparison, RuleIdentifiers.UsePatternMatchingForInequalityComparison);
 
-    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => UsePatternMatchingForEqualityComparisonsFixAllProvider.Instance;
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        if (nodeToFix is not BinaryExpressionSyntax invocation)
+        if (nodeToFix is not BinaryExpressionSyntax binaryExpression)
             return;
 
         var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
         if (semanticModel is null)
             return;
 
-        if (semanticModel.GetOperation(invocation, context.CancellationToken) is not IBinaryOperation)
+        if (semanticModel.GetOperation(binaryExpression, context.CancellationToken) is not IBinaryOperation)
+            return;
+
+        var expressionToFix = GetContainingBooleanExpression(binaryExpression);
+        var updatedExpression = RewriteExpression(expressionToFix, semanticModel, context.CancellationToken);
+        if (SyntaxFactory.AreEquivalent(expressionToFix, updatedExpression))
             return;
 
         context.RegisterCodeFix(
             CodeAction.Create(
                 "Use pattern matching",
-                ct => Update(context.Document, invocation, ct),
+                ct => UpdateDocumentAsync(context.Document, binaryExpression, ct),
                 equivalenceKey: "Use pattern matching"),
             context.Diagnostics);
     }
 
-    private static async Task<Document> Update(Document document, BinaryExpressionSyntax node, CancellationToken cancellationToken)
+    internal static async Task<Document> UpdateDocumentAsync(Document document, BinaryExpressionSyntax node, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var operation = (IBinaryOperation)editor.SemanticModel.GetOperation(node, cancellationToken)!;
+        var expressionToFix = GetContainingBooleanExpression(node);
+        var updatedExpression = RewriteExpression(expressionToFix, editor.SemanticModel, cancellationToken);
+        if (SyntaxFactory.AreEquivalent(expressionToFix, updatedExpression))
+            return document;
 
-        if (UsePatternMatchingForEqualityComparisonsCommon.IsNull(operation.LeftOperand))
-        {
-            var newExpression = MakeIsNull(operation, operation.RightOperand);
-            if (newExpression is not null)
-            {
-                editor.ReplaceNode(node, newExpression);
-            }
-        }
-        else if (UsePatternMatchingForEqualityComparisonsCommon.IsNull(operation.RightOperand))
-        {
-            var newExpression = MakeIsNull(operation, operation.LeftOperand);
-            if (newExpression is not null)
-            {
-                editor.ReplaceNode(node, newExpression);
-            }
-        }
-        else
-        {
-            var (expression, constant) = UsePatternMatchingForEqualityComparisonsCommon.IsConstantLiteral(operation.RightOperand) ? (operation.LeftOperand, operation.RightOperand) : (operation.RightOperand, operation.LeftOperand);
-
-            PatternSyntax constantExpression = ConstantPattern((ExpressionSyntax)constant.Syntax);
-            if (operation.OperatorKind is BinaryOperatorKind.NotEquals)
-            {
-                constantExpression = UnaryPattern(constantExpression);
-            }
-
-            var newExpression = IsPatternExpression((ExpressionSyntax)expression.Syntax.Parentheses(), constantExpression);
-            if (newExpression is not null)
-            {
-                editor.ReplaceNode(node, newExpression);
-            }
-        }
-
+        editor.ReplaceNode(expressionToFix, updatedExpression.WithTriviaFrom(expressionToFix));
         return editor.GetChangedDocument();
     }
 
-    private static IsPatternExpressionSyntax? MakeIsNull(IBinaryOperation binaryOperation, IOperation expressionOperation)
+    private static ExpressionSyntax GetContainingBooleanExpression(BinaryExpressionSyntax binaryExpression)
     {
-        if (expressionOperation.Syntax is not ExpressionSyntax expression)
-            return null;
-
-        PatternSyntax constantExpression = ConstantPattern(LiteralExpression(SyntaxKind.NullLiteralExpression));
-        if (binaryOperation.OperatorKind is BinaryOperatorKind.NotEquals)
+        ExpressionSyntax current = binaryExpression;
+        while (TryGetParentLogicalExpression(current, out var parentBinary))
         {
-            constantExpression = UnaryPattern(constantExpression);
+            current = parentBinary;
         }
 
-        return IsPatternExpression(expression.Parentheses(), constantExpression);
+        return current;
     }
+
+    private static bool TryGetParentLogicalExpression(ExpressionSyntax expression, out BinaryExpressionSyntax parentBinary)
+    {
+        var parent = expression.Parent;
+        if (parent is ParenthesizedExpressionSyntax parenthesizedExpression)
+        {
+            parent = parenthesizedExpression.Parent;
+        }
+
+        if (parent is BinaryExpressionSyntax binaryExpression && IsLogicalBinary(binaryExpression.Kind()))
+        {
+            parentBinary = binaryExpression;
+            return true;
+        }
+
+        parentBinary = null!;
+        return false;
+    }
+
+    private static ExpressionSyntax RewriteExpression(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        if (expression is ParenthesizedExpressionSyntax parenthesizedExpression)
+        {
+            var updatedExpression = RewriteExpression(parenthesizedExpression.Expression, semanticModel, cancellationToken);
+            return SyntaxFactory.AreEquivalent(parenthesizedExpression.Expression, updatedExpression) ? expression : parenthesizedExpression.WithExpression(updatedExpression);
+        }
+
+        if (expression is BinaryExpressionSyntax binaryExpression)
+        {
+            if (binaryExpression.IsKind(SyntaxKind.LogicalOrExpression) || binaryExpression.IsKind(SyntaxKind.LogicalAndExpression))
+            {
+                return RewriteLogicalBinaryExpression(binaryExpression, semanticModel, cancellationToken);
+            }
+
+            if (TryCreatePatternExpression(binaryExpression, semanticModel, cancellationToken, out var updatedExpression))
+            {
+                return updatedExpression;
+            }
+        }
+
+        return expression;
+    }
+
+    private static ExpressionSyntax RewriteLogicalBinaryExpression(BinaryExpressionSyntax rootExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        var logicalExpressionKind = rootExpression.Kind();
+        var terms = new List<ExpressionSyntax>();
+        FlattenLogicalTerms(rootExpression, logicalExpressionKind, terms);
+
+        var expectedComparisonOperatorKind = logicalExpressionKind switch
+        {
+            SyntaxKind.LogicalOrExpression => BinaryOperatorKind.Equals,
+            SyntaxKind.LogicalAndExpression => BinaryOperatorKind.NotEquals,
+            _ => throw new InvalidOperationException("Unexpected logical expression kind"),
+        };
+
+        var updatedTerms = new List<ExpressionSyntax>(terms.Count);
+        var mergeCandidates = new List<DiscreteComparisonCandidate>();
+        foreach (var term in terms)
+        {
+            if (TryCreateDiscreteComparisonCandidate(term, expectedComparisonOperatorKind, semanticModel, cancellationToken, out var candidate))
+            {
+                if (mergeCandidates.Count > 0 && !SyntaxFactory.AreEquivalent(mergeCandidates[0].Expression, candidate.Expression))
+                {
+                    updatedTerms.Add(CreatePatternExpressionFromCandidates(mergeCandidates, expectedComparisonOperatorKind));
+                    mergeCandidates.Clear();
+                }
+
+                mergeCandidates.Add(candidate);
+                continue;
+            }
+
+            if (mergeCandidates.Count > 0)
+            {
+                updatedTerms.Add(CreatePatternExpressionFromCandidates(mergeCandidates, expectedComparisonOperatorKind));
+                mergeCandidates.Clear();
+            }
+
+            updatedTerms.Add(RewriteExpression(term, semanticModel, cancellationToken));
+        }
+
+        if (mergeCandidates.Count > 0)
+        {
+            updatedTerms.Add(CreatePatternExpressionFromCandidates(mergeCandidates, expectedComparisonOperatorKind));
+        }
+
+        if (updatedTerms.Count == 0)
+            return rootExpression;
+
+        var updatedExpression = updatedTerms[0];
+        for (var i = 1; i < updatedTerms.Count; i++)
+        {
+            updatedExpression = logicalExpressionKind switch
+            {
+                SyntaxKind.LogicalOrExpression => BinaryExpression(SyntaxKind.LogicalOrExpression, updatedExpression, updatedTerms[i]),
+                SyntaxKind.LogicalAndExpression => BinaryExpression(SyntaxKind.LogicalAndExpression, updatedExpression, updatedTerms[i]),
+                _ => throw new InvalidOperationException("Unexpected logical expression kind"),
+            };
+        }
+
+        return updatedExpression;
+    }
+
+    private static void FlattenLogicalTerms(ExpressionSyntax expression, SyntaxKind logicalExpressionKind, List<ExpressionSyntax> terms)
+    {
+        if (expression is BinaryExpressionSyntax binaryExpression && binaryExpression.IsKind(logicalExpressionKind))
+        {
+            FlattenLogicalTerms(binaryExpression.Left, logicalExpressionKind, terms);
+            FlattenLogicalTerms(binaryExpression.Right, logicalExpressionKind, terms);
+            return;
+        }
+
+        terms.Add(expression);
+    }
+
+    private static IsPatternExpressionSyntax CreatePatternExpressionFromCandidates(List<DiscreteComparisonCandidate> candidates, BinaryOperatorKind expectedComparisonOperatorKind)
+    {
+        PatternSyntax combinedPattern = candidates[0].Pattern;
+        for (var i = 1; i < candidates.Count; i++)
+        {
+            combinedPattern = BinaryPattern(SyntaxKind.OrPattern, combinedPattern, Token(SyntaxKind.OrKeyword), candidates[i].Pattern);
+        }
+
+        if (expectedComparisonOperatorKind is BinaryOperatorKind.NotEquals)
+        {
+            combinedPattern = candidates.Count > 1 ? UnaryPattern(ParenthesizedPattern(combinedPattern)) : UnaryPattern(combinedPattern);
+        }
+
+        return IsPatternExpression(candidates[0].Expression.Parentheses(), combinedPattern);
+    }
+
+    private static bool TryCreateDiscreteComparisonCandidate(ExpressionSyntax expression, BinaryOperatorKind expectedComparisonOperatorKind, SemanticModel semanticModel, CancellationToken cancellationToken, out DiscreteComparisonCandidate candidate)
+    {
+        candidate = default;
+
+        if (semanticModel.GetOperation(expression, cancellationToken) is not IBinaryOperation operation)
+            return false;
+
+        if (operation is not { OperatorMethod: null } || operation.OperatorKind != expectedComparisonOperatorKind)
+            return false;
+
+        var leftIsConstant = UsePatternMatchingForEqualityComparisonsCommon.IsConstantLiteral(operation.LeftOperand);
+        var rightIsConstant = UsePatternMatchingForEqualityComparisonsCommon.IsConstantLiteral(operation.RightOperand);
+        if (!(leftIsConstant ^ rightIsConstant))
+            return false;
+
+        var constantOperation = leftIsConstant ? operation.LeftOperand : operation.RightOperand;
+        if (UsePatternMatchingForEqualityComparisonsCommon.IsNull(constantOperation))
+            return false;
+
+        var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
+        if (expressionOperation.Syntax is not ExpressionSyntax valueExpression || constantOperation.Syntax is not ExpressionSyntax constantExpression)
+            return false;
+
+        candidate = new(valueExpression, ConstantPattern(constantExpression));
+        return true;
+    }
+
+    private static bool TryCreatePatternExpression(BinaryExpressionSyntax binaryExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out IsPatternExpressionSyntax updatedExpression)
+    {
+        updatedExpression = null!;
+        if (semanticModel.GetOperation(binaryExpression, cancellationToken) is not IBinaryOperation operation)
+            return false;
+
+        if (operation is not { OperatorKind: BinaryOperatorKind.Equals or BinaryOperatorKind.NotEquals, OperatorMethod: null })
+            return false;
+
+        if (UsePatternMatchingForEqualityComparisonsCommon.IsNull(operation.LeftOperand))
+        {
+            return TryCreateNullPatternExpression(operation, operation.RightOperand, out updatedExpression);
+        }
+
+        if (UsePatternMatchingForEqualityComparisonsCommon.IsNull(operation.RightOperand))
+        {
+            return TryCreateNullPatternExpression(operation, operation.LeftOperand, out updatedExpression);
+        }
+
+        var leftIsConstant = UsePatternMatchingForEqualityComparisonsCommon.IsConstantLiteral(operation.LeftOperand);
+        var rightIsConstant = UsePatternMatchingForEqualityComparisonsCommon.IsConstantLiteral(operation.RightOperand);
+        if (!(leftIsConstant ^ rightIsConstant))
+            return false;
+
+        var constantOperation = leftIsConstant ? operation.LeftOperand : operation.RightOperand;
+        var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
+
+        if (constantOperation.Syntax is not ExpressionSyntax constantExpression || expressionOperation.Syntax is not ExpressionSyntax valueExpression)
+            return false;
+
+        PatternSyntax constantPattern = ConstantPattern(constantExpression);
+        if (operation.OperatorKind is BinaryOperatorKind.NotEquals)
+        {
+            constantPattern = UnaryPattern(constantPattern);
+        }
+
+        updatedExpression = IsPatternExpression(valueExpression.Parentheses(), constantPattern);
+        return true;
+    }
+
+    private static bool TryCreateNullPatternExpression(IBinaryOperation binaryOperation, IOperation expressionOperation, out IsPatternExpressionSyntax updatedExpression)
+    {
+        updatedExpression = null!;
+        if (expressionOperation.Syntax is not ExpressionSyntax expression)
+            return false;
+
+        PatternSyntax constantPattern = ConstantPattern(LiteralExpression(SyntaxKind.NullLiteralExpression));
+        if (binaryOperation.OperatorKind is BinaryOperatorKind.NotEquals)
+        {
+            constantPattern = UnaryPattern(constantPattern);
+        }
+
+        updatedExpression = IsPatternExpression(expression.Parentheses(), constantPattern);
+        return true;
+    }
+
+    private static bool IsLogicalBinary(SyntaxKind kind) => kind is SyntaxKind.LogicalAndExpression or SyntaxKind.LogicalOrExpression;
+
+    private readonly record struct DiscreteComparisonCandidate(ExpressionSyntax Expression, PatternSyntax Pattern);
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
@@ -165,6 +165,87 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
     }
 
     [Fact]
+    public async Task EqualityComparison_MergeConditions()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  var value = 0;
+                  _ = [|value == 0|] || [|value == 1|];
+                  """)
+              .ShouldFixCodeWith("""
+                  var value = 0;
+                  _ = value is 0 or 1;
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InequalityComparison_MergeConditions()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  var value = 0;
+                  _ = [|value != 0|] && [|value != 1|];
+                  """)
+              .ShouldFixCodeWith("""
+                  var value = 0;
+                  _ = value is not (0 or 1);
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task EqualityComparison_DifferentExpressions_DoNotMerge()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  var value1 = 0;
+                  var value2 = 0;
+                  _ = [|value1 == 0|] || [|value2 == 1|];
+                  """)
+              .ShouldFixCodeWith("""
+                  var value1 = 0;
+                  var value2 = 0;
+                  _ = value1 is 0 || value2 is 1;
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task EqualityComparison_NonContiguousExpressions_DoNotMerge()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  var value1 = 0;
+                  var value2 = 0;
+                  _ = [|value1 == 0|] || [|value2 == 1|] || [|value1 == 2|];
+                  """)
+              .ShouldFixCodeWith("""
+                  var value1 = 0;
+                  var value2 = 0;
+                  _ = value1 is 0 || value2 is 1 || value1 is 2;
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task BatchFix_MergeConditions()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  var value = 0;
+                  _ = [|value == 0|] || [|value == 1|];
+                  _ = [|value != 2|] && [|value != 3|];
+                  """)
+              .ShouldBatchFixCodeWith("""
+                  var value = 0;
+                  _ = value is 0 or 1;
+                  _ = value is not (2 or 3);
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task CustomOperator_Class_Int32()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
## Why
MA0148 and MA0149 currently fix one comparison at a time. For chained conditions, this produces less idiomatic output and misses opportunities to emit a single merged pattern.

## What changed
- Added a custom `UsePatternMatchingForEqualityComparisonsFixAllProvider` so Fix All can process diagnostics in a stable order and apply merge-aware rewrites safely per document.
- Refactored `UsePatternMatchingForEqualityComparisonsFixer` to rewrite the containing boolean expression of the selected diagnostic, not just the single binary node.
- Implemented merge logic for contiguous compatible terms:
  - `value == 0 || value == 1` -> `value is 0 or 1`
  - `value != 0 && value != 1` -> `value is not (0 or 1)`
- Kept mixed and non-contiguous operands as separate conversions, for example:
  - `value1 == 0 || value2 == 1` -> `value1 is 0 || value2 is 1`
  - `value1 == 0 || value2 == 1 || value1 == 2` -> `value1 is 0 || value2 is 1 || value1 is 2`
- Added regression coverage in `UsePatternMatchingForEqualityComparisonsAnalyzerTests` for single-fix merge, Fix All merge, and edge cases.
- Updated MA0148 and MA0149 rule documentation examples.

## Validation
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj --filter "FullyQualifiedName~UsePatternMatchingForEqualityComparisonsAnalyzerTests"`
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj /p:RoslynVersion=roslyn4.2 --filter "FullyQualifiedName~UsePatternMatchingForEqualityComparisonsAnalyzerTests"`
- `dotnet run --project src/DocumentationGenerator`
- `dotnet build Meziantou.Analyzer.slnx`