### PR TITLE
Fix MA0004 code fix crash in nested await using declarations

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
@@ -107,7 +107,13 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
         {
             // await using (var a = expr);
             // var a = expr; await using (a.ConfigureAwait(false));
-            var usingBlock = nodeToFix.Ancestors(ascendOutOfTrivia: true).OfType<UsingStatementSyntax>().FirstOrDefault();
+            var usingBlock = nodeToFix.Ancestors(ascendOutOfTrivia: true).OfType<UsingStatementSyntax>().FirstOrDefault(usingStatement =>
+            {
+                if (usingStatement.Declaration is not null)
+                    return usingStatement.Declaration.Span.Contains(nodeToFix.Span);
+
+                return usingStatement.Expression?.Span.Contains(nodeToFix.Span) == true;
+            });
             if (usingBlock is not null)
             {
                 if (usingBlock.Declaration is not null && usingBlock.Declaration.Variables.Count == 1)
@@ -198,7 +204,10 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
                 }
             }
 
-            editor.ReplaceNode(nodeToFix, AppendConfigureAwait(nodeToFix));
+            if (nodeToFix is not ExpressionSyntax expression)
+                return context.Document;
+
+            editor.ReplaceNode(nodeToFix, AppendConfigureAwait(expression));
             return editor.GetChangedDocument();
         }
 
@@ -229,7 +238,7 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
             return false;
         }
 
-        ExpressionSyntax AppendConfigureAwait(SyntaxNode expressionSyntax)
+        ExpressionSyntax AppendConfigureAwait(ExpressionSyntax expressionSyntax)
         {
             return (ExpressionSyntax)generator.InvocationExpression(
                 generator.MemberAccessExpression(expressionSyntax, nameof(Task.ConfigureAwait)),

--- a/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
@@ -788,6 +788,58 @@ class MyClass : System.Windows.Window
     }
 
     [Fact]
+    public async Task AwaitUsingVar_InsideConfiguredUsing_ShouldNotThrow()
+    {
+        const string SourceCode = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    var connection = new AsyncDisposable();
+                    await using (connection.ConfigureAwait(false))
+                    {
+                        await using var [|command = new AsyncDisposable()|];
+                    }
+                }
+            }
+            class AsyncDisposable : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => throw null;
+            }
+            """;
+
+        const string CodeFix = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    var connection = new AsyncDisposable();
+                    await using (connection.ConfigureAwait(false))
+                    {
+                        var command = new AsyncDisposable();
+                        await using (command.ConfigureAwait(false))
+                        {
+                        }
+                    }
+                }
+            }
+            class AsyncDisposable : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => throw null;
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ShouldFixCodeWith(CodeFix)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task AwaitUsingAwait_NoVariable()
     {
         const string SourceCode = """


### PR DESCRIPTION
## Summary
Applying the MA0004 code fix top-to-bottom could crash `UseConfigureAwaitFixer` when an inner `await using var` remained inside an outer `await using (...)` already rewritten by a previous fix. This PR makes the fixer robust for that edit sequence.

## Changes
- Restrict `UsingStatementSyntax` handling in `UseConfigureAwaitFixer` to cases where the diagnostic node is actually inside the using resource span, so outer using statements do not hijack inner declaration fixes.
- Harden the fallback path to only append `ConfigureAwait(...)` to `ExpressionSyntax`, avoiding invalid casts from `VariableDeclaratorSyntax`.
- Add regression test `AwaitUsingVar_InsideConfiguredUsing_ShouldNotThrow` in `UseConfigureAwaitAnalyzerTests` to cover the nested configured-using scenario.

## Notes
- Behavior of MA0004 diagnostics is unchanged; this is a code-fix stability improvement.
- Focused MA0004 test suite passes for default Roslyn and `roslyn4.2`.

Fix https://github.com/meziantou/Meziantou.Analyzer/issues/1117