### PR TITLE
Clarify ambiguous analyzer rule titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,19 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0029](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0029.md)|Performance|Combine LINQ methods|ℹ️|✔️|✔️|
 |[MA0030](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0030.md)|Performance|Remove useless OrderBy call|⚠️|✔️|✔️|
 |[MA0031](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0031.md)|Performance|Optimize Enumerable.Count() usage|ℹ️|✔️|✔️|
-|[MA0032](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0032.md)|Usage|Use an overload with a CancellationToken argument|ℹ️|❌|❌|
+|[MA0032](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0032.md)|Usage|Use the CancellationToken overload, even if one must be introduced|ℹ️|❌|❌|
 |[MA0033](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0033.md)|Design|Do not tag instance fields with ThreadStaticAttribute|⚠️|✔️|❌|
 |[MA0035](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0035.md)|Usage|Do not use dangerous threading methods|⚠️|✔️|❌|
 |[MA0036](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0036.md)|Design|Make class static|ℹ️|✔️|✔️|
 |[MA0037](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0037.md)|Usage|Remove empty statement|❌|✔️|✔️|
 |[MA0038](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0038.md)|Design|Make method static (deprecated, use CA1822 instead)|ℹ️|✔️|✔️|
 |[MA0039](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0039.md)|Security|Do not write your own certificate validation method|❌|✔️|❌|
-|[MA0040](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0040.md)|Usage|Forward the CancellationToken parameter to methods that take one|ℹ️|✔️|✔️|
+|[MA0040](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0040.md)|Usage|Forward the available CancellationToken to called methods|ℹ️|✔️|✔️|
 |[MA0041](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0041.md)|Design|Make property static (deprecated, use CA1822 instead)|ℹ️|✔️|✔️|
-|[MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md)|Design|Do not use blocking calls in an async method|ℹ️|✔️|✔️|
+|[MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md)|Design|Use await instead of blocking in async-compatible methods|ℹ️|✔️|✔️|
 |[MA0043](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0043.md)|Usage|Use nameof operator in ArgumentException|ℹ️|✔️|✔️|
 |[MA0044](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0044.md)|Performance|Remove useless ToString call|ℹ️|✔️|✔️|
-|[MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md)|Design|Do not use blocking calls in a sync method (need to make calling method async)|ℹ️|❌|✔️|
+|[MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md)|Design|Do not use blocking calls when the calling method must become async|ℹ️|❌|✔️|
 |[MA0046](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0046.md)|Design|Use EventHandler\<T\> to declare events|⚠️|✔️|❌|
 |[MA0047](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0047.md)|Design|Declare types in namespaces|⚠️|✔️|❌|
 |[MA0048](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md)|Design|File name must match type name|⚠️|✔️|❌|
@@ -126,7 +126,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0104](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0104.md)|Design|Do not create a type with a name from the BCL|⚠️|❌|❌|
 |[MA0105](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0105.md)|Performance|Use the lambda parameters instead of using a closure|ℹ️|✔️|✔️|
 |[MA0106](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0106.md)|Performance|Avoid closure by using an overload with the 'factoryArgument' parameter|ℹ️|✔️|✔️|
-|[MA0107](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0107.md)|Design|Do not use object.ToString|ℹ️|❌|❌|
+|[MA0107](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0107.md)|Design|Do not call object.ToString() on values typed as object|ℹ️|❌|❌|
 |[MA0108](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0108.md)|Usage|Remove redundant argument value|ℹ️|✔️|✔️|
 |[MA0109](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0109.md)|Design|Consider adding an overload with a Span\<T\> or Memory\<T\>|ℹ️|❌|❌|
 |[MA0110](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0110.md)|Performance|Use the Regex source generator|ℹ️|✔️|✔️|
@@ -143,7 +143,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0121](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0121.md)|Design|Do not overwrite parameter value|ℹ️|❌|❌|
 |[MA0122](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0122.md)|Design|Parameters with \[SupplyParameterFromQuery\] attributes are only valid in routable components (@page)|ℹ️|✔️|❌|
 |[MA0123](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0123.md)|Design|Sequence number must be a constant|⚠️|✔️|❌|
-|[MA0124](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0124.md)|Design|Log parameter type is not valid|⚠️|✔️|❌|
+|[MA0124](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0124.md)|Design|Microsoft.Extensions.Logging parameter type is not valid|⚠️|✔️|❌|
 |[MA0125](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0125.md)|Design|The list of log parameter types contains an invalid type|⚠️|✔️|❌|
 |[MA0126](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0126.md)|Design|The list of log parameter types contains a duplicate|⚠️|✔️|❌|
 |[MA0127](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0127.md)|Usage|Use String.Equals instead of is pattern|👻|✔️|✔️|
@@ -156,27 +156,27 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0134](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md)|Usage|Observe result of async calls|⚠️|✔️|❌|
 |[MA0135](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0135.md)|Design|The log parameter has no configured type|⚠️|❌|❌|
 |[MA0136](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0136.md)|Usage|Raw String contains an implicit end of line character|👻|✔️|❌|
-|[MA0137](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0137.md)|Design|Use 'Async' suffix when a method returns an awaitable type|⚠️|❌|✔️|
-|[MA0138](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0138.md)|Design|Do not use 'Async' suffix when a method does not return an awaitable type|⚠️|❌|✔️|
-|[MA0139](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0139.md)|Design|Log parameter type is not valid|⚠️|✔️|❌|
+|[MA0137](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0137.md)|Design|Awaitable-returning method name should end with 'Async'|⚠️|❌|✔️|
+|[MA0138](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0138.md)|Design|Non-awaitable method name should not end with 'Async'|⚠️|❌|✔️|
+|[MA0139](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0139.md)|Design|Serilog parameter type is not valid|⚠️|✔️|❌|
 |[MA0140](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0140.md)|Design|Both if and else branch have identical code|⚠️|✔️|❌|
-|[MA0141](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0141.md)|Usage|Use pattern matching instead of inequality operators for null check|ℹ️|❌|✔️|
-|[MA0142](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0142.md)|Usage|Use pattern matching instead of equality operators for null check|ℹ️|❌|✔️|
+|[MA0141](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0141.md)|Usage|Use 'is not null' instead of '!= null'|ℹ️|❌|✔️|
+|[MA0142](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0142.md)|Usage|Use 'is null' instead of '== null'|ℹ️|❌|✔️|
 |[MA0143](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0143.md)|Design|Primary constructor parameters should be readonly|⚠️|✔️|❌|
 |[MA0144](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0144.md)|Performance|Use System.OperatingSystem to check the current OS|⚠️|✔️|✔️|
 |[MA0145](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0145.md)|Usage|Signature for \[UnsafeAccessorAttribute\] method is not valid|⚠️|✔️|❌|
 |[MA0146](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0146.md)|Usage|Name must be set explicitly on local functions|⚠️|✔️|✔️|
 |[MA0147](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0147.md)|Usage|Avoid async void method for delegate|⚠️|✔️|❌|
-|[MA0148](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0148.md)|Usage|Use pattern matching instead of equality operators for discrete value|ℹ️|❌|✔️|
-|[MA0149](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0149.md)|Usage|Use pattern matching instead of inequality operators for discrete value|ℹ️|❌|✔️|
-|[MA0150](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0150.md)|Design|Do not call the default object.ToString explicitly|⚠️|✔️|❌|
+|[MA0148](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0148.md)|Usage|Use 'is' patterns instead of '==' for constant values|ℹ️|❌|✔️|
+|[MA0149](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0149.md)|Usage|Use 'is not' patterns instead of '!=' for constant values|ℹ️|❌|✔️|
+|[MA0150](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0150.md)|Design|Do not call ToString() when the type falls back to object.ToString()|⚠️|✔️|❌|
 |[MA0151](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0151.md)|Usage|DebuggerDisplay must contain valid members|⚠️|✔️|❌|
 |[MA0152](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0152.md)|Performance|Use Unwrap instead of using await twice|ℹ️|✔️|✔️|
 |[MA0153](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0153.md)|Design|Do not log symbols decorated with DataClassificationAttribute directly|⚠️|✔️|❌|
 |[MA0154](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0154.md)|Design|Use langword in XML comment|ℹ️|✔️|✔️|
 |[MA0155](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0155.md)|Design|Do not use async void methods|⚠️|❌|❌|
-|[MA0156](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0156.md)|Design|Use 'Async' suffix when a method returns IAsyncEnumerable\<T\>|⚠️|❌|✔️|
-|[MA0157](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0157.md)|Design|Do not use 'Async' suffix when a method returns IAsyncEnumerable\<T\>|⚠️|❌|✔️|
+|[MA0156](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0156.md)|Design|IAsyncEnumerable-returning method name should end with 'Async'|⚠️|❌|✔️|
+|[MA0157](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0157.md)|Design|IAsyncEnumerable-returning method name should not end with 'Async'|⚠️|❌|✔️|
 |[MA0158](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0158.md)|Performance|Use System.Threading.Lock|⚠️|✔️|✔️|
 |[MA0159](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0159.md)|Performance|Use 'Order' instead of 'OrderBy'|ℹ️|✔️|✔️|
 |[MA0160](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0160.md)|Performance|Use ContainsKey instead of TryGetValue|ℹ️|✔️|✔️|
@@ -189,7 +189,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0168](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0168.md)|Performance|Use readonly struct for in or ref readonly parameter|ℹ️|❌|❌|
 |[MA0169](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0169.md)|Design|Use Equals method instead of operator|⚠️|✔️|✔️|
 |[MA0170](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0170.md)|Design|Type cannot be used as an attribute argument|⚠️|❌|❌|
-|[MA0171](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0171.md)|Usage|Use pattern matching instead of HasValue for Nullable\<T\> check|ℹ️|❌|✔️|
+|[MA0171](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0171.md)|Usage|Use 'is null' / 'is not null' instead of Nullable\<T\>.HasValue|ℹ️|❌|✔️|
 |[MA0172](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0172.md)|Usage|Both sides of the logical operation are identical|⚠️|❌|❌|
 |[MA0173](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0173.md)|Design|Use LazyInitializer.EnsureInitialize|ℹ️|✔️|✔️|
 |[MA0174](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0174.md)|Style|Record should use explicit 'class' keyword|ℹ️|❌|✔️|

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,19 +32,19 @@
 |[MA0029](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0029.md)|Performance|Combine LINQ methods|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0030](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0030.md)|Performance|Remove useless OrderBy call|<span title='Warning'>⚠️</span>|✔️|✔️|
 |[MA0031](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0031.md)|Performance|Optimize Enumerable.Count() usage|<span title='Info'>ℹ️</span>|✔️|✔️|
-|[MA0032](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0032.md)|Usage|Use an overload with a CancellationToken argument|<span title='Info'>ℹ️</span>|❌|❌|
+|[MA0032](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0032.md)|Usage|Use the CancellationToken overload, even if one must be introduced|<span title='Info'>ℹ️</span>|❌|❌|
 |[MA0033](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0033.md)|Design|Do not tag instance fields with ThreadStaticAttribute|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0035](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0035.md)|Usage|Do not use dangerous threading methods|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0036](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0036.md)|Design|Make class static|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0037](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0037.md)|Usage|Remove empty statement|<span title='Error'>❌</span>|✔️|✔️|
 |[MA0038](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0038.md)|Design|Make method static (deprecated, use CA1822 instead)|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0039](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0039.md)|Security|Do not write your own certificate validation method|<span title='Error'>❌</span>|✔️|❌|
-|[MA0040](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0040.md)|Usage|Forward the CancellationToken parameter to methods that take one|<span title='Info'>ℹ️</span>|✔️|✔️|
+|[MA0040](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0040.md)|Usage|Forward the available CancellationToken to called methods|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0041](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0041.md)|Design|Make property static (deprecated, use CA1822 instead)|<span title='Info'>ℹ️</span>|✔️|✔️|
-|[MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md)|Design|Do not use blocking calls in an async method|<span title='Info'>ℹ️</span>|✔️|✔️|
+|[MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md)|Design|Use await instead of blocking in async-compatible methods|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0043](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0043.md)|Usage|Use nameof operator in ArgumentException|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0044](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0044.md)|Performance|Remove useless ToString call|<span title='Info'>ℹ️</span>|✔️|✔️|
-|[MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md)|Design|Do not use blocking calls in a sync method (need to make calling method async)|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md)|Design|Do not use blocking calls when the calling method must become async|<span title='Info'>ℹ️</span>|❌|✔️|
 |[MA0046](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0046.md)|Design|Use EventHandler\<T\> to declare events|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0047](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0047.md)|Design|Declare types in namespaces|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0048](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md)|Design|File name must match type name|<span title='Warning'>⚠️</span>|✔️|❌|
@@ -106,7 +106,7 @@
 |[MA0104](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0104.md)|Design|Do not create a type with a name from the BCL|<span title='Warning'>⚠️</span>|❌|❌|
 |[MA0105](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0105.md)|Performance|Use the lambda parameters instead of using a closure|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0106](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0106.md)|Performance|Avoid closure by using an overload with the 'factoryArgument' parameter|<span title='Info'>ℹ️</span>|✔️|✔️|
-|[MA0107](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0107.md)|Design|Do not use object.ToString|<span title='Info'>ℹ️</span>|❌|❌|
+|[MA0107](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0107.md)|Design|Do not call object.ToString() on values typed as object|<span title='Info'>ℹ️</span>|❌|❌|
 |[MA0108](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0108.md)|Usage|Remove redundant argument value|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0109](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0109.md)|Design|Consider adding an overload with a Span\<T\> or Memory\<T\>|<span title='Info'>ℹ️</span>|❌|❌|
 |[MA0110](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0110.md)|Performance|Use the Regex source generator|<span title='Info'>ℹ️</span>|✔️|✔️|
@@ -123,7 +123,7 @@
 |[MA0121](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0121.md)|Design|Do not overwrite parameter value|<span title='Info'>ℹ️</span>|❌|❌|
 |[MA0122](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0122.md)|Design|Parameters with \[SupplyParameterFromQuery\] attributes are only valid in routable components (@page)|<span title='Info'>ℹ️</span>|✔️|❌|
 |[MA0123](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0123.md)|Design|Sequence number must be a constant|<span title='Warning'>⚠️</span>|✔️|❌|
-|[MA0124](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0124.md)|Design|Log parameter type is not valid|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0124](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0124.md)|Design|Microsoft.Extensions.Logging parameter type is not valid|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0125](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0125.md)|Design|The list of log parameter types contains an invalid type|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0126](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0126.md)|Design|The list of log parameter types contains a duplicate|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0127](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0127.md)|Usage|Use String.Equals instead of is pattern|<span title='Hidden'>👻</span>|✔️|✔️|
@@ -136,27 +136,27 @@
 |[MA0134](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md)|Usage|Observe result of async calls|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0135](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0135.md)|Design|The log parameter has no configured type|<span title='Warning'>⚠️</span>|❌|❌|
 |[MA0136](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0136.md)|Usage|Raw String contains an implicit end of line character|<span title='Hidden'>👻</span>|✔️|❌|
-|[MA0137](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0137.md)|Design|Use 'Async' suffix when a method returns an awaitable type|<span title='Warning'>⚠️</span>|❌|✔️|
-|[MA0138](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0138.md)|Design|Do not use 'Async' suffix when a method does not return an awaitable type|<span title='Warning'>⚠️</span>|❌|✔️|
-|[MA0139](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0139.md)|Design|Log parameter type is not valid|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0137](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0137.md)|Design|Awaitable-returning method name should end with 'Async'|<span title='Warning'>⚠️</span>|❌|✔️|
+|[MA0138](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0138.md)|Design|Non-awaitable method name should not end with 'Async'|<span title='Warning'>⚠️</span>|❌|✔️|
+|[MA0139](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0139.md)|Design|Serilog parameter type is not valid|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0140](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0140.md)|Design|Both if and else branch have identical code|<span title='Warning'>⚠️</span>|✔️|❌|
-|[MA0141](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0141.md)|Usage|Use pattern matching instead of inequality operators for null check|<span title='Info'>ℹ️</span>|❌|✔️|
-|[MA0142](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0142.md)|Usage|Use pattern matching instead of equality operators for null check|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0141](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0141.md)|Usage|Use 'is not null' instead of '!= null'|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0142](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0142.md)|Usage|Use 'is null' instead of '== null'|<span title='Info'>ℹ️</span>|❌|✔️|
 |[MA0143](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0143.md)|Design|Primary constructor parameters should be readonly|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0144](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0144.md)|Performance|Use System.OperatingSystem to check the current OS|<span title='Warning'>⚠️</span>|✔️|✔️|
 |[MA0145](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0145.md)|Usage|Signature for \[UnsafeAccessorAttribute\] method is not valid|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0146](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0146.md)|Usage|Name must be set explicitly on local functions|<span title='Warning'>⚠️</span>|✔️|✔️|
 |[MA0147](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0147.md)|Usage|Avoid async void method for delegate|<span title='Warning'>⚠️</span>|✔️|❌|
-|[MA0148](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0148.md)|Usage|Use pattern matching instead of equality operators for discrete value|<span title='Info'>ℹ️</span>|❌|✔️|
-|[MA0149](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0149.md)|Usage|Use pattern matching instead of inequality operators for discrete value|<span title='Info'>ℹ️</span>|❌|✔️|
-|[MA0150](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0150.md)|Design|Do not call the default object.ToString explicitly|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0148](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0148.md)|Usage|Use 'is' patterns instead of '==' for constant values|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0149](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0149.md)|Usage|Use 'is not' patterns instead of '!=' for constant values|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0150](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0150.md)|Design|Do not call ToString() when the type falls back to object.ToString()|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0151](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0151.md)|Usage|DebuggerDisplay must contain valid members|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0152](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0152.md)|Performance|Use Unwrap instead of using await twice|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0153](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0153.md)|Design|Do not log symbols decorated with DataClassificationAttribute directly|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0154](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0154.md)|Design|Use langword in XML comment|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0155](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0155.md)|Design|Do not use async void methods|<span title='Warning'>⚠️</span>|❌|❌|
-|[MA0156](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0156.md)|Design|Use 'Async' suffix when a method returns IAsyncEnumerable\<T\>|<span title='Warning'>⚠️</span>|❌|✔️|
-|[MA0157](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0157.md)|Design|Do not use 'Async' suffix when a method returns IAsyncEnumerable\<T\>|<span title='Warning'>⚠️</span>|❌|✔️|
+|[MA0156](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0156.md)|Design|IAsyncEnumerable-returning method name should end with 'Async'|<span title='Warning'>⚠️</span>|❌|✔️|
+|[MA0157](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0157.md)|Design|IAsyncEnumerable-returning method name should not end with 'Async'|<span title='Warning'>⚠️</span>|❌|✔️|
 |[MA0158](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0158.md)|Performance|Use System.Threading.Lock|<span title='Warning'>⚠️</span>|✔️|✔️|
 |[MA0159](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0159.md)|Performance|Use 'Order' instead of 'OrderBy'|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0160](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0160.md)|Performance|Use ContainsKey instead of TryGetValue|<span title='Info'>ℹ️</span>|✔️|✔️|
@@ -169,7 +169,7 @@
 |[MA0168](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0168.md)|Performance|Use readonly struct for in or ref readonly parameter|<span title='Info'>ℹ️</span>|❌|❌|
 |[MA0169](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0169.md)|Design|Use Equals method instead of operator|<span title='Warning'>⚠️</span>|✔️|✔️|
 |[MA0170](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0170.md)|Design|Type cannot be used as an attribute argument|<span title='Warning'>⚠️</span>|❌|❌|
-|[MA0171](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0171.md)|Usage|Use pattern matching instead of HasValue for Nullable\<T\> check|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0171](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0171.md)|Usage|Use 'is null' / 'is not null' instead of Nullable\<T\>.HasValue|<span title='Info'>ℹ️</span>|❌|✔️|
 |[MA0172](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0172.md)|Usage|Both sides of the logical operation are identical|<span title='Warning'>⚠️</span>|❌|❌|
 |[MA0173](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0173.md)|Design|Use LazyInitializer.EnsureInitialize|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0174](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0174.md)|Style|Record should use explicit 'class' keyword|<span title='Info'>ℹ️</span>|❌|✔️|
@@ -304,7 +304,7 @@ dotnet_diagnostic.MA0030.severity = warning
 # MA0031: Optimize Enumerable.Count() usage
 dotnet_diagnostic.MA0031.severity = suggestion
 
-# MA0032: Use an overload with a CancellationToken argument
+# MA0032: Use the CancellationToken overload, even if one must be introduced
 dotnet_diagnostic.MA0032.severity = none
 
 # MA0033: Do not tag instance fields with ThreadStaticAttribute
@@ -325,13 +325,13 @@ dotnet_diagnostic.MA0038.severity = suggestion
 # MA0039: Do not write your own certificate validation method
 dotnet_diagnostic.MA0039.severity = error
 
-# MA0040: Forward the CancellationToken parameter to methods that take one
+# MA0040: Forward the available CancellationToken to called methods
 dotnet_diagnostic.MA0040.severity = suggestion
 
 # MA0041: Make property static (deprecated, use CA1822 instead)
 dotnet_diagnostic.MA0041.severity = suggestion
 
-# MA0042: Do not use blocking calls in an async method
+# MA0042: Use await instead of blocking in async-compatible methods
 dotnet_diagnostic.MA0042.severity = suggestion
 
 # MA0043: Use nameof operator in ArgumentException
@@ -340,7 +340,7 @@ dotnet_diagnostic.MA0043.severity = suggestion
 # MA0044: Remove useless ToString call
 dotnet_diagnostic.MA0044.severity = suggestion
 
-# MA0045: Do not use blocking calls in a sync method (need to make calling method async)
+# MA0045: Do not use blocking calls when the calling method must become async
 dotnet_diagnostic.MA0045.severity = none
 
 # MA0046: Use EventHandler<T> to declare events
@@ -526,7 +526,7 @@ dotnet_diagnostic.MA0105.severity = suggestion
 # MA0106: Avoid closure by using an overload with the 'factoryArgument' parameter
 dotnet_diagnostic.MA0106.severity = suggestion
 
-# MA0107: Do not use object.ToString
+# MA0107: Do not call object.ToString() on values typed as object
 dotnet_diagnostic.MA0107.severity = none
 
 # MA0108: Remove redundant argument value
@@ -577,7 +577,7 @@ dotnet_diagnostic.MA0122.severity = suggestion
 # MA0123: Sequence number must be a constant
 dotnet_diagnostic.MA0123.severity = warning
 
-# MA0124: Log parameter type is not valid
+# MA0124: Microsoft.Extensions.Logging parameter type is not valid
 dotnet_diagnostic.MA0124.severity = warning
 
 # MA0125: The list of log parameter types contains an invalid type
@@ -616,22 +616,22 @@ dotnet_diagnostic.MA0135.severity = none
 # MA0136: Raw String contains an implicit end of line character
 dotnet_diagnostic.MA0136.severity = silent
 
-# MA0137: Use 'Async' suffix when a method returns an awaitable type
+# MA0137: Awaitable-returning method name should end with 'Async'
 dotnet_diagnostic.MA0137.severity = none
 
-# MA0138: Do not use 'Async' suffix when a method does not return an awaitable type
+# MA0138: Non-awaitable method name should not end with 'Async'
 dotnet_diagnostic.MA0138.severity = none
 
-# MA0139: Log parameter type is not valid
+# MA0139: Serilog parameter type is not valid
 dotnet_diagnostic.MA0139.severity = warning
 
 # MA0140: Both if and else branch have identical code
 dotnet_diagnostic.MA0140.severity = warning
 
-# MA0141: Use pattern matching instead of inequality operators for null check
+# MA0141: Use 'is not null' instead of '!= null'
 dotnet_diagnostic.MA0141.severity = none
 
-# MA0142: Use pattern matching instead of equality operators for null check
+# MA0142: Use 'is null' instead of '== null'
 dotnet_diagnostic.MA0142.severity = none
 
 # MA0143: Primary constructor parameters should be readonly
@@ -649,13 +649,13 @@ dotnet_diagnostic.MA0146.severity = warning
 # MA0147: Avoid async void method for delegate
 dotnet_diagnostic.MA0147.severity = warning
 
-# MA0148: Use pattern matching instead of equality operators for discrete value
+# MA0148: Use 'is' patterns instead of '==' for constant values
 dotnet_diagnostic.MA0148.severity = none
 
-# MA0149: Use pattern matching instead of inequality operators for discrete value
+# MA0149: Use 'is not' patterns instead of '!=' for constant values
 dotnet_diagnostic.MA0149.severity = none
 
-# MA0150: Do not call the default object.ToString explicitly
+# MA0150: Do not call ToString() when the type falls back to object.ToString()
 dotnet_diagnostic.MA0150.severity = warning
 
 # MA0151: DebuggerDisplay must contain valid members
@@ -673,10 +673,10 @@ dotnet_diagnostic.MA0154.severity = suggestion
 # MA0155: Do not use async void methods
 dotnet_diagnostic.MA0155.severity = none
 
-# MA0156: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
+# MA0156: IAsyncEnumerable-returning method name should end with 'Async'
 dotnet_diagnostic.MA0156.severity = none
 
-# MA0157: Do not use 'Async' suffix when a method returns IAsyncEnumerable<T>
+# MA0157: IAsyncEnumerable-returning method name should not end with 'Async'
 dotnet_diagnostic.MA0157.severity = none
 
 # MA0158: Use System.Threading.Lock
@@ -715,7 +715,7 @@ dotnet_diagnostic.MA0169.severity = warning
 # MA0170: Type cannot be used as an attribute argument
 dotnet_diagnostic.MA0170.severity = none
 
-# MA0171: Use pattern matching instead of HasValue for Nullable<T> check
+# MA0171: Use 'is null' / 'is not null' instead of Nullable<T>.HasValue
 dotnet_diagnostic.MA0171.severity = none
 
 # MA0172: Both sides of the logical operation are identical
@@ -881,7 +881,7 @@ dotnet_diagnostic.MA0030.severity = none
 # MA0031: Optimize Enumerable.Count() usage
 dotnet_diagnostic.MA0031.severity = none
 
-# MA0032: Use an overload with a CancellationToken argument
+# MA0032: Use the CancellationToken overload, even if one must be introduced
 dotnet_diagnostic.MA0032.severity = none
 
 # MA0033: Do not tag instance fields with ThreadStaticAttribute
@@ -902,13 +902,13 @@ dotnet_diagnostic.MA0038.severity = none
 # MA0039: Do not write your own certificate validation method
 dotnet_diagnostic.MA0039.severity = none
 
-# MA0040: Forward the CancellationToken parameter to methods that take one
+# MA0040: Forward the available CancellationToken to called methods
 dotnet_diagnostic.MA0040.severity = none
 
 # MA0041: Make property static (deprecated, use CA1822 instead)
 dotnet_diagnostic.MA0041.severity = none
 
-# MA0042: Do not use blocking calls in an async method
+# MA0042: Use await instead of blocking in async-compatible methods
 dotnet_diagnostic.MA0042.severity = none
 
 # MA0043: Use nameof operator in ArgumentException
@@ -917,7 +917,7 @@ dotnet_diagnostic.MA0043.severity = none
 # MA0044: Remove useless ToString call
 dotnet_diagnostic.MA0044.severity = none
 
-# MA0045: Do not use blocking calls in a sync method (need to make calling method async)
+# MA0045: Do not use blocking calls when the calling method must become async
 dotnet_diagnostic.MA0045.severity = none
 
 # MA0046: Use EventHandler<T> to declare events
@@ -1103,7 +1103,7 @@ dotnet_diagnostic.MA0105.severity = none
 # MA0106: Avoid closure by using an overload with the 'factoryArgument' parameter
 dotnet_diagnostic.MA0106.severity = none
 
-# MA0107: Do not use object.ToString
+# MA0107: Do not call object.ToString() on values typed as object
 dotnet_diagnostic.MA0107.severity = none
 
 # MA0108: Remove redundant argument value
@@ -1154,7 +1154,7 @@ dotnet_diagnostic.MA0122.severity = none
 # MA0123: Sequence number must be a constant
 dotnet_diagnostic.MA0123.severity = none
 
-# MA0124: Log parameter type is not valid
+# MA0124: Microsoft.Extensions.Logging parameter type is not valid
 dotnet_diagnostic.MA0124.severity = none
 
 # MA0125: The list of log parameter types contains an invalid type
@@ -1193,22 +1193,22 @@ dotnet_diagnostic.MA0135.severity = none
 # MA0136: Raw String contains an implicit end of line character
 dotnet_diagnostic.MA0136.severity = none
 
-# MA0137: Use 'Async' suffix when a method returns an awaitable type
+# MA0137: Awaitable-returning method name should end with 'Async'
 dotnet_diagnostic.MA0137.severity = none
 
-# MA0138: Do not use 'Async' suffix when a method does not return an awaitable type
+# MA0138: Non-awaitable method name should not end with 'Async'
 dotnet_diagnostic.MA0138.severity = none
 
-# MA0139: Log parameter type is not valid
+# MA0139: Serilog parameter type is not valid
 dotnet_diagnostic.MA0139.severity = none
 
 # MA0140: Both if and else branch have identical code
 dotnet_diagnostic.MA0140.severity = none
 
-# MA0141: Use pattern matching instead of inequality operators for null check
+# MA0141: Use 'is not null' instead of '!= null'
 dotnet_diagnostic.MA0141.severity = none
 
-# MA0142: Use pattern matching instead of equality operators for null check
+# MA0142: Use 'is null' instead of '== null'
 dotnet_diagnostic.MA0142.severity = none
 
 # MA0143: Primary constructor parameters should be readonly
@@ -1226,13 +1226,13 @@ dotnet_diagnostic.MA0146.severity = none
 # MA0147: Avoid async void method for delegate
 dotnet_diagnostic.MA0147.severity = none
 
-# MA0148: Use pattern matching instead of equality operators for discrete value
+# MA0148: Use 'is' patterns instead of '==' for constant values
 dotnet_diagnostic.MA0148.severity = none
 
-# MA0149: Use pattern matching instead of inequality operators for discrete value
+# MA0149: Use 'is not' patterns instead of '!=' for constant values
 dotnet_diagnostic.MA0149.severity = none
 
-# MA0150: Do not call the default object.ToString explicitly
+# MA0150: Do not call ToString() when the type falls back to object.ToString()
 dotnet_diagnostic.MA0150.severity = none
 
 # MA0151: DebuggerDisplay must contain valid members
@@ -1250,10 +1250,10 @@ dotnet_diagnostic.MA0154.severity = none
 # MA0155: Do not use async void methods
 dotnet_diagnostic.MA0155.severity = none
 
-# MA0156: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
+# MA0156: IAsyncEnumerable-returning method name should end with 'Async'
 dotnet_diagnostic.MA0156.severity = none
 
-# MA0157: Do not use 'Async' suffix when a method returns IAsyncEnumerable<T>
+# MA0157: IAsyncEnumerable-returning method name should not end with 'Async'
 dotnet_diagnostic.MA0157.severity = none
 
 # MA0158: Use System.Threading.Lock
@@ -1292,7 +1292,7 @@ dotnet_diagnostic.MA0169.severity = none
 # MA0170: Type cannot be used as an attribute argument
 dotnet_diagnostic.MA0170.severity = none
 
-# MA0171: Use pattern matching instead of HasValue for Nullable<T> check
+# MA0171: Use 'is null' / 'is not null' instead of Nullable<T>.HasValue
 dotnet_diagnostic.MA0171.severity = none
 
 # MA0172: Both sides of the logical operation are identical

--- a/docs/Rules/MA0032.md
+++ b/docs/Rules/MA0032.md
@@ -1,4 +1,4 @@
-# MA0032 - Use an overload with a CancellationToken argument
+# MA0032 - Use the CancellationToken overload, even if one must be introduced
 <!-- sources -->
 Source: [UseAnOverloadThatHasCancellationTokenAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0040.md
+++ b/docs/Rules/MA0040.md
@@ -1,4 +1,4 @@
-# MA0040 - Forward the CancellationToken parameter to methods that take one
+# MA0040 - Forward the available CancellationToken to called methods
 <!-- sources -->
 Sources: [UseAnOverloadThatHasCancellationTokenAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs), [UseAnOverloadThatHasCancellationTokenFixer_Argument.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs)
 <!-- sources -->

--- a/docs/Rules/MA0042.md
+++ b/docs/Rules/MA0042.md
@@ -1,4 +1,4 @@
-# MA0042 - Do not use blocking calls in an async method
+# MA0042 - Use await instead of blocking in async-compatible methods
 <!-- sources -->
 Sources: [DoNotUseBlockingCallInAsyncContextAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs), [DoNotUseBlockingCallInAsyncContextFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseBlockingCallInAsyncContextFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0045.md
+++ b/docs/Rules/MA0045.md
@@ -1,4 +1,4 @@
-# MA0045 - Do not use blocking calls in a sync method (need to make calling method async)
+# MA0045 - Do not use blocking calls when the calling method must become async
 <!-- sources -->
 Sources: [DoNotUseBlockingCallInAsyncContextAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs), [DoNotUseBlockingCallInAsyncContextFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseBlockingCallInAsyncContextFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0107.md
+++ b/docs/Rules/MA0107.md
@@ -1,4 +1,4 @@
-# MA0107 - Do not use object.ToString
+# MA0107 - Do not call object.ToString() on values typed as object
 <!-- sources -->
 Source: [DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0124.md
+++ b/docs/Rules/MA0124.md
@@ -1,4 +1,4 @@
-# MA0124 - Log parameter type is not valid
+# MA0124 - Microsoft.Extensions.Logging parameter type is not valid
 <!-- sources -->
 Source: [LoggerParameterTypeAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0137.md
+++ b/docs/Rules/MA0137.md
@@ -1,4 +1,4 @@
-# MA0137 - Use 'Async' suffix when a method returns an awaitable type
+# MA0137 - Awaitable-returning method name should end with 'Async'
 <!-- sources -->
 Sources: [MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs), [MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0138.md
+++ b/docs/Rules/MA0138.md
@@ -1,4 +1,4 @@
-# MA0138 - Do not use 'Async' suffix when a method does not return an awaitable type
+# MA0138 - Non-awaitable method name should not end with 'Async'
 <!-- sources -->
 Sources: [MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs), [MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0139.md
+++ b/docs/Rules/MA0139.md
@@ -1,4 +1,4 @@
-# MA0139 - Log parameter type is not valid
+# MA0139 - Serilog parameter type is not valid
 <!-- sources -->
 Source: [LoggerParameterTypeAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0141.md
+++ b/docs/Rules/MA0141.md
@@ -1,4 +1,4 @@
-# MA0141 - Use pattern matching instead of inequality operators for null check
+# MA0141 - Use 'is not null' instead of '!= null'
 <!-- sources -->
 Sources: [UsePatternMatchingForEqualityComparisonsAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs), [UsePatternMatchingForEqualityComparisonsFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0142.md
+++ b/docs/Rules/MA0142.md
@@ -1,4 +1,4 @@
-# MA0142 - Use pattern matching instead of equality operators for null check
+# MA0142 - Use 'is null' instead of '== null'
 <!-- sources -->
 Sources: [UsePatternMatchingForEqualityComparisonsAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs), [UsePatternMatchingForEqualityComparisonsFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0148.md
+++ b/docs/Rules/MA0148.md
@@ -1,4 +1,4 @@
-# MA0148 - Use pattern matching instead of equality operators for discrete value
+# MA0148 - Use 'is' patterns instead of '==' for constant values
 <!-- sources -->
 Sources: [UsePatternMatchingForEqualityComparisonsAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs), [UsePatternMatchingForEqualityComparisonsFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0149.md
+++ b/docs/Rules/MA0149.md
@@ -1,4 +1,4 @@
-# MA0149 - Use pattern matching instead of inequality operators for discrete value
+# MA0149 - Use 'is not' patterns instead of '!=' for constant values
 <!-- sources -->
 Sources: [UsePatternMatchingForEqualityComparisonsAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs), [UsePatternMatchingForEqualityComparisonsFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0150.md
+++ b/docs/Rules/MA0150.md
@@ -1,4 +1,4 @@
-# MA0150 - Do not call the default object.ToString explicitly
+# MA0150 - Do not call ToString() when the type falls back to object.ToString()
 <!-- sources -->
 Source: [DoNotUseToStringIfObjectAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0156.md
+++ b/docs/Rules/MA0156.md
@@ -1,4 +1,4 @@
-# MA0156 - Use 'Async' suffix when a method returns IAsyncEnumerable\<T\>
+# MA0156 - IAsyncEnumerable-returning method name should end with 'Async'
 <!-- sources -->
 Sources: [MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs), [MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0157.md
+++ b/docs/Rules/MA0157.md
@@ -1,4 +1,4 @@
-# MA0157 - Do not use 'Async' suffix when a method returns IAsyncEnumerable\<T\>
+# MA0157 - IAsyncEnumerable-returning method name should not end with 'Async'
 <!-- sources -->
 Sources: [MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs), [MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs)
 <!-- sources -->

--- a/docs/Rules/MA0171.md
+++ b/docs/Rules/MA0171.md
@@ -1,4 +1,4 @@
-# MA0171 - Use pattern matching instead of HasValue for Nullable\<T\> check
+# MA0171 - Use 'is null' / 'is not null' instead of Nullable\<T\>.HasValue
 <!-- sources -->
 Sources: [UsePatternMatchingInsteadOfHasValueAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UsePatternMatchingInsteadOfHasValueAnalyzer.cs), [UsePatternMatchingInsteadOfHasvalueFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingInsteadOfHasvalueFixer.cs)
 <!-- sources -->

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -95,7 +95,7 @@ dotnet_diagnostic.MA0030.severity = warning
 # MA0031: Optimize Enumerable.Count() usage
 dotnet_diagnostic.MA0031.severity = suggestion
 
-# MA0032: Use an overload with a CancellationToken argument
+# MA0032: Use the CancellationToken overload, even if one must be introduced
 dotnet_diagnostic.MA0032.severity = none
 
 # MA0033: Do not tag instance fields with ThreadStaticAttribute
@@ -116,13 +116,13 @@ dotnet_diagnostic.MA0038.severity = suggestion
 # MA0039: Do not write your own certificate validation method
 dotnet_diagnostic.MA0039.severity = error
 
-# MA0040: Forward the CancellationToken parameter to methods that take one
+# MA0040: Forward the available CancellationToken to called methods
 dotnet_diagnostic.MA0040.severity = suggestion
 
 # MA0041: Make property static (deprecated, use CA1822 instead)
 dotnet_diagnostic.MA0041.severity = suggestion
 
-# MA0042: Do not use blocking calls in an async method
+# MA0042: Use await instead of blocking in async-compatible methods
 dotnet_diagnostic.MA0042.severity = suggestion
 
 # MA0043: Use nameof operator in ArgumentException
@@ -131,7 +131,7 @@ dotnet_diagnostic.MA0043.severity = suggestion
 # MA0044: Remove useless ToString call
 dotnet_diagnostic.MA0044.severity = suggestion
 
-# MA0045: Do not use blocking calls in a sync method (need to make calling method async)
+# MA0045: Do not use blocking calls when the calling method must become async
 dotnet_diagnostic.MA0045.severity = none
 
 # MA0046: Use EventHandler<T> to declare events
@@ -317,7 +317,7 @@ dotnet_diagnostic.MA0105.severity = suggestion
 # MA0106: Avoid closure by using an overload with the 'factoryArgument' parameter
 dotnet_diagnostic.MA0106.severity = suggestion
 
-# MA0107: Do not use object.ToString
+# MA0107: Do not call object.ToString() on values typed as object
 dotnet_diagnostic.MA0107.severity = none
 
 # MA0108: Remove redundant argument value
@@ -368,7 +368,7 @@ dotnet_diagnostic.MA0122.severity = suggestion
 # MA0123: Sequence number must be a constant
 dotnet_diagnostic.MA0123.severity = warning
 
-# MA0124: Log parameter type is not valid
+# MA0124: Microsoft.Extensions.Logging parameter type is not valid
 dotnet_diagnostic.MA0124.severity = warning
 
 # MA0125: The list of log parameter types contains an invalid type
@@ -407,22 +407,22 @@ dotnet_diagnostic.MA0135.severity = none
 # MA0136: Raw String contains an implicit end of line character
 dotnet_diagnostic.MA0136.severity = silent
 
-# MA0137: Use 'Async' suffix when a method returns an awaitable type
+# MA0137: Awaitable-returning method name should end with 'Async'
 dotnet_diagnostic.MA0137.severity = none
 
-# MA0138: Do not use 'Async' suffix when a method does not return an awaitable type
+# MA0138: Non-awaitable method name should not end with 'Async'
 dotnet_diagnostic.MA0138.severity = none
 
-# MA0139: Log parameter type is not valid
+# MA0139: Serilog parameter type is not valid
 dotnet_diagnostic.MA0139.severity = warning
 
 # MA0140: Both if and else branch have identical code
 dotnet_diagnostic.MA0140.severity = warning
 
-# MA0141: Use pattern matching instead of inequality operators for null check
+# MA0141: Use 'is not null' instead of '!= null'
 dotnet_diagnostic.MA0141.severity = none
 
-# MA0142: Use pattern matching instead of equality operators for null check
+# MA0142: Use 'is null' instead of '== null'
 dotnet_diagnostic.MA0142.severity = none
 
 # MA0143: Primary constructor parameters should be readonly
@@ -440,13 +440,13 @@ dotnet_diagnostic.MA0146.severity = warning
 # MA0147: Avoid async void method for delegate
 dotnet_diagnostic.MA0147.severity = warning
 
-# MA0148: Use pattern matching instead of equality operators for discrete value
+# MA0148: Use 'is' patterns instead of '==' for constant values
 dotnet_diagnostic.MA0148.severity = none
 
-# MA0149: Use pattern matching instead of inequality operators for discrete value
+# MA0149: Use 'is not' patterns instead of '!=' for constant values
 dotnet_diagnostic.MA0149.severity = none
 
-# MA0150: Do not call the default object.ToString explicitly
+# MA0150: Do not call ToString() when the type falls back to object.ToString()
 dotnet_diagnostic.MA0150.severity = warning
 
 # MA0151: DebuggerDisplay must contain valid members
@@ -464,10 +464,10 @@ dotnet_diagnostic.MA0154.severity = suggestion
 # MA0155: Do not use async void methods
 dotnet_diagnostic.MA0155.severity = none
 
-# MA0156: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
+# MA0156: IAsyncEnumerable-returning method name should end with 'Async'
 dotnet_diagnostic.MA0156.severity = none
 
-# MA0157: Do not use 'Async' suffix when a method returns IAsyncEnumerable<T>
+# MA0157: IAsyncEnumerable-returning method name should not end with 'Async'
 dotnet_diagnostic.MA0157.severity = none
 
 # MA0158: Use System.Threading.Lock
@@ -506,7 +506,7 @@ dotnet_diagnostic.MA0169.severity = warning
 # MA0170: Type cannot be used as an attribute argument
 dotnet_diagnostic.MA0170.severity = none
 
-# MA0171: Use pattern matching instead of HasValue for Nullable<T> check
+# MA0171: Use 'is null' / 'is not null' instead of Nullable<T>.HasValue
 dotnet_diagnostic.MA0171.severity = none
 
 # MA0172: Both sides of the logical operation are identical

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -95,7 +95,7 @@ dotnet_diagnostic.MA0030.severity = none
 # MA0031: Optimize Enumerable.Count() usage
 dotnet_diagnostic.MA0031.severity = none
 
-# MA0032: Use an overload with a CancellationToken argument
+# MA0032: Use the CancellationToken overload, even if one must be introduced
 dotnet_diagnostic.MA0032.severity = none
 
 # MA0033: Do not tag instance fields with ThreadStaticAttribute
@@ -116,13 +116,13 @@ dotnet_diagnostic.MA0038.severity = none
 # MA0039: Do not write your own certificate validation method
 dotnet_diagnostic.MA0039.severity = none
 
-# MA0040: Forward the CancellationToken parameter to methods that take one
+# MA0040: Forward the available CancellationToken to called methods
 dotnet_diagnostic.MA0040.severity = none
 
 # MA0041: Make property static (deprecated, use CA1822 instead)
 dotnet_diagnostic.MA0041.severity = none
 
-# MA0042: Do not use blocking calls in an async method
+# MA0042: Use await instead of blocking in async-compatible methods
 dotnet_diagnostic.MA0042.severity = none
 
 # MA0043: Use nameof operator in ArgumentException
@@ -131,7 +131,7 @@ dotnet_diagnostic.MA0043.severity = none
 # MA0044: Remove useless ToString call
 dotnet_diagnostic.MA0044.severity = none
 
-# MA0045: Do not use blocking calls in a sync method (need to make calling method async)
+# MA0045: Do not use blocking calls when the calling method must become async
 dotnet_diagnostic.MA0045.severity = none
 
 # MA0046: Use EventHandler<T> to declare events
@@ -317,7 +317,7 @@ dotnet_diagnostic.MA0105.severity = none
 # MA0106: Avoid closure by using an overload with the 'factoryArgument' parameter
 dotnet_diagnostic.MA0106.severity = none
 
-# MA0107: Do not use object.ToString
+# MA0107: Do not call object.ToString() on values typed as object
 dotnet_diagnostic.MA0107.severity = none
 
 # MA0108: Remove redundant argument value
@@ -368,7 +368,7 @@ dotnet_diagnostic.MA0122.severity = none
 # MA0123: Sequence number must be a constant
 dotnet_diagnostic.MA0123.severity = none
 
-# MA0124: Log parameter type is not valid
+# MA0124: Microsoft.Extensions.Logging parameter type is not valid
 dotnet_diagnostic.MA0124.severity = none
 
 # MA0125: The list of log parameter types contains an invalid type
@@ -407,22 +407,22 @@ dotnet_diagnostic.MA0135.severity = none
 # MA0136: Raw String contains an implicit end of line character
 dotnet_diagnostic.MA0136.severity = none
 
-# MA0137: Use 'Async' suffix when a method returns an awaitable type
+# MA0137: Awaitable-returning method name should end with 'Async'
 dotnet_diagnostic.MA0137.severity = none
 
-# MA0138: Do not use 'Async' suffix when a method does not return an awaitable type
+# MA0138: Non-awaitable method name should not end with 'Async'
 dotnet_diagnostic.MA0138.severity = none
 
-# MA0139: Log parameter type is not valid
+# MA0139: Serilog parameter type is not valid
 dotnet_diagnostic.MA0139.severity = none
 
 # MA0140: Both if and else branch have identical code
 dotnet_diagnostic.MA0140.severity = none
 
-# MA0141: Use pattern matching instead of inequality operators for null check
+# MA0141: Use 'is not null' instead of '!= null'
 dotnet_diagnostic.MA0141.severity = none
 
-# MA0142: Use pattern matching instead of equality operators for null check
+# MA0142: Use 'is null' instead of '== null'
 dotnet_diagnostic.MA0142.severity = none
 
 # MA0143: Primary constructor parameters should be readonly
@@ -440,13 +440,13 @@ dotnet_diagnostic.MA0146.severity = none
 # MA0147: Avoid async void method for delegate
 dotnet_diagnostic.MA0147.severity = none
 
-# MA0148: Use pattern matching instead of equality operators for discrete value
+# MA0148: Use 'is' patterns instead of '==' for constant values
 dotnet_diagnostic.MA0148.severity = none
 
-# MA0149: Use pattern matching instead of inequality operators for discrete value
+# MA0149: Use 'is not' patterns instead of '!=' for constant values
 dotnet_diagnostic.MA0149.severity = none
 
-# MA0150: Do not call the default object.ToString explicitly
+# MA0150: Do not call ToString() when the type falls back to object.ToString()
 dotnet_diagnostic.MA0150.severity = none
 
 # MA0151: DebuggerDisplay must contain valid members
@@ -464,10 +464,10 @@ dotnet_diagnostic.MA0154.severity = none
 # MA0155: Do not use async void methods
 dotnet_diagnostic.MA0155.severity = none
 
-# MA0156: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
+# MA0156: IAsyncEnumerable-returning method name should end with 'Async'
 dotnet_diagnostic.MA0156.severity = none
 
-# MA0157: Do not use 'Async' suffix when a method returns IAsyncEnumerable<T>
+# MA0157: IAsyncEnumerable-returning method name should not end with 'Async'
 dotnet_diagnostic.MA0157.severity = none
 
 # MA0158: Use System.Threading.Lock
@@ -506,7 +506,7 @@ dotnet_diagnostic.MA0169.severity = none
 # MA0170: Type cannot be used as an attribute argument
 dotnet_diagnostic.MA0170.severity = none
 
-# MA0171: Use pattern matching instead of HasValue for Nullable<T> check
+# MA0171: Use 'is null' / 'is not null' instead of Nullable<T>.HasValue
 dotnet_diagnostic.MA0171.severity = none
 
 # MA0172: Both sides of the logical operation are identical

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -12,7 +12,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
 {
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.DoNotUseBlockingCallInAsyncContext,
-        title: "Do not use blocking calls in an async method",
+        title: "Use await instead of blocking in async-compatible methods",
         messageFormat: "{0}",
         RuleCategories.Design,
         DiagnosticSeverity.Info,
@@ -22,7 +22,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
 
     private static readonly DiagnosticDescriptor Rule2 = new(
         RuleIdentifiers.DoNotUseBlockingCall,
-        title: "Do not use blocking calls in a sync method (need to make calling method async)",
+        title: "Do not use blocking calls when the calling method must become async",
         messageFormat: "{0}",
         RuleCategories.Design,
         DiagnosticSeverity.Info,

--- a/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
@@ -33,7 +33,7 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
 
     private static readonly DiagnosticDescriptor ObjectToStringRule = new(
         RuleIdentifiers.DoNotUseCultureSensitiveObjectToString,
-        title: "Do not use object.ToString",
+        title: "Do not call object.ToString() on values typed as object",
         messageFormat: "Do not use object.ToString",
         RuleCategories.Design,
         DiagnosticSeverity.Info,

--- a/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
@@ -12,7 +12,7 @@ public sealed class DoNotUseToStringIfObjectAnalyzer : DiagnosticAnalyzer
 {
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.DoNotUseToStringIfObject,
-        title: "Do not call the default object.ToString explicitly",
+        title: "Do not call ToString() when the type falls back to object.ToString()",
         messageFormat: "ToString on '{0}' will use the default object.ToString",
         RuleCategories.Design,
         DiagnosticSeverity.Warning,

--- a/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
@@ -15,7 +15,7 @@ public sealed class LoggerParameterTypeAnalyzer : DiagnosticAnalyzer
 {
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.LoggerParameterType,
-        title: "Log parameter type is not valid",
+        title: "Microsoft.Extensions.Logging parameter type is not valid",
         messageFormat: "Log parameter '{0}' {1}",
         RuleCategories.Design,
         DiagnosticSeverity.Warning,
@@ -25,7 +25,7 @@ public sealed class LoggerParameterTypeAnalyzer : DiagnosticAnalyzer
 
     private static readonly DiagnosticDescriptor RuleSerilog = new(
         RuleIdentifiers.LoggerParameterType_Serilog,
-        title: "Log parameter type is not valid",
+        title: "Serilog parameter type is not valid",
         messageFormat: "Log parameter '{0}' {1}",
         RuleCategories.Design,
         DiagnosticSeverity.Warning,

--- a/src/Meziantou.Analyzer/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs
@@ -12,7 +12,7 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
 {
     private static readonly DiagnosticDescriptor AsyncSuffixRule = new(
         RuleIdentifiers.MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffix,
-        title: "Use 'Async' suffix when a method returns an awaitable type",
+        title: "Awaitable-returning method name should end with 'Async'",
         messageFormat: "Method returning an awaitable type must use the 'Async' suffix",
         RuleCategories.Design,
         DiagnosticSeverity.Warning,
@@ -22,7 +22,7 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
 
     private static readonly DiagnosticDescriptor NotAsyncSuffixRule = new(
         RuleIdentifiers.MethodsNotReturningAnAwaitableTypeMustNotHaveTheAsyncSuffix,
-        title: "Do not use 'Async' suffix when a method does not return an awaitable type",
+        title: "Non-awaitable method name should not end with 'Async'",
         messageFormat: "Method not returning an awaitable type must not use the 'Async' suffix",
         RuleCategories.Design,
         DiagnosticSeverity.Warning,
@@ -32,7 +32,7 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
 
     private static readonly DiagnosticDescriptor AsyncSuffixRuleAsyncEnumerable = new(
        RuleIdentifiers.MethodsReturningIAsyncEnumerableMustHaveTheAsyncSuffix,
-       title: "Use 'Async' suffix when a method returns IAsyncEnumerable<T>",
+        title: "IAsyncEnumerable-returning method name should end with 'Async'",
        messageFormat: "Method returning IAsyncEnumerable<T> must use the 'Async' suffix",
        RuleCategories.Design,
        DiagnosticSeverity.Warning,
@@ -42,7 +42,7 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
 
     private static readonly DiagnosticDescriptor NotAsyncSuffixRuleAsyncEnumerable = new(
         RuleIdentifiers.MethodsNotReturningIAsyncEnumerableMustNotHaveTheAsyncSuffix,
-        title: "Do not use 'Async' suffix when a method returns IAsyncEnumerable<T>",
+        title: "IAsyncEnumerable-returning method name should not end with 'Async'",
         messageFormat: "Method returning IAsyncEnumerable<T> must not use the 'Async' suffix",
         RuleCategories.Design,
         DiagnosticSeverity.Warning,

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
@@ -17,7 +17,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
 {
     private static readonly DiagnosticDescriptor UseAnOverloadThatHasCancellationTokenRule = new(
         RuleIdentifiers.UseAnOverloadThatHasCancellationToken,
-        title: "Use an overload with a CancellationToken argument",
+        title: "Use the CancellationToken overload, even if one must be introduced",
         messageFormat: "Use an overload with a CancellationToken",
         RuleCategories.Usage,
         DiagnosticSeverity.Info,
@@ -27,7 +27,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
 
     private static readonly DiagnosticDescriptor UseAnOverloadThatHasCancellationTokenWhenACancellationTokenIsAvailableRule = new(
         RuleIdentifiers.UseAnOverloadThatHasCancellationTokenWhenACancellationTokenIsAvailable,
-        title: "Forward the CancellationToken parameter to methods that take one",
+        title: "Forward the available CancellationToken to called methods",
         messageFormat: "Use an overload with a CancellationToken, available tokens: {0}",
         RuleCategories.Usage,
         DiagnosticSeverity.Info,

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
@@ -11,8 +11,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzer : Diagnosti
 {
     private static readonly DiagnosticDescriptor RuleEqualNull = new(
         RuleIdentifiers.UsePatternMatchingForNullEquality,
-        title: "Use pattern matching instead of equality operators for null check",
-        messageFormat: "Use pattern matching instead of equality operators for null check",
+        title: "Use 'is null' instead of '== null'",
+        messageFormat: "Use 'is null' instead of '== null'",
         RuleCategories.Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: false,
@@ -21,8 +21,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzer : Diagnosti
 
     private static readonly DiagnosticDescriptor RuleNotEqualNull = new(
         RuleIdentifiers.UsePatternMatchingForNullCheck,
-        title: "Use pattern matching instead of inequality operators for null check",
-        messageFormat: "Use pattern matching instead of inequality operators for null check",
+        title: "Use 'is not null' instead of '!= null'",
+        messageFormat: "Use 'is not null' instead of '!= null'",
         RuleCategories.Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: false,
@@ -31,8 +31,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzer : Diagnosti
 
     private static readonly DiagnosticDescriptor RuleEqualConstant = new(
         RuleIdentifiers.UsePatternMatchingForEqualityComparison,
-        title: "Use pattern matching instead of equality operators for discrete value",
-        messageFormat: "Use pattern matching instead of equality operators for discrete value",
+        title: "Use 'is' patterns instead of '==' for constant values",
+        messageFormat: "Use 'is' patterns instead of '==' for constant values",
         RuleCategories.Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: false,
@@ -41,8 +41,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzer : Diagnosti
 
     private static readonly DiagnosticDescriptor RuleNotEqualConstant = new(
         RuleIdentifiers.UsePatternMatchingForInequalityComparison,
-        title: "Use pattern matching instead of inequality operators for discrete value",
-        messageFormat: "Use pattern matching instead of inequality operators for discrete values",
+        title: "Use 'is not' patterns instead of '!=' for constant values",
+        messageFormat: "Use 'is not' patterns instead of '!=' for constant values",
         RuleCategories.Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: false,

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingInsteadOfHasValueAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingInsteadOfHasValueAnalyzer.cs
@@ -11,8 +11,8 @@ public sealed class UsePatternMatchingInsteadOfHasValueAnalyzer : DiagnosticAnal
 {
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.UsePatternMatchingInsteadOfHasvalue,
-        title: "Use pattern matching instead of HasValue for Nullable<T> check",
-        messageFormat: "Use pattern matching instead of HasValue for Nullable<T> check",
+        title: "Use 'is null' / 'is not null' instead of Nullable<T>.HasValue",
+        messageFormat: "Use 'is null' / 'is not null' instead of Nullable<T>.HasValue",
         RuleCategories.Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: false,


### PR DESCRIPTION
## Why

Several analyzer rules had titles that were easy to confuse in the README and generated documentation, especially when two rules covered the same area with different scopes or frameworks. This makes the rule list harder to scan and can obscure the actual behavior of the analyzer.

## What changed

This updates the diagnostic titles for the ambiguous rule groups directly in the analyzer source so the wording better reflects each rule's behavior.

The main clarifications are:
- distinguish the broader vs narrower `CancellationToken` rules (`MA0032` vs `MA0040`)
- distinguish the async-compatible blocking-call rule from the rule that requires propagating `async` outward (`MA0042` vs `MA0045`)
- disambiguate the two logging-framework parameter-type rules (`MA0124` vs `MA0139`)
- make the async-suffix and pattern-matching families more explicit about the code shape they target
- separate the two `ToString()`-related rules by the actual scenario they diagnose

## Notes

The source changes were followed by regenerating the derived markdown and packaged configuration comments, so the updated wording is reflected consistently in:
- `README.md`
- `docs/README.md`
- the affected `docs/Rules/*.md` pages
- `src/Meziantou.Analyzer.Pack/configuration/*.editorconfig`

## Validation

- solution build succeeded
- focused analyzer test slice passed (`372` tests)

I used the installed `10.0.203` SDK via direct MSBuild/vstest invocation for validation because this environment does not have the `10.0.100` SDK feature band pinned by `global.json`.