### PR TITLE
Adjust MA0007 trailing comma behavior for collection expressions

### DIFF
--- a/docs/Rules/MA0007.md
+++ b/docs/Rules/MA0007.md
@@ -21,6 +21,30 @@ new Sample
 };
 ````
 
+## Collection expressions
+
+For collection expressions, a trailing comma is not required when the last value is immediately followed by `]` on the same line.
+
+````csharp
+// Compliant
+[
+    .. source];
+````
+
+A trailing comma is required when `]` is on a following line.
+
+````csharp
+// Non-compliant
+[
+    .. source
+];
+
+// Compliant
+[
+    .. source,
+];
+````
+
 ## Configuration
 
 ### `MA0007.IgnoreCatchAllArm`

--- a/src/Meziantou.Analyzer/Rules/CommaAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/CommaAnalyzer.cs
@@ -58,7 +58,17 @@ public sealed class CommaAnalyzer : DiagnosticAnalyzer
     private void HandleCollectionExpression(SyntaxNodeAnalysisContext context)
     {
         var node = (CollectionExpressionSyntax)context.Node;
-        HandleSeparatedList(context, node, node.Elements);
+        if (node.Elements.Count == 0)
+            return;
+
+        if (node.Elements.Count == node.Elements.SeparatorCount || !node.SpansMultipleLines(context.CancellationToken))
+            return;
+
+        var lastElement = node.Elements[^1];
+        if (lastElement.GetEndLine(context.CancellationToken) == node.CloseBracketToken.GetEndLine(context.CancellationToken))
+            return;
+
+        context.ReportDiagnostic(Rule, lastElement);
     }
 #endif
 

--- a/tests/Meziantou.Analyzer.Test/Rules/CommaAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/CommaAnalyzerTests.cs
@@ -237,7 +237,7 @@ public sealed class CommaAnalyzerTests
 
 #if CSHARP12_OR_GREATER
     [Fact]
-    public async Task CollectionExpressionWithoutLeadingComma()
+    public async Task CollectionExpressionWithoutLeadingComma_ClosingBracketOnNextLine()
     {
         const string SourceCode = """
 class TypeName
@@ -271,6 +271,73 @@ class TypeName
             .ShouldFixCodeWith(CodeFix)
             .ValidateAsync();
     }
+
+    [Fact]
+    public Task CollectionExpressionWithoutLeadingComma_ClosingBracketOnSameLine()
+        => CreateProjectBuilder()
+            .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+            .WithSourceCode("""
+                class TypeName
+                {
+                    public void Test(int[] source)
+                    {
+                        int[] a =
+                        [
+                            .. source];
+                    }
+                }
+                """)
+            .ValidateAsync();
+
+    [Fact]
+    public Task CollectionExpressionWithoutLeadingComma_ClosingBracketOnSameLine_WithPreviousValue()
+        => CreateProjectBuilder()
+            .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+            .WithSourceCode("""
+                class TypeName
+                {
+                    public void Test(int[] source)
+                    {
+                        int[] a =
+                        [
+                            1,
+                            .. source];
+                    }
+                }
+                """)
+            .ValidateAsync();
+
+    [Fact]
+    public Task CollectionExpressionWithoutLeadingComma_SpreadElementWithComment()
+        => CreateProjectBuilder()
+            .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+            .WithSourceCode("""
+                class TypeName
+                {
+                    public void Test(int[] source)
+                    {
+                        int[] a =
+                        [
+                            1,
+                            [|.. source|] // comment
+                        ];
+                    }
+                }
+                """)
+            .ShouldFixCodeWith("""
+                class TypeName
+                {
+                    public void Test(int[] source)
+                    {
+                        int[] a =
+                        [
+                            1,
+                            .. source, // comment
+                        ];
+                    }
+                }
+                """)
+            .ValidateAsync();
 #endif
 
     [Fact]


### PR DESCRIPTION
MA0007 currently reports on multiline collection expressions even when the last element is directly followed by the closing bracket on the same line. This produces noise for common spread-element formatting.

This change updates MA0007 so collection expressions only require a trailing comma when the closing `]` is on a later line than the last element. If the last element and `]` are on the same line, no diagnostic is reported.

It also adds focused C# 12 tests for:
- same-line closing bracket cases (with and without preceding values)
- next-line closing bracket cases
- a trailing comment before the closing bracket on the next line

Finally, the MA0007 rule documentation is updated to describe the new default behavior for collection expressions.

Fix https://github.com/meziantou/Meziantou.Analyzer/issues/1126