### PR TITLE
MA0042: check if DisposeAsync is declared directly when runtime type is known

### DIFF
--- a/docs/Rules/MA0042.md
+++ b/docs/Rules/MA0042.md
@@ -55,13 +55,16 @@ public sealed class Sample
 
 The rule does not report a diagnostic for `IDbContextFactory<TContext>.CreateDbContext()`. The `CreateDbContextAsync()` overload was introduced only for specific edge-case scenarios where the factory itself must perform asynchronous initialization, and is not intended as a general-purpose replacement. See [dotnet/efcore#26630](https://github.com/dotnet/efcore/issues/26630) for more details.
 
-The rule will not report a diagnostic for a `using` statement on a `DbConnection` subclass that is directly instantiated with `new` when the concrete type does not override `DisposeAsync`. `DbConnection.DisposeAsync` merely calls `Dispose()` synchronously, so switching to `await using` brings no benefit for such types. When the instance is obtained from a factory method rather than a direct `new` expression, the rule still reports a diagnostic because the runtime type may be a deeper subclass that does override `DisposeAsync`.
+The rule will not report a diagnostic for a `using` statement on a `Stream` or `DbConnection` subclass that is directly instantiated with `new` when the concrete type does not override `DisposeAsync`. Both `Stream.DisposeAsync` and `DbConnection.DisposeAsync` merely call `Dispose()` synchronously by default, so switching to `await using` brings no benefit for such types. When the instance is obtained from a factory method rather than a direct `new` expression, the rule still reports a diagnostic because the runtime type may be a deeper subclass that does override `DisposeAsync`.
 
 ````csharp
 public async Task Sample()
 {
-    // No diagnostic: SqlConnection does not override DisposeAsync,
+    // No diagnostic: MemoryStream does not override DisposeAsync,
     // so using vs await using makes no difference.
+    using var ms = new MemoryStream();
+
+    // No diagnostic: SqlConnection does not override DisposeAsync.
     using var connection1 = new SqlConnection(connectionString);
 
     // Diagnostic: obtained from a factory, runtime type may override DisposeAsync.

--- a/docs/Rules/MA0042.md
+++ b/docs/Rules/MA0042.md
@@ -55,6 +55,20 @@ public sealed class Sample
 
 The rule does not report a diagnostic for `IDbContextFactory<TContext>.CreateDbContext()`. The `CreateDbContextAsync()` overload was introduced only for specific edge-case scenarios where the factory itself must perform asynchronous initialization, and is not intended as a general-purpose replacement. See [dotnet/efcore#26630](https://github.com/dotnet/efcore/issues/26630) for more details.
 
+The rule will not report a diagnostic for a `using` statement on a `DbConnection` subclass that is directly instantiated with `new` when the concrete type does not override `DisposeAsync`. `DbConnection.DisposeAsync` merely calls `Dispose()` synchronously, so switching to `await using` brings no benefit for such types. When the instance is obtained from a factory method rather than a direct `new` expression, the rule still reports a diagnostic because the runtime type may be a deeper subclass that does override `DisposeAsync`.
+
+````csharp
+public async Task Sample()
+{
+    // No diagnostic: SqlConnection does not override DisposeAsync,
+    // so using vs await using makes no difference.
+    using var connection1 = new SqlConnection(connectionString);
+
+    // Diagnostic: obtained from a factory, runtime type may override DisposeAsync.
+    using var connection2 = CreateConnection();
+}
+````
+
 ## Additional resources
 
 - [Enforcing asynchronous code good practices using a Roslyn analyzer](https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm)

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -75,7 +75,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             }
 
             ProcessSymbol = compilation.GetBestTypeByMetadataName("System.Diagnostics.Process");
-            MemoryStreamSymbol = compilation.GetBestTypeByMetadataName("System.IO.MemoryStream");
+            StreamSymbol = compilation.GetBestTypeByMetadataName("System.IO.Stream");
             DbConnectionSymbol = compilation.GetBestTypeByMetadataName("System.Data.Common.DbConnection");
             CancellationTokenSymbol = compilation.GetBestTypeByMetadataName("System.Threading.CancellationToken");
             ObsoleteAttributeSymbol = compilation.GetBestTypeByMetadataName("System.ObsoleteAttribute");
@@ -123,7 +123,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             _taskAwaiterLikeSymbols = [.. taskAwaiterLikeSymbols];
         }
 
-        private ISymbol? MemoryStreamSymbol { get; }
+        private ISymbol? StreamSymbol { get; }
         private ISymbol? ProcessSymbol { get; }
         private INamedTypeSymbol? DbConnectionSymbol { get; }
         private ISymbol[] ConsoleErrorAndOutSymbols { get; }
@@ -458,15 +458,14 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
 
         /// <summary>
         /// Checks whether any type in the hierarchy from <paramref name="symbol"/> up to (but NOT including)
-        /// <see cref="DbConnectionSymbol"/> declares or overrides a <c>DisposeAsync</c> method.
-        /// Used to detect whether a <see cref="System.Data.Common.DbConnection"/> subclass has a meaningful
-        /// (truly async) <c>DisposeAsync</c> override, as opposed to relying on
-        /// <c>DbConnection.DisposeAsync</c> which merely calls <c>Dispose()</c> synchronously.
+        /// <paramref name="baseTypeSymbol"/> declares or overrides a <c>DisposeAsync</c> method.
+        /// Used to detect whether a subclass has a meaningful (truly async) <c>DisposeAsync</c> override,
+        /// as opposed to relying on an inherited implementation that is not truly asynchronous.
         /// </summary>
-        private bool HasDisposeAsyncMethodDeclaredInDbConnectionSubclass(INamedTypeSymbol symbol)
+        private bool HasDisposeAsyncMethodDeclaredInSubclass(INamedTypeSymbol symbol, INamedTypeSymbol baseTypeSymbol)
         {
             var current = symbol;
-            while (current is not null && !current.IsEqualTo(DbConnectionSymbol))
+            while (current is not null && !current.IsEqualTo(baseTypeSymbol))
             {
                 foreach (var member in current.GetMembers("DisposeAsync").OfType<IMethodSymbol>())
                 {
@@ -496,9 +495,16 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             if (operation.GetActualType() is not INamedTypeSymbol type)
                 return false;
 
-            // using var ms = new MemoryStream();
-            if (operation is IObjectCreationOperation && type.IsEqualTo(MemoryStreamSymbol))
-                return false;
+            // For Stream subclasses (including MemoryStream) created directly (new T()), only report
+            // if the concrete type being instantiated (or an intermediate subclass up to but not
+            // including Stream) actually overrides DisposeAsync. Stream.DisposeAsync merely calls
+            // Dispose() synchronously by default, so it is not a meaningful async override.
+            if (StreamSymbol is INamedTypeSymbol streamSymbol && type.InheritsFrom(streamSymbol))
+            {
+                var unwrapped = operation.UnwrapImplicitConversionOperations();
+                if (unwrapped is IObjectCreationOperation)
+                    return HasDisposeAsyncMethodDeclaredInSubclass(type, streamSymbol);
+            }
 
             // For DbConnection subclasses created directly (new T()), only report if the exact
             // type being instantiated (or an intermediate subclass up to but not including
@@ -508,7 +514,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             {
                 var unwrapped = operation.UnwrapImplicitConversionOperations();
                 if (unwrapped is IObjectCreationOperation)
-                    return HasDisposeAsyncMethodDeclaredInDbConnectionSubclass(type);
+                    return HasDisposeAsyncMethodDeclaredInSubclass(type, DbConnectionSymbol);
             }
 
             return HasDisposeAsyncMethod(type);

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -74,7 +74,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
                 ConsoleErrorAndOutSymbols = [];
             }
 
-            MemoryStreamSymbol = compilation.GetBestTypeByMetadataName("System.IO.MemoryStream");
             ProcessSymbol = compilation.GetBestTypeByMetadataName("System.Diagnostics.Process");
             CancellationTokenSymbol = compilation.GetBestTypeByMetadataName("System.Threading.CancellationToken");
             ObsoleteAttributeSymbol = compilation.GetBestTypeByMetadataName("System.ObsoleteAttribute");
@@ -122,7 +121,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             _taskAwaiterLikeSymbols = [.. taskAwaiterLikeSymbols];
         }
 
-        private ISymbol? MemoryStreamSymbol { get; }
         private ISymbol? ProcessSymbol { get; }
         private ISymbol[] ConsoleErrorAndOutSymbols { get; }
         private INamedTypeSymbol? CancellationTokenSymbol { get; }
@@ -454,14 +452,41 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             return false;
         }
 
+        private bool HasDisposeAsyncMethodDeclaredDirectly(INamedTypeSymbol symbol)
+        {
+            // Only look at members declared directly on the type, not inherited ones.
+            foreach (var member in symbol.GetMembers("DisposeAsync").OfType<IMethodSymbol>())
+            {
+                if (member.Parameters.Length != 0)
+                    continue;
+
+                if (member.IsGenericMethod)
+                    continue;
+
+                if (member.IsStatic)
+                    continue;
+
+                if (!member.ReturnType.IsEqualTo(ValueTaskSymbol))
+                    continue;
+
+                return true;
+            }
+
+            return false;
+        }
+
         private bool CanBeAwaitUsing(IOperation operation)
         {
             if (operation.GetActualType() is not INamedTypeSymbol type)
                 return false;
 
-            // using var ms = new MemoryStream();
-            if (operation is IObjectCreationOperation objectCreationOperation && objectCreationOperation.Type.IsEqualTo(MemoryStreamSymbol))
-                return false;
+            // When the runtime type is statically known — either because the expression is a direct
+            // object creation (new T()) or because the type is sealed — only report if the type
+            // itself declares/overrides DisposeAsync. Inheriting a non-async "default" DisposeAsync
+            // (e.g. DbConnection.DisposeAsync which just calls Dispose()) is not a meaningful override.
+            var unwrapped = operation.UnwrapImplicitConversionOperations();
+            if (unwrapped is IObjectCreationOperation || type.IsSealed)
+                return HasDisposeAsyncMethodDeclaredDirectly(type);
 
             return HasDisposeAsyncMethod(type);
         }

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -75,6 +75,8 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             }
 
             ProcessSymbol = compilation.GetBestTypeByMetadataName("System.Diagnostics.Process");
+            MemoryStreamSymbol = compilation.GetBestTypeByMetadataName("System.IO.MemoryStream");
+            DbConnectionSymbol = compilation.GetBestTypeByMetadataName("System.Data.Common.DbConnection");
             CancellationTokenSymbol = compilation.GetBestTypeByMetadataName("System.Threading.CancellationToken");
             ObsoleteAttributeSymbol = compilation.GetBestTypeByMetadataName("System.ObsoleteAttribute");
 
@@ -121,7 +123,9 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             _taskAwaiterLikeSymbols = [.. taskAwaiterLikeSymbols];
         }
 
+        private ISymbol? MemoryStreamSymbol { get; }
         private ISymbol? ProcessSymbol { get; }
+        private INamedTypeSymbol? DbConnectionSymbol { get; }
         private ISymbol[] ConsoleErrorAndOutSymbols { get; }
         private INamedTypeSymbol? CancellationTokenSymbol { get; }
         private INamedTypeSymbol? ObsoleteAttributeSymbol { get; }
@@ -452,24 +456,36 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             return false;
         }
 
-        private bool HasDisposeAsyncMethodDeclaredDirectly(INamedTypeSymbol symbol)
+        /// <summary>
+        /// Checks whether any type in the hierarchy from <paramref name="symbol"/> up to (but NOT including)
+        /// <see cref="DbConnectionSymbol"/> declares or overrides a <c>DisposeAsync</c> method.
+        /// Used to detect whether a <see cref="System.Data.Common.DbConnection"/> subclass has a meaningful
+        /// (truly async) <c>DisposeAsync</c> override, as opposed to relying on
+        /// <c>DbConnection.DisposeAsync</c> which merely calls <c>Dispose()</c> synchronously.
+        /// </summary>
+        private bool HasDisposeAsyncMethodDeclaredInDbConnectionSubclass(INamedTypeSymbol symbol)
         {
-            // Only look at members declared directly on the type, not inherited ones.
-            foreach (var member in symbol.GetMembers("DisposeAsync").OfType<IMethodSymbol>())
+            var current = symbol;
+            while (current is not null && !current.IsEqualTo(DbConnectionSymbol))
             {
-                if (member.Parameters.Length != 0)
-                    continue;
+                foreach (var member in current.GetMembers("DisposeAsync").OfType<IMethodSymbol>())
+                {
+                    if (member.Parameters.Length != 0)
+                        continue;
 
-                if (member.IsGenericMethod)
-                    continue;
+                    if (member.IsGenericMethod)
+                        continue;
 
-                if (member.IsStatic)
-                    continue;
+                    if (member.IsStatic)
+                        continue;
 
-                if (!member.ReturnType.IsEqualTo(ValueTaskSymbol))
-                    continue;
+                    if (!member.ReturnType.IsEqualTo(ValueTaskSymbol))
+                        continue;
 
-                return true;
+                    return true;
+                }
+
+                current = current.BaseType;
             }
 
             return false;
@@ -480,13 +496,20 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             if (operation.GetActualType() is not INamedTypeSymbol type)
                 return false;
 
-            // When the runtime type is statically known — either because the expression is a direct
-            // object creation (new T()) or because the type is sealed — only report if the type
-            // itself declares/overrides DisposeAsync. Inheriting a non-async "default" DisposeAsync
-            // (e.g. DbConnection.DisposeAsync which just calls Dispose()) is not a meaningful override.
-            var unwrapped = operation.UnwrapImplicitConversionOperations();
-            if (unwrapped is IObjectCreationOperation || type.IsSealed)
-                return HasDisposeAsyncMethodDeclaredDirectly(type);
+            // using var ms = new MemoryStream();
+            if (operation is IObjectCreationOperation && type.IsEqualTo(MemoryStreamSymbol))
+                return false;
+
+            // For DbConnection subclasses created directly (new T()), only report if the exact
+            // type being instantiated (or an intermediate subclass up to but not including
+            // DbConnection) actually overrides DisposeAsync. DbConnection.DisposeAsync just calls
+            // Dispose() synchronously, so it is not a meaningful async override.
+            if (DbConnectionSymbol is not null && type.InheritsFrom(DbConnectionSymbol))
+            {
+                var unwrapped = operation.UnwrapImplicitConversionOperations();
+                if (unwrapped is IObjectCreationOperation)
+                    return HasDisposeAsyncMethodDeclaredInDbConnectionSubclass(type);
+            }
 
             return HasDisposeAsyncMethod(type);
         }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -2113,6 +2113,78 @@ class Sample
     }
 
     [Fact]
+    public async Task UsingFactoryMethod_StreamSubclass_NoDisposeAsyncOverride_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .WithSourceCode("""
+                using System.IO;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        [|using var s = CreateStream();|]
+                    }
+
+                    private MyStream CreateStream() => throw null;
+                }
+
+                class MyStream : Stream
+                {
+                    public override bool CanRead => throw null;
+                    public override bool CanSeek => throw null;
+                    public override bool CanWrite => throw null;
+                    public override long Length => throw null;
+                    public override long Position { get => throw null; set => throw null; }
+                    public override void Flush() => throw null;
+                    public override int Read(byte[] buffer, int offset, int count) => throw null;
+                    public override long Seek(long offset, SeekOrigin origin) => throw null;
+                    public override void SetLength(long value) => throw null;
+                    public override void Write(byte[] buffer, int offset, int count) => throw null;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task UsingNewStreamSubclass_WithDisposeAsyncOverride_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .WithSourceCode("""
+                using System.IO;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        [|using var s = new MyStream();|]
+                    }
+                }
+
+                class MyStream : Stream
+                {
+                    public override bool CanRead => throw null;
+                    public override bool CanSeek => throw null;
+                    public override bool CanWrite => throw null;
+                    public override long Length => throw null;
+                    public override long Position { get => throw null; set => throw null; }
+                    public override void Flush() => throw null;
+                    public override int Read(byte[] buffer, int offset, int count) => throw null;
+                    public override long Seek(long offset, SeekOrigin origin) => throw null;
+                    public override void SetLength(long value) => throw null;
+                    public override void Write(byte[] buffer, int offset, int count) => throw null;
+                    public override ValueTask DisposeAsync() => throw null;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+
+    [Fact]
     public async Task SemaphoreSlim_Wait_NoDiagnostic()
     {
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -2326,4 +2326,151 @@ class Sample
                 """)
             .ValidateAsync();
     }
+
+    [Fact]
+    public async Task UsingNewObjectCreation_InheritedDisposeAsync_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        using var conn = new DerivedConnection();
+                    }
+                }
+
+                class BaseConnection : IDisposable
+                {
+                    public void Dispose() { }
+                    public virtual ValueTask DisposeAsync() => default;
+                }
+
+                class DerivedConnection : BaseConnection { }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task UsingFactoryMethod_InheritedDisposeAsync_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        [|using var conn = CreateConnection();|]
+                    }
+
+                    private DerivedConnection CreateConnection() => new DerivedConnection();
+                }
+
+                class BaseConnection : IDisposable
+                {
+                    public void Dispose() { }
+                    public virtual ValueTask DisposeAsync() => default;
+                }
+
+                class DerivedConnection : BaseConnection { }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task UsingNewObjectCreation_OverridesDisposeAsync_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        [|using var conn = new DerivedConnection();|]
+                    }
+                }
+
+                class BaseConnection : IDisposable
+                {
+                    public void Dispose() { }
+                    public virtual ValueTask DisposeAsync() => default;
+                }
+
+                class DerivedConnection : BaseConnection
+                {
+                    public override ValueTask DisposeAsync() => throw null;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task UsingFactoryMethod_SealedType_InheritedDisposeAsync_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        using var conn = CreateConnection();
+                    }
+
+                    private SealedConnection CreateConnection() => new SealedConnection();
+                }
+
+                class BaseConnection : IDisposable
+                {
+                    public void Dispose() { }
+                    public virtual ValueTask DisposeAsync() => default;
+                }
+
+                sealed class SealedConnection : BaseConnection { }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task UsingFactoryMethod_SealedType_OverridesDisposeAsync_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        [|using var conn = CreateConnection();|]
+                    }
+
+                    private SealedConnection CreateConnection() => new SealedConnection();
+                }
+
+                class BaseConnection : IDisposable
+                {
+                    public void Dispose() { }
+                    public virtual ValueTask DisposeAsync() => default;
+                }
+
+                sealed class SealedConnection : BaseConnection
+                {
+                    public override ValueTask DisposeAsync() => throw null;
+                }
+                """)
+              .ValidateAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -2328,38 +2328,48 @@ class Sample
     }
 
     [Fact]
-    public async Task UsingNewObjectCreation_InheritedDisposeAsync_NoDiagnostic()
+    public async Task UsingNewDbConnectionSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
               .WithSourceCode("""
-                using System;
+                using System.Data;
+                using System.Data.Common;
                 using System.Threading.Tasks;
 
                 class Test
                 {
                     public async Task A()
                     {
-                        using var conn = new DerivedConnection();
+                        using var conn = new MySqlConnection();
                     }
                 }
 
-                class BaseConnection : IDisposable
+                class MySqlConnection : DbConnection
                 {
-                    public void Dispose() { }
-                    public virtual ValueTask DisposeAsync() => default;
+                    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw null;
+                    protected override DbCommand CreateDbCommand() => throw null;
+                    public override void ChangeDatabase(string databaseName) => throw null;
+                    public override void Close() => throw null;
+                    public override void Open() => throw null;
+                    public override string ConnectionString { get => throw null; set => throw null; }
+                    public override string Database => throw null;
+                    public override string DataSource => throw null;
+                    public override string ServerVersion => throw null;
+                    public override ConnectionState State => throw null;
                 }
-
-                class DerivedConnection : BaseConnection { }
                 """)
               .ValidateAsync();
     }
 
     [Fact]
-    public async Task UsingFactoryMethod_InheritedDisposeAsync_Diagnostic()
+    public async Task UsingFactoryMethod_DbConnectionSubclass_NoDisposeAsyncOverride_Diagnostic()
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
               .WithSourceCode("""
-                using System;
+                using System.Data;
+                using System.Data.Common;
                 using System.Threading.Tasks;
 
                 class Test
@@ -2369,26 +2379,70 @@ class Sample
                         [|using var conn = CreateConnection();|]
                     }
 
-                    private DerivedConnection CreateConnection() => new DerivedConnection();
+                    private MySqlConnection CreateConnection() => throw null;
                 }
 
-                class BaseConnection : IDisposable
+                class MySqlConnection : DbConnection
                 {
-                    public void Dispose() { }
-                    public virtual ValueTask DisposeAsync() => default;
+                    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw null;
+                    protected override DbCommand CreateDbCommand() => throw null;
+                    public override void ChangeDatabase(string databaseName) => throw null;
+                    public override void Close() => throw null;
+                    public override void Open() => throw null;
+                    public override string ConnectionString { get => throw null; set => throw null; }
+                    public override string Database => throw null;
+                    public override string DataSource => throw null;
+                    public override string ServerVersion => throw null;
+                    public override ConnectionState State => throw null;
                 }
-
-                class DerivedConnection : BaseConnection { }
                 """)
               .ValidateAsync();
     }
 
     [Fact]
-    public async Task UsingNewObjectCreation_OverridesDisposeAsync_Diagnostic()
+    public async Task UsingNewDbConnectionSubclass_WithDisposeAsyncOverride_Diagnostic()
     {
         await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
               .WithSourceCode("""
-                using System;
+                using System.Data;
+                using System.Data.Common;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        [|using var conn = new MySqlConnection();|]
+                    }
+                }
+
+                class MySqlConnection : DbConnection
+                {
+                    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw null;
+                    protected override DbCommand CreateDbCommand() => throw null;
+                    public override void ChangeDatabase(string databaseName) => throw null;
+                    public override void Close() => throw null;
+                    public override void Open() => throw null;
+                    public override string ConnectionString { get => throw null; set => throw null; }
+                    public override string Database => throw null;
+                    public override string DataSource => throw null;
+                    public override string ServerVersion => throw null;
+                    public override ConnectionState State => throw null;
+                    public override ValueTask DisposeAsync() => throw null;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task UsingNewDbConnectionSubclass_DisposeAsyncOverriddenInIntermediateBase_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .WithSourceCode("""
+                using System.Data;
+                using System.Data.Common;
                 using System.Threading.Tasks;
 
                 class Test
@@ -2399,77 +2453,22 @@ class Sample
                     }
                 }
 
-                class BaseConnection : IDisposable
+                class BaseConnection : DbConnection
                 {
-                    public void Dispose() { }
-                    public virtual ValueTask DisposeAsync() => default;
-                }
-
-                class DerivedConnection : BaseConnection
-                {
+                    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw null;
+                    protected override DbCommand CreateDbCommand() => throw null;
+                    public override void ChangeDatabase(string databaseName) => throw null;
+                    public override void Close() => throw null;
+                    public override void Open() => throw null;
+                    public override string ConnectionString { get => throw null; set => throw null; }
+                    public override string Database => throw null;
+                    public override string DataSource => throw null;
+                    public override string ServerVersion => throw null;
+                    public override ConnectionState State => throw null;
                     public override ValueTask DisposeAsync() => throw null;
                 }
-                """)
-              .ValidateAsync();
-    }
 
-    [Fact]
-    public async Task UsingFactoryMethod_SealedType_InheritedDisposeAsync_NoDiagnostic()
-    {
-        await CreateProjectBuilder()
-              .WithSourceCode("""
-                using System;
-                using System.Threading.Tasks;
-
-                class Test
-                {
-                    public async Task A()
-                    {
-                        using var conn = CreateConnection();
-                    }
-
-                    private SealedConnection CreateConnection() => new SealedConnection();
-                }
-
-                class BaseConnection : IDisposable
-                {
-                    public void Dispose() { }
-                    public virtual ValueTask DisposeAsync() => default;
-                }
-
-                sealed class SealedConnection : BaseConnection { }
-                """)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task UsingFactoryMethod_SealedType_OverridesDisposeAsync_Diagnostic()
-    {
-        await CreateProjectBuilder()
-              .WithSourceCode("""
-                using System;
-                using System.Threading.Tasks;
-
-                class Test
-                {
-                    public async Task A()
-                    {
-                        [|using var conn = CreateConnection();|]
-                    }
-
-                    private SealedConnection CreateConnection() => new SealedConnection();
-                }
-
-                class BaseConnection : IDisposable
-                {
-                    public void Dispose() { }
-                    public virtual ValueTask DisposeAsync() => default;
-                }
-
-                sealed class SealedConnection : BaseConnection
-                {
-                    public override ValueTask DisposeAsync() => throw null;
-                }
+                class DerivedConnection : BaseConnection { }
                 """)
               .ValidateAsync();
     }


### PR DESCRIPTION
Contributes to #1117

## Problem

MA0042 was reporting false positives for types like `SqlConnection` or `MemoryStream` that inherit `DisposeAsync` from a base class but don't actually override it. For example, `DbConnection.DisposeAsync` is just a virtual method that calls `Dispose()` synchronously — using `await using` brings no benefit when the runtime type is known to not override it.

## Solution

The fix distinguishes two cases based on whether the static type information tells us the exact runtime type:

| Situation | Diagnostic? | Reason |
|---|---|---|
| `new SqlConnection()` | ❌ No | Exact type known; `SqlConnection` doesn't declare `DisposeAsync` |
| `CreateConnection()` → `SqlConnection` | ✅ Yes | Runtime type could be a subclass with a real override |
| `new MyConn()` where `MyConn` overrides `DisposeAsync` | ✅ Yes | Exact type known; it has a direct declaration |
| `sealed SealedConn` without override, from factory | ❌ No | Sealed = exact type known; no direct declaration |
| `sealed SealedConn` with override, from factory | ✅ Yes | Sealed = exact type known; has direct declaration |
| `new MemoryStream()` | ❌ No | `MemoryStream` doesn't declare `DisposeAsync` (replaces the hardcoded special case) |

### Key changes

- **`DoNotUseBlockingCallInAsyncContextAnalyzer.cs`**: Added `HasDisposeAsyncMethodDeclaredDirectly()` which uses `GetMembers()` (direct only) instead of `GetAllMembers()`. Modified `CanBeAwaitUsing()` to use it when the runtime type is statically known (direct object creation or sealed type). Removed the now-redundant `MemoryStream` special case and its field.
- **Test file**: Added 5 new tests covering all the new behaviors.