### PR TITLE
Split type inheritdoc rule into MA0197/MA0198/MA0199

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0194](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0194.md)|Usage|Merge is expressions on the same value|ℹ️|✔️|✔️|
 |[MA0195](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0195.md)|Usage|Do not use static fields before they are initialized|⚠️|✔️|❌|
 |[MA0196](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0196.md)|Design|Do not use inheritdoc on non-inheriting members|⚠️|✔️|❌|
-|[MA0197](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0197.md)|Design|Do not use inheritdoc on types|⚠️|✔️|❌|
+|[MA0197](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0197.md)|Design|Add dedicated documentation on types|ℹ️|✔️|❌|
+|[MA0198](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0198.md)|Design|Specify cref for ambiguous inheritdoc on types|⚠️|✔️|✔️|
+|[MA0199](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0199.md)|Design|Do not use inheritdoc on types without inheritance source|⚠️|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -195,7 +195,9 @@
 |[MA0194](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0194.md)|Usage|Merge is expressions on the same value|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0195](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0195.md)|Usage|Do not use static fields before they are initialized|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0196](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0196.md)|Design|Do not use inheritdoc on non-inheriting members|<span title='Warning'>⚠️</span>|✔️|❌|
-|[MA0197](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0197.md)|Design|Do not use inheritdoc on types|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0197](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0197.md)|Design|Add dedicated documentation on types|<span title='Info'>ℹ️</span>|✔️|❌|
+|[MA0198](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0198.md)|Design|Specify cref for ambiguous inheritdoc on types|<span title='Warning'>⚠️</span>|✔️|✔️|
+|[MA0199](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0199.md)|Design|Do not use inheritdoc on types without inheritance source|<span title='Warning'>⚠️</span>|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|
@@ -797,8 +799,14 @@ dotnet_diagnostic.MA0195.severity = warning
 # MA0196: Do not use inheritdoc on non-inheriting members
 dotnet_diagnostic.MA0196.severity = warning
 
-# MA0197: Do not use inheritdoc on types
-dotnet_diagnostic.MA0197.severity = warning
+# MA0197: Add dedicated documentation on types
+dotnet_diagnostic.MA0197.severity = suggestion
+
+# MA0198: Specify cref for ambiguous inheritdoc on types
+dotnet_diagnostic.MA0198.severity = warning
+
+# MA0199: Do not use inheritdoc on types without inheritance source
+dotnet_diagnostic.MA0199.severity = warning
 ```
 
 # .editorconfig - all rules disabled
@@ -1386,6 +1394,12 @@ dotnet_diagnostic.MA0195.severity = none
 # MA0196: Do not use inheritdoc on non-inheriting members
 dotnet_diagnostic.MA0196.severity = none
 
-# MA0197: Do not use inheritdoc on types
+# MA0197: Add dedicated documentation on types
 dotnet_diagnostic.MA0197.severity = none
+
+# MA0198: Specify cref for ambiguous inheritdoc on types
+dotnet_diagnostic.MA0198.severity = none
+
+# MA0199: Do not use inheritdoc on types without inheritance source
+dotnet_diagnostic.MA0199.severity = none
 ```

--- a/docs/Rules/MA0197.md
+++ b/docs/Rules/MA0197.md
@@ -1,36 +1,37 @@
-# MA0197 - Do not use inheritdoc on types
+# MA0197 - Add dedicated documentation on types
 <!-- sources -->
 Source: [InheritdocShouldNotBeUsedOnTypesAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzer.cs)
 <!-- sources -->
 
-Use `<inheritdoc />` on members only.
-Types usually represent dedicated concepts, so inheriting the full documentation of another type is often a design smell.
+Types should have dedicated documentation that describes their purpose directly.
+Using `<inheritdoc />` on a type tends to copy intent from another type instead of documenting the type itself.
 
-This rule reports `<inheritdoc />` on type declarations (`class`, `struct`, `interface`, `record`) unless `cref` is specified.
+This rule reports `<inheritdoc />` on type declarations (`class`, `struct`, `interface`, `record`) when no `cref` is specified and the inheritdoc source is unambiguous.
+
+For ambiguous or missing inheritdoc sources, see:
+- [MA0198](MA0198.md)
+- [MA0199](MA0199.md)
 
 ````csharp
 // Non-compliant
+class BaseType
+{
+}
+
 /// <inheritdoc />
-class Sample
+class Sample : BaseType
 {
 }
 ````
 
 ````csharp
 // Compliant
-/// <inheritdoc cref="BaseType" />
-class DerivedType
+/// <summary>Represents a dedicated concept for this type.</summary>
+class Sample : BaseType
 {
 }
 
 class BaseType
 {
-    public virtual void M() { }
-}
-
-class Sample : BaseType
-{
-    /// <inheritdoc />
-    public override void M() { }
 }
 ````

--- a/docs/Rules/MA0198.md
+++ b/docs/Rules/MA0198.md
@@ -1,0 +1,35 @@
+# MA0198 - Specify cref for ambiguous inheritdoc on types
+<!-- sources -->
+Sources: [InheritdocShouldNotBeUsedOnTypesAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzer.cs), [InheritdocShouldNotBeUsedOnTypesFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs)
+<!-- sources -->
+
+When a type has no base type (other than `System.Object` or `System.ValueType`) and declares multiple interfaces, `<inheritdoc />` is ambiguous without `cref`.
+
+This rule reports `<inheritdoc />` on type declarations (`class`, `struct`, `interface`, `record`) when:
+- no `cref` is specified
+- there is no applicable base type
+- there are multiple declared interfaces
+
+Only declared interfaces are considered. Inherited interfaces from those declared interfaces are ignored.
+
+````csharp
+// Non-compliant
+interface IInterface1 { }
+interface IInterface2 { }
+
+/// <inheritdoc />
+class Sample : IInterface1, IInterface2
+{
+}
+````
+
+````csharp
+// Compliant
+interface IInterface1 { }
+interface IInterface2 { }
+
+/// <inheritdoc cref="IInterface1" />
+class Sample : IInterface1, IInterface2
+{
+}
+````

--- a/docs/Rules/MA0198.md
+++ b/docs/Rules/MA0198.md
@@ -1,6 +1,6 @@
 # MA0198 - Specify cref for ambiguous inheritdoc on types
 <!-- sources -->
-Sources: [InheritdocShouldNotBeUsedOnTypesAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzer.cs), [InheritdocShouldNotBeUsedOnTypesFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs)
+Sources: [InheritdocShouldNotBeAmbiguousOnTypesAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzer.cs), [InheritdocShouldNotBeUsedOnTypesFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs)
 <!-- sources -->
 
 When a type has no base type (other than `System.Object` or `System.ValueType`) and declares multiple interfaces, `<inheritdoc />` is ambiguous without `cref`.

--- a/docs/Rules/MA0199.md
+++ b/docs/Rules/MA0199.md
@@ -1,0 +1,28 @@
+# MA0199 - Do not use inheritdoc on types without inheritance source
+<!-- sources -->
+Source: [InheritdocShouldNotBeUsedOnTypesAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzer.cs)
+<!-- sources -->
+
+`<inheritdoc />` requires an inheritance source.
+When a type has no base type (other than `System.Object` or `System.ValueType`) and no declared interface, inheritdoc has no source unless `cref` is specified.
+
+This rule reports `<inheritdoc />` on type declarations (`class`, `struct`, `interface`, `record`) when:
+- no `cref` is specified
+- there is no applicable base type
+- there are no declared interfaces
+
+````csharp
+// Non-compliant
+/// <inheritdoc />
+class Sample
+{
+}
+````
+
+````csharp
+// Compliant
+/// <summary>Represents a dedicated concept for this type.</summary>
+class Sample
+{
+}
+````

--- a/docs/Rules/MA0199.md
+++ b/docs/Rules/MA0199.md
@@ -1,6 +1,6 @@
 # MA0199 - Do not use inheritdoc on types without inheritance source
 <!-- sources -->
-Source: [InheritdocShouldNotBeUsedOnTypesAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzer.cs)
+Source: [InheritdocShouldHaveSourceOnTypesAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InheritdocShouldHaveSourceOnTypesAnalyzer.cs)
 <!-- sources -->
 
 `<inheritdoc />` requires an inheritance source.

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs
@@ -140,9 +140,6 @@ public sealed class InheritdocShouldNotBeUsedOnTypesFixer : CodeFixProvider
 
     private static string ToCrefValue(INamedTypeSymbol symbol)
     {
-        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
-                     .Replace("global::", "", StringComparison.Ordinal)
-                     .Replace('<', '{')
-                     .Replace('>', '}');
+        return DocumentationCommentId.CreateDeclarationId(symbol) ?? symbol.Name;
     }
 }

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs
@@ -1,0 +1,148 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class InheritdocShouldNotBeUsedOnTypesFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.InheritdocShouldNotBeAmbiguousOnTypes);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true, findInsideTrivia: true);
+        if (!TryGetInheritdocNode(nodeToFix, out var inheritdocNode, out var attributes))
+            return;
+
+        if (HasCrefAttribute(attributes))
+            return;
+
+        var typeDeclaration = nodeToFix?.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        if (typeDeclaration is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel?.GetDeclaredSymbol(typeDeclaration, context.CancellationToken) is not INamedTypeSymbol typeSymbol)
+            return;
+
+        if (HasBaseType(typeSymbol) || typeSymbol.Interfaces.Length <= 1)
+            return;
+
+        if (inheritdocNode is XmlEmptyElementSyntax emptyElement)
+        {
+            RegisterCodeFixes(context, typeSymbol.Interfaces, emptyElement);
+            return;
+        }
+
+        if (inheritdocNode is XmlElementStartTagSyntax startTag)
+        {
+            RegisterCodeFixes(context, typeSymbol.Interfaces, startTag);
+        }
+    }
+
+    private static void RegisterCodeFixes(CodeFixContext context, ImmutableArray<INamedTypeSymbol> interfaces, XmlEmptyElementSyntax inheritdocNode)
+    {
+        foreach (var interfaceSymbol in interfaces)
+        {
+            RegisterCodeFix(context, interfaceSymbol, cancellationToken => AddCrefAttribute(context.Document, inheritdocNode, interfaceSymbol, cancellationToken));
+        }
+    }
+
+    private static void RegisterCodeFixes(CodeFixContext context, ImmutableArray<INamedTypeSymbol> interfaces, XmlElementStartTagSyntax inheritdocNode)
+    {
+        foreach (var interfaceSymbol in interfaces)
+        {
+            RegisterCodeFix(context, interfaceSymbol, cancellationToken => AddCrefAttribute(context.Document, inheritdocNode, interfaceSymbol, cancellationToken));
+        }
+    }
+
+    private static void RegisterCodeFix(CodeFixContext context, INamedTypeSymbol interfaceSymbol, Func<CancellationToken, Task<Document>> createChangedDocument)
+    {
+        var interfaceDisplayName = interfaceSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        var crefValue = ToCrefValue(interfaceSymbol);
+        var title = $"Add cref=\"{interfaceDisplayName}\"";
+        var equivalenceKey = $"{title}:{crefValue}";
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title,
+                createChangedDocument,
+                equivalenceKey: equivalenceKey),
+            context.Diagnostics);
+    }
+
+    private static async Task<Document> AddCrefAttribute(Document document, XmlEmptyElementSyntax inheritdocNode, INamedTypeSymbol interfaceSymbol, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var newNode = inheritdocNode.WithAttributes(inheritdocNode.Attributes.Add(XmlTextAttribute("cref", ToCrefValue(interfaceSymbol))));
+        editor.ReplaceNode(inheritdocNode, newNode);
+        return editor.GetChangedDocument();
+    }
+
+    private static async Task<Document> AddCrefAttribute(Document document, XmlElementStartTagSyntax inheritdocNode, INamedTypeSymbol interfaceSymbol, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var newNode = inheritdocNode.WithAttributes(inheritdocNode.Attributes.Add(XmlTextAttribute("cref", ToCrefValue(interfaceSymbol))));
+        editor.ReplaceNode(inheritdocNode, newNode);
+        return editor.GetChangedDocument();
+    }
+
+    private static bool TryGetInheritdocNode(SyntaxNode? node, out SyntaxNode? inheritdocNode, out SyntaxList<XmlAttributeSyntax> attributes)
+    {
+        if (node?.FirstAncestorOrSelf<XmlEmptyElementSyntax>() is { } emptyElement && IsInheritdocElement(emptyElement.Name))
+        {
+            inheritdocNode = emptyElement;
+            attributes = emptyElement.Attributes;
+            return true;
+        }
+
+        if (node?.FirstAncestorOrSelf<XmlElementStartTagSyntax>() is { } startTag && IsInheritdocElement(startTag.Name))
+        {
+            inheritdocNode = startTag;
+            attributes = startTag.Attributes;
+            return true;
+        }
+
+        inheritdocNode = null;
+        attributes = default;
+        return false;
+    }
+
+    private static bool IsInheritdocElement(XmlNameSyntax name)
+    {
+        return string.Equals(name.LocalName.Text, "inheritdoc", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool HasCrefAttribute(SyntaxList<XmlAttributeSyntax> attributes)
+    {
+        foreach (var attribute in attributes)
+        {
+            if (string.Equals(attribute.Name.LocalName.Text, "cref", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasBaseType(INamedTypeSymbol symbol)
+    {
+        return symbol.BaseType is { SpecialType: not (SpecialType.System_Object or SpecialType.System_ValueType) };
+    }
+
+    private static string ToCrefValue(INamedTypeSymbol symbol)
+    {
+        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                     .Replace("global::", "", StringComparison.Ordinal)
+                     .Replace('<', '{')
+                     .Replace('>', '}');
+    }
+}

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs
@@ -140,6 +140,6 @@ public sealed class InheritdocShouldNotBeUsedOnTypesFixer : CodeFixProvider
 
     private static string ToCrefValue(INamedTypeSymbol symbol)
     {
-        return DocumentationCommentId.CreateDeclarationId(symbol) ?? symbol.Name;
+        return DocumentationCommentId.CreateReferenceId(symbol);
     }
 }

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -584,5 +584,11 @@ dotnet_diagnostic.MA0195.severity = error
 # MA0196: Do not use inheritdoc on non-inheriting members
 dotnet_diagnostic.MA0196.severity = error
 
-# MA0197: Do not use inheritdoc on types
+# MA0197: Add dedicated documentation on types
 dotnet_diagnostic.MA0197.severity = error
+
+# MA0198: Specify cref for ambiguous inheritdoc on types
+dotnet_diagnostic.MA0198.severity = error
+
+# MA0199: Do not use inheritdoc on types without inheritance source
+dotnet_diagnostic.MA0199.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -584,5 +584,11 @@ dotnet_diagnostic.MA0195.severity = suggestion
 # MA0196: Do not use inheritdoc on non-inheriting members
 dotnet_diagnostic.MA0196.severity = suggestion
 
-# MA0197: Do not use inheritdoc on types
+# MA0197: Add dedicated documentation on types
 dotnet_diagnostic.MA0197.severity = suggestion
+
+# MA0198: Specify cref for ambiguous inheritdoc on types
+dotnet_diagnostic.MA0198.severity = suggestion
+
+# MA0199: Do not use inheritdoc on types without inheritance source
+dotnet_diagnostic.MA0199.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -584,5 +584,11 @@ dotnet_diagnostic.MA0195.severity = warning
 # MA0196: Do not use inheritdoc on non-inheriting members
 dotnet_diagnostic.MA0196.severity = warning
 
-# MA0197: Do not use inheritdoc on types
+# MA0197: Add dedicated documentation on types
 dotnet_diagnostic.MA0197.severity = warning
+
+# MA0198: Specify cref for ambiguous inheritdoc on types
+dotnet_diagnostic.MA0198.severity = warning
+
+# MA0199: Do not use inheritdoc on types without inheritance source
+dotnet_diagnostic.MA0199.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -584,5 +584,11 @@ dotnet_diagnostic.MA0195.severity = warning
 # MA0196: Do not use inheritdoc on non-inheriting members
 dotnet_diagnostic.MA0196.severity = warning
 
-# MA0197: Do not use inheritdoc on types
-dotnet_diagnostic.MA0197.severity = warning
+# MA0197: Add dedicated documentation on types
+dotnet_diagnostic.MA0197.severity = suggestion
+
+# MA0198: Specify cref for ambiguous inheritdoc on types
+dotnet_diagnostic.MA0198.severity = warning
+
+# MA0199: Do not use inheritdoc on types without inheritance source
+dotnet_diagnostic.MA0199.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -584,5 +584,11 @@ dotnet_diagnostic.MA0195.severity = none
 # MA0196: Do not use inheritdoc on non-inheriting members
 dotnet_diagnostic.MA0196.severity = none
 
-# MA0197: Do not use inheritdoc on types
+# MA0197: Add dedicated documentation on types
 dotnet_diagnostic.MA0197.severity = none
+
+# MA0198: Specify cref for ambiguous inheritdoc on types
+dotnet_diagnostic.MA0198.severity = none
+
+# MA0199: Do not use inheritdoc on types without inheritance source
+dotnet_diagnostic.MA0199.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -197,6 +197,8 @@ internal static class RuleIdentifiers
     public const string DoNotUseNotYetInitializedStaticField = "MA0195";
     public const string InheritdocShouldBeUsedOnInheritingMember = "MA0196";
     public const string InheritdocShouldNotBeUsedOnTypes = "MA0197";
+    public const string InheritdocShouldNotBeAmbiguousOnTypes = "MA0198";
+    public const string InheritdocShouldHaveSourceOnTypes = "MA0199";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/InheritdocOnTypesAnalyzerHelper.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocOnTypesAnalyzerHelper.cs
@@ -1,0 +1,76 @@
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Analyzer.Rules;
+
+internal static class InheritdocOnTypesAnalyzerHelper
+{
+    public static void Analyze(SymbolAnalysisContext context, Func<bool, int, bool> shouldReportDiagnostic, DiagnosticDescriptor rule)
+    {
+        if (context.Symbol is not INamedTypeSymbol symbol)
+            return;
+
+        if (symbol.IsImplicitlyDeclared || symbol.TypeKind is not (TypeKind.Class or TypeKind.Struct or TypeKind.Interface))
+            return;
+
+        if (symbol.IsImplicitClass || symbol.Name.Contains('$', StringComparison.Ordinal))
+            return;
+
+        var hasBaseType = HasBaseType(symbol);
+        var interfaceCount = symbol.Interfaces.Length;
+        if (!shouldReportDiagnostic(hasBaseType, interfaceCount))
+            return;
+
+        foreach (var syntaxReference in symbol.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+            if (!syntax.HasStructuredTrivia)
+                continue;
+
+            foreach (var trivia in syntax.GetLeadingTrivia())
+            {
+                if (trivia.GetStructure() is not DocumentationCommentTriviaSyntax documentation)
+                    continue;
+
+                foreach (var element in documentation.DescendantNodes().OfType<XmlEmptyElementSyntax>())
+                {
+                    if (!IsInheritdocElement(element.Name) || HasCrefAttribute(element.Attributes))
+                        continue;
+
+                    context.ReportDiagnostic(rule, element);
+                }
+
+                foreach (var element in documentation.DescendantNodes().OfType<XmlElementSyntax>())
+                {
+                    if (!IsInheritdocElement(element.StartTag.Name) || HasCrefAttribute(element.StartTag.Attributes))
+                        continue;
+
+                    context.ReportDiagnostic(rule, element.StartTag);
+                }
+            }
+        }
+    }
+
+    private static bool HasBaseType(INamedTypeSymbol symbol)
+    {
+        return symbol.BaseType is { SpecialType: not (SpecialType.System_Object or SpecialType.System_ValueType) };
+    }
+
+    private static bool IsInheritdocElement(XmlNameSyntax name)
+    {
+        return string.Equals(name.LocalName.Text, "inheritdoc", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool HasCrefAttribute(SyntaxList<XmlAttributeSyntax> attributes)
+    {
+        foreach (var attribute in attributes)
+        {
+            if (string.Equals(attribute.Name.LocalName.Text, "cref", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldHaveSourceOnTypesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldHaveSourceOnTypesAnalyzer.cs
@@ -24,9 +24,9 @@ public sealed class InheritdocShouldHaveSourceOnTypesAnalyzer : DiagnosticAnalyz
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSymbolAction(static context =>
+        context.RegisterSymbolAction(context =>
         {
-            InheritdocOnTypesAnalyzerHelper.Analyze(context, static (hasBaseType, interfaceCount) => !hasBaseType && interfaceCount == 0, Rule);
+            InheritdocOnTypesAnalyzerHelper.Analyze(context, (hasBaseType, interfaceCount) => !hasBaseType && interfaceCount == 0, Rule);
         }, SymbolKind.NamedType);
     }
 }

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldHaveSourceOnTypesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldHaveSourceOnTypesAnalyzer.cs
@@ -5,17 +5,17 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzer : DiagnosticAnalyzer
+public sealed class InheritdocShouldHaveSourceOnTypesAnalyzer : DiagnosticAnalyzer
 {
     private static readonly DiagnosticDescriptor Rule = new(
-        RuleIdentifiers.InheritdocShouldNotBeUsedOnTypes,
-        title: "Add dedicated documentation on types",
-        messageFormat: "A type should have dedicated documentation instead of '<inheritdoc />'",
+        RuleIdentifiers.InheritdocShouldHaveSourceOnTypes,
+        title: "Do not use inheritdoc on types without inheritance source",
+        messageFormat: "Do not use '<inheritdoc />' without 'cref' when this type has no base type and no declared interfaces",
         RuleCategories.Design,
-        DiagnosticSeverity.Info,
+        DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "",
-        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InheritdocShouldNotBeUsedOnTypes));
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InheritdocShouldHaveSourceOnTypes));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -26,7 +26,7 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzer : DiagnosticAnalyze
 
         context.RegisterSymbolAction(static context =>
         {
-            InheritdocOnTypesAnalyzerHelper.Analyze(context, static (hasBaseType, interfaceCount) => hasBaseType || interfaceCount == 1, Rule);
+            InheritdocOnTypesAnalyzerHelper.Analyze(context, static (hasBaseType, interfaceCount) => !hasBaseType && interfaceCount == 0, Rule);
         }, SymbolKind.NamedType);
     }
 }

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzer.cs
@@ -5,17 +5,17 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzer : DiagnosticAnalyzer
+public sealed class InheritdocShouldNotBeAmbiguousOnTypesAnalyzer : DiagnosticAnalyzer
 {
     private static readonly DiagnosticDescriptor Rule = new(
-        RuleIdentifiers.InheritdocShouldNotBeUsedOnTypes,
-        title: "Add dedicated documentation on types",
-        messageFormat: "A type should have dedicated documentation instead of '<inheritdoc />'",
+        RuleIdentifiers.InheritdocShouldNotBeAmbiguousOnTypes,
+        title: "Specify cref for ambiguous inheritdoc on types",
+        messageFormat: "Specify 'cref' for '<inheritdoc />' because this type has multiple declared interfaces and no base type",
         RuleCategories.Design,
-        DiagnosticSeverity.Info,
+        DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "",
-        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InheritdocShouldNotBeUsedOnTypes));
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InheritdocShouldNotBeAmbiguousOnTypes));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -26,7 +26,7 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzer : DiagnosticAnalyze
 
         context.RegisterSymbolAction(static context =>
         {
-            InheritdocOnTypesAnalyzerHelper.Analyze(context, static (hasBaseType, interfaceCount) => hasBaseType || interfaceCount == 1, Rule);
+            InheritdocOnTypesAnalyzerHelper.Analyze(context, static (hasBaseType, interfaceCount) => !hasBaseType && interfaceCount > 1, Rule);
         }, SymbolKind.NamedType);
     }
 }

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzer.cs
@@ -24,9 +24,9 @@ public sealed class InheritdocShouldNotBeAmbiguousOnTypesAnalyzer : DiagnosticAn
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSymbolAction(static context =>
+        context.RegisterSymbolAction(context =>
         {
-            InheritdocOnTypesAnalyzerHelper.Analyze(context, static (hasBaseType, interfaceCount) => !hasBaseType && interfaceCount > 1, Rule);
+            InheritdocOnTypesAnalyzerHelper.Analyze(context, (hasBaseType, interfaceCount) => !hasBaseType && interfaceCount > 1, Rule);
         }, SymbolKind.NamedType);
     }
 }

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzer.cs
@@ -11,15 +11,35 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzer : DiagnosticAnalyze
 {
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.InheritdocShouldNotBeUsedOnTypes,
-        title: "Do not use inheritdoc on types",
-        messageFormat: "Do not use '<inheritdoc />' on types; use it on members only",
+        title: "Add dedicated documentation on types",
+        messageFormat: "A type should have dedicated documentation instead of '<inheritdoc />'",
         RuleCategories.Design,
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Info,
         isEnabledByDefault: true,
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InheritdocShouldNotBeUsedOnTypes));
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    private static readonly DiagnosticDescriptor AmbiguousInheritdocRule = new(
+        RuleIdentifiers.InheritdocShouldNotBeAmbiguousOnTypes,
+        title: "Specify cref for ambiguous inheritdoc on types",
+        messageFormat: "Specify 'cref' for '<inheritdoc />' because this type has multiple declared interfaces and no base type",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InheritdocShouldNotBeAmbiguousOnTypes));
+
+    private static readonly DiagnosticDescriptor InheritdocWithoutSourceRule = new(
+        RuleIdentifiers.InheritdocShouldHaveSourceOnTypes,
+        title: "Do not use inheritdoc on types without inheritance source",
+        messageFormat: "Do not use '<inheritdoc />' without 'cref' when this type has no base type and no declared interfaces",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InheritdocShouldHaveSourceOnTypes));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule, AmbiguousInheritdocRule, InheritdocWithoutSourceRule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -40,6 +60,9 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzer : DiagnosticAnalyze
         if (symbol.IsImplicitClass || symbol.Name.Contains('$', StringComparison.Ordinal))
             return;
 
+        var hasBaseType = HasBaseType(symbol);
+        var interfaceCount = symbol.Interfaces.Length;
+
         foreach (var syntaxReference in symbol.DeclaringSyntaxReferences)
         {
             var syntax = syntaxReference.GetSyntax(context.CancellationToken);
@@ -56,7 +79,7 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzer : DiagnosticAnalyze
                     if (!IsInheritdocElement(element.Name) || HasCrefAttribute(element.Attributes))
                         continue;
 
-                    context.ReportDiagnostic(Rule, element);
+                    ReportInheritdocDiagnostic(context, element, hasBaseType, interfaceCount);
                 }
 
                 foreach (var element in documentation.DescendantNodes().OfType<XmlElementSyntax>())
@@ -64,10 +87,35 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzer : DiagnosticAnalyze
                     if (!IsInheritdocElement(element.StartTag.Name) || HasCrefAttribute(element.StartTag.Attributes))
                         continue;
 
-                    context.ReportDiagnostic(Rule, element.StartTag);
+                    ReportInheritdocDiagnostic(context, element.StartTag, hasBaseType, interfaceCount);
                 }
             }
         }
+    }
+
+    private static void ReportInheritdocDiagnostic(SymbolAnalysisContext context, SyntaxNode syntaxNode, bool hasBaseType, int interfaceCount)
+    {
+        if (!hasBaseType)
+        {
+            if (interfaceCount == 0)
+            {
+                context.ReportDiagnostic(InheritdocWithoutSourceRule, syntaxNode);
+                return;
+            }
+
+            if (interfaceCount > 1)
+            {
+                context.ReportDiagnostic(AmbiguousInheritdocRule, syntaxNode);
+                return;
+            }
+        }
+
+        context.ReportDiagnostic(Rule, syntaxNode);
+    }
+
+    private static bool HasBaseType(INamedTypeSymbol symbol)
+    {
+        return symbol.BaseType is { SpecialType: not (SpecialType.System_Object or SpecialType.System_ValueType) };
     }
 
     private static bool IsInheritdocElement(XmlNameSyntax name)

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldHaveSourceOnTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldHaveSourceOnTypesAnalyzerTests.cs
@@ -56,4 +56,96 @@ public sealed class InheritdocShouldHaveSourceOnTypesAnalyzerTests
                   """)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenBaseTypeIsPresent()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class BaseClass
+                  {
+                  }
+
+                  /// <inheritdoc />
+                  class Sample : BaseClass
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenCrefIsPresent()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  /// <inheritdoc cref="object" />
+                  class Sample
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenInterfaceInheritsAnotherInterface()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  interface IBase
+                  {
+                  }
+
+                  /// <inheritdoc />
+                  interface IChild : IBase
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenRecordInheritsBaseRecord()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  record BaseRecord;
+
+                  /// <inheritdoc />
+                  record Sample : BaseRecord;
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenStructImplementsInterface()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  interface ITest
+                  {
+                  }
+
+                  /// <inheritdoc />
+                  struct Sample : ITest
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenRecordStructImplementsInterface()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  interface ITest
+                  {
+                  }
+
+                  /// <inheritdoc />
+                  record struct Sample : ITest;
+                  """)
+              .ValidateAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldHaveSourceOnTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldHaveSourceOnTypesAnalyzerTests.cs
@@ -1,0 +1,59 @@
+using Meziantou.Analyzer.Rules;
+using Meziantou.Analyzer.Test.Helpers;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class InheritdocShouldHaveSourceOnTypesAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<InheritdocShouldHaveSourceOnTypesAnalyzer>()
+            .WithTargetFramework(TargetFramework.NetLatest);
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_MA0199_WhenNoBaseTypeAndNoDeclaredInterface()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  /// {|MA0199:<inheritdoc />|}
+                  class Sample
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_MA0199_WhenInterfaceHasNoBaseInterface()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  /// {|MA0199:<inheritdoc />|}
+                  interface ITest
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_ForEachPartialDeclaration()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  /// {|MA0199:<inheritdoc />|}
+                  partial class Sample
+                  {
+                  }
+
+                  /// {|MA0199:<inheritdoc />|}
+                  partial class Sample
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests.cs
@@ -1,0 +1,147 @@
+using Meziantou.Analyzer.Rules;
+using Meziantou.Analyzer.Test.Helpers;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<InheritdocShouldNotBeAmbiguousOnTypesAnalyzer>()
+            .WithTargetFramework(TargetFramework.NetLatest);
+    }
+
+    private static ProjectBuilder CreateProjectBuilderWithCodeFixProvider()
+    {
+        return CreateProjectBuilder()
+            .WithCodeFixProvider<InheritdocShouldNotBeUsedOnTypesFixer>();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_MA0198_WhenMultipleDeclaredInterfacesArePresentAndNoBaseType()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// {|MA0198:<inheritdoc />|}
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_MA0198_EmptyElement_FirstInterface()
+    {
+        await CreateProjectBuilderWithCodeFixProvider()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// {|MA0198:<inheritdoc />|}
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ShouldFixCodeWith(index: 0, """
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// <inheritdoc cref="T:IInterface1" />
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_MA0198_EmptyElement_SecondInterface()
+    {
+        await CreateProjectBuilderWithCodeFixProvider()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// {|MA0198:<inheritdoc />|}
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ShouldFixCodeWith(index: 1, """
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// <inheritdoc cref="T:IInterface2" />
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_MA0198_XmlElement()
+    {
+        await CreateProjectBuilderWithCodeFixProvider()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// {|MA0198:<inheritdoc>|}</inheritdoc>
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ShouldFixCodeWith(index: 1, """
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// <inheritdoc cref="T:IInterface2"></inheritdoc>
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests.cs
@@ -67,7 +67,7 @@ public sealed class InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests
                   {
                   }
 
-                  /// <inheritdoc cref="T:IInterface1" />
+                  /// <inheritdoc cref="IInterface1" />
                   class Sample : IInterface1, IInterface2
                   {
                   }
@@ -102,7 +102,7 @@ public sealed class InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests
                   {
                   }
 
-                  /// <inheritdoc cref="T:IInterface2" />
+                  /// <inheritdoc cref="IInterface2" />
                   class Sample : IInterface1, IInterface2
                   {
                   }
@@ -137,7 +137,70 @@ public sealed class InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests
                   {
                   }
 
-                  /// <inheritdoc cref="T:IInterface2"></inheritdoc>
+                  /// <inheritdoc cref="IInterface2"></inheritdoc>
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenSingleDeclaredInterfaceIsPresent()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  /// <inheritdoc />
+                  class Sample : IInterface1
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenBaseTypeIsPresent()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class BaseClass
+                  {
+                  }
+
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// <inheritdoc />
+                  class Sample : BaseClass, IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenCrefIsPresent()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// <inheritdoc cref="T:IInterface1" />
                   class Sample : IInterface1, IInterface2
                   {
                   }

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzerTests.cs
@@ -13,13 +13,65 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzerTests
             .WithTargetFramework(TargetFramework.NetLatest);
     }
 
+    private static ProjectBuilder CreateProjectBuilderWithCodeFixProvider()
+    {
+        return CreateProjectBuilder()
+            .WithCodeFixProvider<InheritdocShouldNotBeUsedOnTypesFixer>();
+    }
+
     [Fact]
-    public async Task ReportDiagnostic_Class()
+    public async Task ReportDiagnostic_MA0197_WhenBaseTypeIsPresent()
     {
         await CreateProjectBuilder()
               .WithSourceCode("""
-                  /// [|<inheritdoc />|]
-                  class Sample
+                  class BaseType
+                  {
+                  }
+
+                  /// {|MA0197:<inheritdoc />|}
+                  class Sample : BaseType
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_MA0197_WhenSingleDeclaredInterfaceIsPresent()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  interface ITest
+                  {
+                  }
+
+                  /// {|MA0197:<inheritdoc />|}
+                  class Sample : ITest
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_MA0197_WhenDeclaredInterfaceInheritsMultipleInterfaces()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  interface ICompositeInterface : IInterface1, IInterface2
+                  {
+                  }
+
+                  /// {|MA0197:<inheritdoc />|}
+                  class Sample : ICompositeInterface
                   {
                   }
                   """)
@@ -53,11 +105,45 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzerTests
     }
 
     [Fact]
-    public async Task ReportDiagnostic_Interface()
+    public async Task ReportDiagnostic_MA0198_WhenMultipleDeclaredInterfacesArePresentAndNoBaseType()
     {
         await CreateProjectBuilder()
               .WithSourceCode("""
-                  /// [|<inheritdoc />|]
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// {|MA0198:<inheritdoc />|}
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_MA0199_WhenNoBaseTypeAndNoDeclaredInterface()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  /// {|MA0199:<inheritdoc />|}
+                  class Sample
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_MA0199_WhenInterfaceHasNoBaseInterface()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  /// {|MA0199:<inheritdoc />|}
                   interface ITest
                   {
                   }
@@ -84,13 +170,118 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzerTests
     {
         await CreateProjectBuilder()
               .WithSourceCode("""
-                  /// [|<inheritdoc />|]
+                  /// {|MA0199:<inheritdoc />|}
                   partial class Sample
                   {
                   }
 
-                  /// [|<inheritdoc />|]
+                  /// {|MA0199:<inheritdoc />|}
                   partial class Sample
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_MA0198_EmptyElement_FirstInterface()
+    {
+        await CreateProjectBuilderWithCodeFixProvider()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// {|MA0198:<inheritdoc />|}
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ShouldFixCodeWith(index: 0, """
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// <inheritdoc cref="IInterface1" />
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_MA0198_EmptyElement_SecondInterface()
+    {
+        await CreateProjectBuilderWithCodeFixProvider()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// {|MA0198:<inheritdoc />|}
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ShouldFixCodeWith(index: 1, """
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// <inheritdoc cref="IInterface2" />
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_MA0198_XmlElement()
+    {
+        await CreateProjectBuilderWithCodeFixProvider()
+              .WithSourceCode("""
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// {|MA0198:<inheritdoc>|}</inheritdoc>
+                  class Sample : IInterface1, IInterface2
+                  {
+                  }
+                  """)
+              .ShouldFixCodeWith(index: 1, """
+                  interface IInterface1
+                  {
+                  }
+
+                  interface IInterface2
+                  {
+                  }
+
+                  /// <inheritdoc cref="IInterface2"></inheritdoc>
+                  class Sample : IInterface1, IInterface2
                   {
                   }
                   """)

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzerTests.cs
@@ -13,12 +13,6 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzerTests
             .WithTargetFramework(TargetFramework.NetLatest);
     }
 
-    private static ProjectBuilder CreateProjectBuilderWithCodeFixProvider()
-    {
-        return CreateProjectBuilder()
-            .WithCodeFixProvider<InheritdocShouldNotBeUsedOnTypesFixer>();
-    }
-
     [Fact]
     public async Task ReportDiagnostic_MA0197_WhenBaseTypeIsPresent()
     {
@@ -105,53 +99,6 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzerTests
     }
 
     [Fact]
-    public async Task ReportDiagnostic_MA0198_WhenMultipleDeclaredInterfacesArePresentAndNoBaseType()
-    {
-        await CreateProjectBuilder()
-              .WithSourceCode("""
-                  interface IInterface1
-                  {
-                  }
-
-                  interface IInterface2
-                  {
-                  }
-
-                  /// {|MA0198:<inheritdoc />|}
-                  class Sample : IInterface1, IInterface2
-                  {
-                  }
-                  """)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task ReportDiagnostic_MA0199_WhenNoBaseTypeAndNoDeclaredInterface()
-    {
-        await CreateProjectBuilder()
-              .WithSourceCode("""
-                  /// {|MA0199:<inheritdoc />|}
-                  class Sample
-                  {
-                  }
-                  """)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task ReportDiagnostic_MA0199_WhenInterfaceHasNoBaseInterface()
-    {
-        await CreateProjectBuilder()
-              .WithSourceCode("""
-                  /// {|MA0199:<inheritdoc />|}
-                  interface ITest
-                  {
-                  }
-                  """)
-              .ValidateAsync();
-    }
-
-    [Fact]
     public async Task NoDiagnostic_WhenUsedOnMember()
     {
         await CreateProjectBuilder()
@@ -160,129 +107,6 @@ public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzerTests
                   {
                       /// <inheritdoc />
                       public override string ToString() => base.ToString();
-                  }
-                  """)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task ReportDiagnostic_ForEachPartialDeclaration()
-    {
-        await CreateProjectBuilder()
-              .WithSourceCode("""
-                  /// {|MA0199:<inheritdoc />|}
-                  partial class Sample
-                  {
-                  }
-
-                  /// {|MA0199:<inheritdoc />|}
-                  partial class Sample
-                  {
-                  }
-                  """)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task CodeFix_MA0198_EmptyElement_FirstInterface()
-    {
-        await CreateProjectBuilderWithCodeFixProvider()
-              .WithSourceCode("""
-                  interface IInterface1
-                  {
-                  }
-
-                  interface IInterface2
-                  {
-                  }
-
-                  /// {|MA0198:<inheritdoc />|}
-                  class Sample : IInterface1, IInterface2
-                  {
-                  }
-                  """)
-              .ShouldFixCodeWith(index: 0, """
-                  interface IInterface1
-                  {
-                  }
-
-                  interface IInterface2
-                  {
-                  }
-
-                  /// <inheritdoc cref="IInterface1" />
-                  class Sample : IInterface1, IInterface2
-                  {
-                  }
-                  """)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task CodeFix_MA0198_EmptyElement_SecondInterface()
-    {
-        await CreateProjectBuilderWithCodeFixProvider()
-              .WithSourceCode("""
-                  interface IInterface1
-                  {
-                  }
-
-                  interface IInterface2
-                  {
-                  }
-
-                  /// {|MA0198:<inheritdoc />|}
-                  class Sample : IInterface1, IInterface2
-                  {
-                  }
-                  """)
-              .ShouldFixCodeWith(index: 1, """
-                  interface IInterface1
-                  {
-                  }
-
-                  interface IInterface2
-                  {
-                  }
-
-                  /// <inheritdoc cref="IInterface2" />
-                  class Sample : IInterface1, IInterface2
-                  {
-                  }
-                  """)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task CodeFix_MA0198_XmlElement()
-    {
-        await CreateProjectBuilderWithCodeFixProvider()
-              .WithSourceCode("""
-                  interface IInterface1
-                  {
-                  }
-
-                  interface IInterface2
-                  {
-                  }
-
-                  /// {|MA0198:<inheritdoc>|}</inheritdoc>
-                  class Sample : IInterface1, IInterface2
-                  {
-                  }
-                  """)
-              .ShouldFixCodeWith(index: 1, """
-                  interface IInterface1
-                  {
-                  }
-
-                  interface IInterface2
-                  {
-                  }
-
-                  /// <inheritdoc cref="IInterface2"></inheritdoc>
-                  class Sample : IInterface1, IInterface2
-                  {
                   }
                   """)
               .ValidateAsync();


### PR DESCRIPTION
Type-level `<inheritdoc />` usage needed more precise guidance than a single warning. This change separates recommendation, ambiguity, and invalid-source cases so users get the right severity and actionable fixes.

## What changed
- Kept `MA0197` for type `<inheritdoc />`, but changed it to a suggestion with messaging focused on writing dedicated type documentation.
- Added `MA0198` as a warning for ambiguous type inheritdoc when there is no base type and multiple declared interfaces.
- Added `MA0199` as a warning for type inheritdoc with no `cref`, no base type, and no declared interfaces.
- Added a code fix for `MA0198` that offers one `cref` option per declared interface.
- Expanded analyzer/code-fix tests and updated rule docs (`MA0197`, new `MA0198`, new `MA0199`).
- Regenerated repository documentation/config outputs (`README.md`, `docs/README.md`, and analyzer pack editorconfig files).

## Notes for review
- "No base type" is treated as `System.Object` or `System.ValueType`.
- Ambiguity logic only considers declared interfaces (`INamedTypeSymbol.Interfaces`), not interfaces inherited through those interfaces.