### PR TITLE
Broaden MA0042/MA0045 SQLite special-case exclusions

### DIFF
--- a/docs/Rules/MA0042.md
+++ b/docs/Rules/MA0042.md
@@ -55,14 +55,12 @@ public sealed class Sample
 
 The rule does not report a diagnostic for `IDbContextFactory<TContext>.CreateDbContext()`. The `CreateDbContextAsync()` overload was introduced only for specific edge-case scenarios where the factory itself must perform asynchronous initialization, and is not intended as a general-purpose replacement. See [dotnet/efcore#26630](https://github.com/dotnet/efcore/issues/26630) for more details.
 
-The rule does not report a diagnostic for the following SQLite APIs by default:
-- `SqliteConnection.Open()`
-- `SqliteConnection.CreateCommand()`
-- `SqliteCommand.ExecuteNonQuery()`
-- `SqliteCommand.ExecuteScalar()`
-- `SqliteCommand.ExecuteReader()`
+The rule does not report a diagnostic for method invocations on the following SQLite types by default:
+- `SqliteConnection`
+- `SqliteCommand`
+- `SqliteDataReader`
 
-`SqliteCommand` does not override `DisposeAsync`, and SQLite async APIs have documented limitations. See [Async limitations](https://learn.microsoft.com/en-us/dotnet/standard/data/sqlite/async) for details.
+SQLite async APIs have documented limitations. See [Async limitations](https://learn.microsoft.com/en-us/dotnet/standard/data/sqlite/async) for details.
 
 The rule will not report a diagnostic for a `using` statement on a `Stream`, `DbConnection`, or `DbCommand` subclass that is directly instantiated with `new` when the concrete type does not override `DisposeAsync`. `Stream.DisposeAsync`, `DbConnection.DisposeAsync`, and `DbCommand.DisposeAsync` merely call `Dispose()` synchronously by default, so switching to `await using` brings no benefit for such types. When the instance is obtained from a factory method rather than a direct `new` expression, the rule still reports a diagnostic because the runtime type may be a deeper subclass that does override `DisposeAsync`.
 

--- a/docs/Rules/MA0045.md
+++ b/docs/Rules/MA0045.md
@@ -31,11 +31,9 @@ public async Task Sample()
 ````
 
 This rule shares the same SQLite special-cases as [MA0042](MA0042.md) by default:
-- `SqliteConnection.Open()`
-- `SqliteConnection.CreateCommand()`
-- `SqliteCommand.ExecuteNonQuery()`
-- `SqliteCommand.ExecuteScalar()`
-- `SqliteCommand.ExecuteReader()`
+- `SqliteConnection` method invocations
+- `SqliteCommand` method invocations
+- `SqliteDataReader` method invocations
 
 ## Configuration
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -81,6 +81,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             DbCommandSymbol = compilation.GetBestTypeByMetadataName("System.Data.Common.DbCommand");
             SqliteConnectionSymbol = compilation.GetBestTypeByMetadataName("Microsoft.Data.Sqlite.SqliteConnection");
             SqliteCommandSymbol = compilation.GetBestTypeByMetadataName("Microsoft.Data.Sqlite.SqliteCommand");
+            SqliteDataReaderSymbol = compilation.GetBestTypeByMetadataName("Microsoft.Data.Sqlite.SqliteDataReader");
             CancellationTokenSymbol = compilation.GetBestTypeByMetadataName("System.Threading.CancellationToken");
             ObsoleteAttributeSymbol = compilation.GetBestTypeByMetadataName("System.ObsoleteAttribute");
 
@@ -133,6 +134,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
         private INamedTypeSymbol? DbCommandSymbol { get; }
         private INamedTypeSymbol? SqliteConnectionSymbol { get; }
         private INamedTypeSymbol? SqliteCommandSymbol { get; }
+        private INamedTypeSymbol? SqliteDataReaderSymbol { get; }
         private ISymbol[] ConsoleErrorAndOutSymbols { get; }
         private INamedTypeSymbol? CancellationTokenSymbol { get; }
         private INamedTypeSymbol? ObsoleteAttributeSymbol { get; }
@@ -170,7 +172,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             var operation = (IInvocationOperation)context.Operation;
             var targetMethod = operation.TargetMethod;
             var sqliteSpecialCasesEnabled = IsSqliteSpecialCasesEnabled(context, operation);
-            var isSqliteSpecialCaseMethod = IsSqliteSpecialCaseMethod(targetMethod);
+            var isSqliteSpecialCaseMethod = IsSqliteSpecialCaseMethod(operation);
 
             // The cache only contains methods with no async equivalent methods.
             // This optimizes the best-case scenario where code is correctly written according to this analyzer.
@@ -270,11 +272,10 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
                 return false;
             }
 
-            // SqliteConnection.Open() and CreateCommand() are synchronous by design in Microsoft.Data.Sqlite.
-            // SqliteConnection.CreateCommand() always returns SqliteCommand and SqliteCommand does not override
-            // DisposeAsync, so there is no async alternative to require.
+            // Async APIs in Microsoft.Data.Sqlite have documented limitations.
+            // Ignore any invocation on SqliteConnection, SqliteCommand, or SqliteDataReader by default.
             // https://learn.microsoft.com/en-us/dotnet/standard/data/sqlite/async
-            else if (sqliteSpecialCasesEnabled && IsSqliteSpecialCaseMethod(targetMethod))
+            else if (sqliteSpecialCasesEnabled && IsSqliteSpecialCaseMethod(operation))
             {
                 return false;
             }
@@ -320,38 +321,26 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             return context.Options.GetConfigurationValue(operation, RuleIdentifiers.DoNotUseBlockingCall + ".enable_sqlite_special_cases", defaultValue);
         }
 
-        private bool IsSqliteConnectionCreateCommand(IMethodSymbol targetMethod)
+        private bool IsSqliteSpecialCaseType(INamedTypeSymbol type)
         {
-            if (SqliteConnectionSymbol is null || SqliteCommandSymbol is null)
-                return false;
-
-            return targetMethod.Name is "CreateCommand" &&
-                   targetMethod.ContainingType.IsEqualTo(SqliteConnectionSymbol) &&
-                   targetMethod.ReturnType.IsEqualTo(SqliteCommandSymbol);
+            return type.IsEqualToAny(SqliteConnectionSymbol, SqliteCommandSymbol, SqliteDataReaderSymbol);
         }
 
-        private bool IsSqliteConnectionOpen(IMethodSymbol targetMethod)
+        private bool IsSqliteSpecialCaseMethod(IInvocationOperation operation)
         {
-            if (SqliteConnectionSymbol is null)
+            if (IsSqliteSpecialCaseType(operation.TargetMethod.ContainingType))
+                return true;
+
+            if (operation.TargetMethod.IsExtensionMethod)
                 return false;
 
-            return targetMethod.Name is "Open" &&
-                   targetMethod.ContainingType.IsEqualTo(SqliteConnectionSymbol) &&
-                   targetMethod.Parameters.Length == 0;
-        }
-
-        private bool IsSqliteCommandMethod(IMethodSymbol targetMethod)
-        {
-            if (SqliteCommandSymbol is null)
+            if (operation.TargetMethod.IsStatic)
                 return false;
 
-            return targetMethod.ContainingType.IsEqualTo(SqliteCommandSymbol) &&
-                   targetMethod.Name is "ExecuteNonQuery" or "ExecuteScalar" or "ExecuteReader";
-        }
+            if (operation.Instance?.GetActualType() is not INamedTypeSymbol type)
+                return false;
 
-        private bool IsSqliteSpecialCaseMethod(IMethodSymbol targetMethod)
-        {
-            return IsSqliteConnectionOpen(targetMethod) || IsSqliteConnectionCreateCommand(targetMethod) || IsSqliteCommandMethod(targetMethod);
+            return IsSqliteSpecialCaseType(type);
         }
 
         private IMethodSymbol? FindPotentialAsyncEquivalent(IInvocationOperation operation, IMethodSymbol targetMethod, string methodName)
@@ -553,7 +542,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             var unwrappedOperation = operation.UnwrapImplicitConversionOperations();
             if (sqliteSpecialCasesEnabled &&
                 unwrappedOperation is IInvocationOperation invocationOperation &&
-                IsSqliteConnectionCreateCommand(invocationOperation.TargetMethod))
+                IsSqliteSpecialCaseMethod(invocationOperation))
             {
                 return false;
             }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -2026,7 +2026,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
-    public async Task SqliteConnection_Open_NoDiagnostic()
+    public async Task SqliteConnection_Close_NoDiagnostic()
     {
         await CreateProjectBuilder()
               .WithTargetFramework(TargetFramework.Net8_0)
@@ -2039,7 +2039,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
                 {
                     public async Task A(SqliteConnection connection)
                     {
-                        connection.Open();
+                        connection.Close();
                     }
                 }
                 """)
@@ -2048,7 +2048,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
-    public async Task SqliteCommand_ExecuteMethods_NoDiagnostic()
+    public async Task SqliteCommand_Prepare_NoDiagnostic()
     {
         await CreateProjectBuilder()
               .WithTargetFramework(TargetFramework.Net8_0)
@@ -2061,9 +2061,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
                 {
                     public async Task A(SqliteCommand command)
                     {
-                        command.ExecuteNonQuery();
-                        command.ExecuteScalar();
-                        command.ExecuteReader();
+                        command.Prepare();
                     }
                 }
                 """)
@@ -2095,7 +2093,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
-    public async Task SqliteConnection_Open_OptionDisabled_Diagnostic()
+    public async Task SqliteConnection_Close_OptionDisabled_Diagnostic()
     {
         await CreateProjectBuilder()
               .WithTargetFramework(TargetFramework.Net8_0)
@@ -2109,7 +2107,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
                 {
                     public async Task A(SqliteConnection connection)
                     {
-                        [|connection.Open()|];
+                        [|connection.Close()|];
                     }
                 }
                 """)
@@ -2118,7 +2116,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
-    public async Task SqliteCommand_ExecuteMethods_OptionDisabled_Diagnostic()
+    public async Task SqliteCommand_Prepare_OptionDisabled_Diagnostic()
     {
         await CreateProjectBuilder()
               .WithTargetFramework(TargetFramework.Net8_0)
@@ -2132,9 +2130,52 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
                 {
                     public async Task A(SqliteCommand command)
                     {
-                        [|command.ExecuteNonQuery()|];
-                        [|command.ExecuteScalar()|];
-                        [|command.ExecuteReader()|];
+                        [|command.Prepare()|];
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
+    public async Task SqliteDataReader_Read_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .WithSourceCode("""
+                using System.Threading.Tasks;
+                using Microsoft.Data.Sqlite;
+
+                class Test
+                {
+                    public async Task A(SqliteDataReader reader)
+                    {
+                        reader.Read();
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
+    public async Task SqliteDataReader_Read_OptionDisabled_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .AddAnalyzerConfiguration("MA0042.enable_sqlite_special_cases", "false")
+              .WithSourceCode("""
+                using System.Threading.Tasks;
+                using Microsoft.Data.Sqlite;
+
+                class Test
+                {
+                    public async Task A(SqliteDataReader reader)
+                    {
+                        [|reader.Read()|];
                     }
                 }
                 """)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
@@ -140,7 +140,7 @@ public class Test
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
-    public async Task PrivateNonAsync_SqliteCommand_ExecuteMethods_NoDiagnostic()
+    public async Task PrivateNonAsync_SqliteCommand_Prepare_NoDiagnostic()
     {
         await CreateProjectBuilder()
               .WithTargetFramework(TargetFramework.Net8_0)
@@ -152,9 +152,7 @@ public class Test
                 {
                     private void A(SqliteCommand command)
                     {
-                        command.ExecuteNonQuery();
-                        command.ExecuteScalar();
-                        command.ExecuteReader();
+                        command.Prepare();
                     }
                 }
                 """)
@@ -163,7 +161,7 @@ public class Test
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
-    public async Task PrivateNonAsync_SqliteConnection_Open_NoDiagnostic()
+    public async Task PrivateNonAsync_SqliteConnection_Close_NoDiagnostic()
     {
         await CreateProjectBuilder()
               .WithTargetFramework(TargetFramework.Net8_0)
@@ -175,7 +173,7 @@ public class Test
                 {
                     private void A(SqliteConnection connection)
                     {
-                        connection.Open();
+                        connection.Close();
                     }
                 }
                 """)
@@ -184,7 +182,7 @@ public class Test
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
-    public async Task PrivateNonAsync_SqliteConnection_Open_OptionDisabled_Diagnostic()
+    public async Task PrivateNonAsync_SqliteConnection_Close_OptionDisabled_Diagnostic()
     {
         await CreateProjectBuilder()
               .WithTargetFramework(TargetFramework.Net8_0)
@@ -197,7 +195,7 @@ public class Test
                 {
                     private void A(SqliteConnection connection)
                     {
-                        [|connection.Open()|];
+                        [|connection.Close()|];
                     }
                 }
                 """)
@@ -206,7 +204,7 @@ public class Test
 
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
-    public async Task PrivateNonAsync_SqliteCommand_ExecuteMethods_OptionDisabled_Diagnostic()
+    public async Task PrivateNonAsync_SqliteCommand_Prepare_OptionDisabled_Diagnostic()
     {
         await CreateProjectBuilder()
               .WithTargetFramework(TargetFramework.Net8_0)
@@ -219,9 +217,50 @@ public class Test
                 {
                     private void A(SqliteCommand command)
                     {
-                        [|command.ExecuteNonQuery()|];
-                        [|command.ExecuteScalar()|];
-                        [|command.ExecuteReader()|];
+                        [|command.Prepare()|];
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
+    public async Task PrivateNonAsync_SqliteDataReader_Read_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .WithSourceCode("""
+                using Microsoft.Data.Sqlite;
+
+                class Test
+                {
+                    private void A(SqliteDataReader reader)
+                    {
+                        reader.Read();
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1121")]
+    public async Task PrivateNonAsync_SqliteDataReader_Read_OptionDisabled_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .AddAnalyzerConfiguration("MA0042.enable_sqlite_special_cases", "false")
+              .WithSourceCode("""
+                using Microsoft.Data.Sqlite;
+
+                class Test
+                {
+                    private void A(SqliteDataReader reader)
+                    {
+                        [|reader.Read()|];
                     }
                 }
                 """)


### PR DESCRIPTION
## Why
The recent SQLite handling for MA0042/MA0045 only excluded a small set of specific methods, which still left other synchronous SQLite calls flagged even though Microsoft.Data.Sqlite async APIs are documented with limitations.

## What changed
- Switched SQLite special-case detection from method-name checks to type-based checks.
- Excluded invocations on `SqliteConnection`, `SqliteCommand`, and `SqliteDataReader` when SQLite special-cases are enabled.
- Kept extension methods out of the SQLite special-case path so only methods on those SQLite types are excluded.
- Applied the same SQLite special-case behavior to the `using`/`await using` analysis path.
- Updated MA0042 and MA0045 rule docs to describe type-based SQLite exclusions.
- Expanded tests (async and non-async contexts) to cover broader type behavior and added `SqliteDataReader` coverage, with option-enabled and option-disabled cases.

## Notes for reviewers
The config switch (`MA0042.enable_sqlite_special_cases`, shared with MA0045) is unchanged. This PR only broadens what is considered a SQLite special-case when that option is enabled.