### PR TITLE
Skip SqliteConnection.Open in MA0042 and MA0045

### DIFF
--- a/docs/Rules/MA0042.md
+++ b/docs/Rules/MA0042.md
@@ -56,6 +56,7 @@ public sealed class Sample
 The rule does not report a diagnostic for `IDbContextFactory<TContext>.CreateDbContext()`. The `CreateDbContextAsync()` overload was introduced only for specific edge-case scenarios where the factory itself must perform asynchronous initialization, and is not intended as a general-purpose replacement. See [dotnet/efcore#26630](https://github.com/dotnet/efcore/issues/26630) for more details.
 
 The rule does not report a diagnostic for the following SQLite APIs by default:
+- `SqliteConnection.Open()`
 - `SqliteConnection.CreateCommand()`
 - `SqliteCommand.ExecuteNonQuery()`
 - `SqliteCommand.ExecuteScalar()`

--- a/docs/Rules/MA0045.md
+++ b/docs/Rules/MA0045.md
@@ -31,6 +31,7 @@ public async Task Sample()
 ````
 
 This rule shares the same SQLite special-cases as [MA0042](MA0042.md) by default:
+- `SqliteConnection.Open()`
 - `SqliteConnection.CreateCommand()`
 - `SqliteCommand.ExecuteNonQuery()`
 - `SqliteCommand.ExecuteScalar()`

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -270,8 +270,9 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
                 return false;
             }
 
-            // SqliteConnection.CreateCommand() always returns SqliteCommand.
-            // SqliteCommand does not override DisposeAsync, so there is no async alternative to require.
+            // SqliteConnection.Open() and CreateCommand() are synchronous by design in Microsoft.Data.Sqlite.
+            // SqliteConnection.CreateCommand() always returns SqliteCommand and SqliteCommand does not override
+            // DisposeAsync, so there is no async alternative to require.
             // https://learn.microsoft.com/en-us/dotnet/standard/data/sqlite/async
             else if (sqliteSpecialCasesEnabled && IsSqliteSpecialCaseMethod(targetMethod))
             {
@@ -329,6 +330,16 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
                    targetMethod.ReturnType.IsEqualTo(SqliteCommandSymbol);
         }
 
+        private bool IsSqliteConnectionOpen(IMethodSymbol targetMethod)
+        {
+            if (SqliteConnectionSymbol is null)
+                return false;
+
+            return targetMethod.Name is "Open" &&
+                   targetMethod.ContainingType.IsEqualTo(SqliteConnectionSymbol) &&
+                   targetMethod.Parameters.Length == 0;
+        }
+
         private bool IsSqliteCommandMethod(IMethodSymbol targetMethod)
         {
             if (SqliteCommandSymbol is null)
@@ -340,7 +351,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
 
         private bool IsSqliteSpecialCaseMethod(IMethodSymbol targetMethod)
         {
-            return IsSqliteConnectionCreateCommand(targetMethod) || IsSqliteCommandMethod(targetMethod);
+            return IsSqliteConnectionOpen(targetMethod) || IsSqliteConnectionCreateCommand(targetMethod) || IsSqliteCommandMethod(targetMethod);
         }
 
         private IMethodSymbol? FindPotentialAsyncEquivalent(IInvocationOperation operation, IMethodSymbol targetMethod, string methodName)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -2026,6 +2026,28 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
+    public async Task SqliteConnection_Open_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .WithSourceCode("""
+                using System.Threading.Tasks;
+                using Microsoft.Data.Sqlite;
+
+                class Test
+                {
+                    public async Task A(SqliteConnection connection)
+                    {
+                        connection.Open();
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
     public async Task SqliteCommand_ExecuteMethods_NoDiagnostic()
     {
         await CreateProjectBuilder()
@@ -2065,6 +2087,29 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
                     public async Task A(SqliteConnection connection)
                     {
                         [|using var command = connection.CreateCommand();|]
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
+    public async Task SqliteConnection_Open_OptionDisabled_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .AddAnalyzerConfiguration("MA0042.enable_sqlite_special_cases", "false")
+              .WithSourceCode("""
+                using System.Threading.Tasks;
+                using Microsoft.Data.Sqlite;
+
+                class Test
+                {
+                    public async Task A(SqliteConnection connection)
+                    {
+                        [|connection.Open()|];
                     }
                 }
                 """)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
@@ -163,6 +163,49 @@ public class Test
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
+    public async Task PrivateNonAsync_SqliteConnection_Open_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .WithSourceCode("""
+                using Microsoft.Data.Sqlite;
+
+                class Test
+                {
+                    private void A(SqliteConnection connection)
+                    {
+                        connection.Open();
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
+    public async Task PrivateNonAsync_SqliteConnection_Open_OptionDisabled_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .AddAnalyzerConfiguration("MA0042.enable_sqlite_special_cases", "false")
+              .WithSourceCode("""
+                using Microsoft.Data.Sqlite;
+
+                class Test
+                {
+                    private void A(SqliteConnection connection)
+                    {
+                        [|connection.Open()|];
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
     public async Task PrivateNonAsync_SqliteCommand_ExecuteMethods_OptionDisabled_Diagnostic()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
SQLite in Microsoft.Data.Sqlite has documented async limitations, and `SqliteConnection.Open()` is effectively a synchronous API. Reporting MA0042/MA0045 for this call when SQLite special-cases are enabled produces noise.

This updates the shared blocking-call analyzer logic to treat `SqliteConnection.Open()` as a SQLite special-case alongside existing SQLite exemptions. The behavior is still configurable: when `MA0042.enable_sqlite_special_cases = false`, diagnostics are reported as before.

I also added regression tests for both MA0042 (async context) and MA0045 (non-async context) to cover enabled and disabled flag behavior, and updated the MA0042/MA0045 rule docs to list `SqliteConnection.Open()` in the SQLite special-case APIs.


Fix https://github.com/meziantou/Meziantou.Analyzer/issues/1121#issuecomment-4382751492