### PR TITLE
Fix MA0042 comment placement for await using

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseBlockingCallInAsyncContextFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseBlockingCallInAsyncContextFixer.cs
@@ -105,14 +105,25 @@ public sealed class DoNotUseBlockingCallInAsyncContextFixer : CodeFixProvider
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         if (nodeToFix is UsingStatementSyntax usingStatement)
         {
-            editor.ReplaceNode(usingStatement, usingStatement.WithAwaitKeyword(SyntaxFactory.Token(SyntaxKind.AwaitKeyword)));
+            var awaitKeyword = GetAwaitKeyword(usingStatement.UsingKeyword);
+            editor.ReplaceNode(
+                usingStatement,
+                usingStatement.WithUsingKeyword(usingStatement.UsingKeyword.WithLeadingTrivia(SyntaxFactory.TriviaList())).WithAwaitKeyword(awaitKeyword));
         }
         else if (nodeToFix is LocalDeclarationStatementSyntax localDeclarationStatement)
         {
-            editor.ReplaceNode(localDeclarationStatement, localDeclarationStatement.WithAwaitKeyword(SyntaxFactory.Token(SyntaxKind.AwaitKeyword)));
+            var awaitKeyword = GetAwaitKeyword(localDeclarationStatement.UsingKeyword);
+            editor.ReplaceNode(
+                localDeclarationStatement,
+                localDeclarationStatement.WithUsingKeyword(localDeclarationStatement.UsingKeyword.WithLeadingTrivia(SyntaxFactory.TriviaList())).WithAwaitKeyword(awaitKeyword));
         }
 
         return editor.GetChangedDocument();
+    }
+
+    private static SyntaxToken GetAwaitKeyword(SyntaxToken usingKeyword)
+    {
+        return SyntaxFactory.Token(usingKeyword.LeadingTrivia, SyntaxKind.AwaitKeyword, SyntaxFactory.TriviaList(SyntaxFactory.Space));
     }
 
     private static async Task<Document> ReplaceWithMethodName(Document document, SyntaxNode nodeToFix, string methodName, CancellationToken cancellationToken)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -688,6 +688,51 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     }
 
     [Fact]
+    public async Task Using_Diagnostic1_WithComment()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        // MA0042 "Prefer using 'await using'"
+                        [|using var a = new Sample();|]
+                    }
+
+                    private class Sample : IDisposable
+                    {
+                        public void Dispose() => throw null;
+                        public ValueTask DisposeAsync() => throw null;
+                    }
+                }
+                """)
+              .ShouldBatchFixCodeWith("""
+                using System;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        // MA0042 "Prefer using 'await using'"
+                        await using var a = new Sample();
+                    }
+
+                    private class Sample : IDisposable
+                    {
+                        public void Dispose() => throw null;
+                        public ValueTask DisposeAsync() => throw null;
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task Using_Diagnostic2()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
## Why
MA0042's code fix for `using var` did not preserve leading trivia correctly. When a comment preceded the statement, the fix inserted `await` on its own line before the comment instead of producing `await using`.

## What changed
- Added a regression test, `Using_Diagnostic1_WithComment`, in `DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests`.
- Updated `ReplaceWithAwaitUsing` in `DoNotUseBlockingCallInAsyncContextFixer` to preserve leading trivia by transferring the `using` token's leading trivia to the new `await` token and clearing it from `using`.

## Result
The code fix now produces:

```csharp
// MA0042 "Prefer using 'await using'"
await using var connection = new SqlConnection("");
```

instead of splitting `await` onto a separate line.