### PR TITLE
Ignore primary constructors in MA0196 and reuse shared detection

### DIFF
--- a/docs/Rules/MA0196.md
+++ b/docs/Rules/MA0196.md
@@ -9,6 +9,8 @@ This rule reports `<inheritdoc />` when the member is not:
 - an override, and
 - an interface implementation.
 
+Primary constructors are ignored because their XML documentation is shared with the containing type declaration.
+
 `<inheritdoc .../>` with a `cref` attribute is allowed.
 
 ````csharp

--- a/src/Meziantou.Analyzer/Internals/SymbolExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/SymbolExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection.Metadata.Ecma335;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Meziantou.Analyzer.Internals;
 
@@ -32,6 +33,21 @@ internal static class SymbolExtensions
     public static bool IsOperator(this ISymbol? symbol)
     {
         return symbol is IMethodSymbol { MethodKind: MethodKind.UserDefinedOperator or MethodKind.Conversion };
+    }
+
+    public static bool IsPrimaryConstructor(this IMethodSymbol? methodSymbol, CancellationToken cancellationToken, bool includeRecordDeclarations = false)
+    {
+        if (methodSymbol is not { MethodKind: MethodKind.Constructor })
+            return false;
+
+        foreach (var syntaxReference in methodSymbol.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxReference.GetSyntax(cancellationToken);
+            if (syntax is ClassDeclarationSyntax or StructDeclarationSyntax || (includeRecordDeclarations && syntax is RecordDeclarationSyntax))
+                return true;
+        }
+
+        return false;
     }
 
     public static bool IsOverrideOrInterfaceImplementation(this ISymbol? symbol)

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzer.cs
@@ -34,6 +34,9 @@ public sealed class InheritdocShouldBeUsedOnInheritingMemberAnalyzer : Diagnosti
         if (context.Symbol is not (IMethodSymbol or IPropertySymbol or IEventSymbol))
             return;
 
+        if (context.Symbol is IMethodSymbol methodSymbol && methodSymbol.IsPrimaryConstructor(context.CancellationToken, includeRecordDeclarations: true))
+            return;
+
         if (context.Symbol.IsImplicitlyDeclared || context.Symbol.IsOverrideOrInterfaceImplementation())
             return;
 

--- a/src/Meziantou.Analyzer/Rules/LocalVariablesShouldNotHideSymbolsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/LocalVariablesShouldNotHideSymbolsAnalyzer.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using Meziantou.Analyzer.Internals;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -86,21 +85,13 @@ public sealed class LocalVariablesShouldNotHideSymbolsAnalyzer : DiagnosticAnaly
         {
             foreach (var constructor in type.InstanceConstructors)
             {
-                if (constructor.Parameters.Length == 0)
+                if (constructor.Parameters.Length == 0 || !constructor.IsPrimaryConstructor(cancellationToken))
                     continue;
 
-                foreach (var syntaxRef in constructor.DeclaringSyntaxReferences)
+                foreach (var param in constructor.Parameters)
                 {
-                    var syntax = syntaxRef.GetSyntax(cancellationToken);
-                    if (syntax.IsKind(SyntaxKind.ClassDeclaration) || syntax.IsKind(SyntaxKind.StructDeclaration))
-                    {
-                        var typeDeclaration = (TypeDeclarationSyntax)syntax;
-                        foreach (var param in constructor.Parameters)
-                        {
-                            if (param.Name == name)
-                                yield return param;
-                        }
-                    }
+                    if (param.Name == name)
+                        yield return param;
                 }
             }
         }

--- a/src/Meziantou.Analyzer/Rules/PrimaryConstructorParameterShouldBeReadOnlyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/PrimaryConstructorParameterShouldBeReadOnlyAnalyzer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Immutable;
 using Meziantou.Analyzer.Internals;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -124,20 +123,9 @@ public sealed class PrimaryConstructorParameterShouldBeReadOnlyAnalyzer : Diagno
 
     private static bool IsPrimaryConstructorParameter(IOperation operation, CancellationToken cancellationToken)
     {
-        if (operation is IParameterReferenceOperation parameterReferenceOperation)
-        {
-            if (parameterReferenceOperation.Parameter.ContainingSymbol is IMethodSymbol { MethodKind: MethodKind.Constructor } ctor)
-            {
-                foreach (var syntaxRef in ctor.DeclaringSyntaxReferences)
-                {
-                    var syntax = syntaxRef.GetSyntax(cancellationToken);
-                    if (syntax is ClassDeclarationSyntax or StructDeclarationSyntax)
-                        return true;
-                }
-            }
-        }
-
-        return false;
+        return operation is IParameterReferenceOperation parameterReferenceOperation &&
+               parameterReferenceOperation.Parameter.ContainingSymbol is IMethodSymbol methodSymbol &&
+               methodSymbol.IsPrimaryConstructor(cancellationToken);
     }
 }
 #endif

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzerTests.cs
@@ -42,6 +42,33 @@ public sealed class InheritdocShouldBeUsedOnInheritingMemberAnalyzerTests
     }
 
     [Fact]
+    public async Task ReportDiagnostic_ConstructorIsNotOverrideOrInterfaceImplementation()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class Sample
+                  {
+                      /// [|<inheritdoc />|]
+                      public Sample() { }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+#if CSHARP12_OR_GREATER
+    [Fact]
+    public async Task NoDiagnostic_WhenInheritdocIsOnTypeWithPrimaryConstructor()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  /// <inheritdoc />
+                  public class Sample() { }
+                  """)
+              .ValidateAsync();
+    }
+#endif
+
+    [Fact]
     public async Task NoDiagnostic_MethodIsOverride()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
MA0196 should not flag `<inheritdoc />` attached to primary constructor syntax, because that XML documentation primarily describes the containing type. This change fixes that false positive and consolidates primary-constructor detection logic.

## What changed
- Skip MA0196 diagnostics when the analyzed symbol is a primary constructor.
- Add a shared `IsPrimaryConstructor` helper in `SymbolExtensions`.
- Reuse the shared helper in existing primary-constructor detection paths:
  - `InheritdocShouldBeUsedOnInheritingMemberAnalyzer`
  - `PrimaryConstructorParameterShouldBeReadOnlyAnalyzer`
  - `LocalVariablesShouldNotHideSymbolsAnalyzer`
- Add regression tests for MA0196, including a C# 12 primary-constructor case.
- Update MA0196 documentation to explicitly state that primary constructors are ignored.

## Notes
- MA0196 uses `includeRecordDeclarations: true` in the shared helper to cover record primary constructors.
- Targeted analyzer tests were run on default Roslyn plus `roslyn4.2` and `roslyn4.14`.

Fix https://github.com/meziantou/Meziantou.Analyzer/issues/1139