### PR TITLE
Optimize analyzer hot paths and metadata lookups

### DIFF
--- a/src/Meziantou.Analyzer/Internals/ContextExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/ContextExtensions.cs
@@ -17,8 +17,17 @@ internal static partial class ContextExtensions
     public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, locations, messageArgs);
     public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs)
     {
-        var inSource = locations.Where(l => l.IsInSource);
-        if (!inSource.Any())
+        List<Location>? inSourceLocations = null;
+        foreach (var location in locations)
+        {
+            if (!location.IsInSource)
+                continue;
+
+            inSourceLocations ??= [];
+            inSourceLocations.Add(location);
+        }
+
+        if (inSourceLocations is null)
         {
             context.ReportDiagnostic(CreateDiagnostic(descriptor, location: null, properties, messageArgs));
             return;
@@ -26,12 +35,20 @@ internal static partial class ContextExtensions
 
         var diagnostic = Diagnostic.Create(
                  descriptor,
-                 location: inSource.First(),
-                 additionalLocations: inSource.Skip(1),
+                 location: inSourceLocations[0],
+                 additionalLocations: inSourceLocations.Count > 1 ? GetAdditionalLocations(inSourceLocations) : null,
                  properties: properties,
                  messageArgs: messageArgs);
 
         context.ReportDiagnostic(diagnostic);
+
+        static IEnumerable<Location> GetAdditionalLocations(List<Location> locations)
+        {
+            for (var i = 1; i < locations.Count; i++)
+            {
+                yield return locations[i];
+            }
+        }
     }
 
     public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, SyntaxReference syntaxReference, object?[]? messageArgs = null)

--- a/src/Meziantou.Analyzer/Internals/MethodSymbolExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/MethodSymbolExtensions.cs
@@ -39,24 +39,24 @@ internal static class MethodSymbolExtensions
 
     public static IPropertySymbol? GetImplementingInterfaceSymbol(this IPropertySymbol symbol)
     {
-        if (symbol.ExplicitInterfaceImplementations.Any())
-            return symbol.ExplicitInterfaceImplementations.First();
+        if (symbol.ExplicitInterfaceImplementations.Length > 0)
+            return symbol.ExplicitInterfaceImplementations[0];
 
         return (IPropertySymbol?)GetImplementingInterfaceSymbol((ISymbol)symbol);
     }
 
     public static IEventSymbol? GetImplementingInterfaceSymbol(this IEventSymbol symbol)
     {
-        if (symbol.ExplicitInterfaceImplementations.Any())
-            return symbol.ExplicitInterfaceImplementations.First();
+        if (symbol.ExplicitInterfaceImplementations.Length > 0)
+            return symbol.ExplicitInterfaceImplementations[0];
 
         return (IEventSymbol?)GetImplementingInterfaceSymbol((ISymbol)symbol);
     }
 
     public static IMethodSymbol? GetImplementingInterfaceSymbol(this IMethodSymbol symbol)
     {
-        if (symbol.ExplicitInterfaceImplementations.Any())
-            return symbol.ExplicitInterfaceImplementations.First();
+        if (symbol.ExplicitInterfaceImplementations.Length > 0)
+            return symbol.ExplicitInterfaceImplementations[0];
 
         return (IMethodSymbol?)GetImplementingInterfaceSymbol((ISymbol)symbol);
     }

--- a/src/Meziantou.Analyzer/Internals/RegexCache.cs
+++ b/src/Meziantou.Analyzer/Internals/RegexCache.cs
@@ -1,0 +1,14 @@
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+
+namespace Meziantou.Analyzer.Internals;
+
+internal static class RegexCache
+{
+    private static readonly ConcurrentDictionary<(string Pattern, RegexOptions Options, long TimeoutTicks), Regex> Cache = new();
+
+    public static Regex GetOrCreate(string pattern, RegexOptions options, TimeSpan timeout)
+    {
+        return Cache.GetOrAdd((pattern, options, timeout.Ticks), static key => new Regex(key.Pattern, key.Options, TimeSpan.FromTicks(key.TimeoutTicks)));
+    }
+}

--- a/src/Meziantou.Analyzer/Internals/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/TypeSymbolExtensions.cs
@@ -45,7 +45,13 @@ internal static class TypeSymbolExtensions
         if (interfaceType is null)
             return false;
 
-        return classSymbol.AllInterfaces.Any(interfaceType.IsEqualTo);
+        foreach (var @interface in classSymbol.AllInterfaces)
+        {
+            if (@interface.IsEqualTo(interfaceType))
+                return true;
+        }
+
+        return false;
     }
 
     public static bool ImplementsGenericInterface(this ITypeSymbol classSymbol, ITypeSymbol? interfaceType)
@@ -53,7 +59,13 @@ internal static class TypeSymbolExtensions
         if (interfaceType is null)
             return false;
 
-        return classSymbol.AllInterfaces.Any(iface => iface.OriginalDefinition.IsEqualTo(interfaceType.OriginalDefinition));
+        foreach (var iface in classSymbol.AllInterfaces)
+        {
+            if (iface.OriginalDefinition.IsEqualTo(interfaceType.OriginalDefinition))
+                return true;
+        }
+
+        return false;
     }
 
     public static bool IsOrImplements(this ITypeSymbol symbol, ITypeSymbol? interfaceType)
@@ -61,7 +73,16 @@ internal static class TypeSymbolExtensions
         if (interfaceType is null)
             return false;
 
-        return GetAllInterfacesIncludingThis(symbol).Any(interfaceType.IsEqualTo);
+        if (symbol is INamedTypeSymbol { TypeKind: TypeKind.Interface } interfaceSymbol && interfaceSymbol.IsEqualTo(interfaceType))
+            return true;
+
+        foreach (var @interface in symbol.AllInterfaces)
+        {
+            if (@interface.IsEqualTo(interfaceType))
+                return true;
+        }
+
+        return false;
     }
 
     public static IEnumerable<AttributeData> GetAttributes(this ISymbol symbol, ITypeSymbol? attributeType, bool inherits = true)
@@ -95,7 +116,30 @@ internal static class TypeSymbolExtensions
 
     public static AttributeData? GetAttribute(this ISymbol symbol, ITypeSymbol? attributeType, bool inherits = true)
     {
-        return GetAttributes(symbol, attributeType, inherits).FirstOrDefault();
+        if (attributeType is null)
+            return null;
+
+        if (attributeType.IsSealed)
+            inherits = false;
+
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (attribute.AttributeClass is null)
+                continue;
+
+            if (inherits)
+            {
+                if (attribute.AttributeClass.IsOrInheritFrom(attributeType))
+                    return attribute;
+            }
+            else
+            {
+                if (attributeType.IsEqualTo(attribute.AttributeClass))
+                    return attribute;
+            }
+        }
+
+        return null;
     }
 
     public static bool HasAttribute(this ISymbol symbol, ITypeSymbol? attributeType, bool inherits = true)

--- a/src/Meziantou.Analyzer/Rules/AddOverloadWithSpanOrMemoryAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AddOverloadWithSpanOrMemoryAnalyzer.cs
@@ -31,74 +31,8 @@ public sealed class AddOverloadWithSpanOrMemoryAnalyzer : DiagnosticAnalyzer
             if (!analyzerContext.IsValid)
                 return;
 
-            compilationContext.RegisterSymbolAction(context => AnalyzeMethod(context, analyzerContext), SymbolKind.Method);
+            compilationContext.RegisterSymbolAction(analyzerContext.AnalyzeMethod, SymbolKind.Method);
         });
-    }
-
-    private static void AnalyzeMethod(SymbolAnalysisContext context, AnalyzerContext analyzerContext)
-    {
-        var method = (IMethodSymbol)context.Symbol;
-        if (method.IsImplicitlyDeclared || method.IsOverrideOrInterfaceImplementation())
-            return;
-
-        if (!method.IsVisibleOutsideOfAssembly())
-            return;
-
-        if (method.MethodKind is not MethodKind.Ordinary and not MethodKind.Constructor)
-            return;
-
-        // Skip the program entry point (e.g., Main(string[] args)) as the signature is mandated by the runtime
-        if (method.IsEqualTo(context.Compilation.GetEntryPoint(context.CancellationToken)))
-            return;
-
-        if (!method.Parameters.Any(IsCandidateForSpanOrMemory))
-            return;
-
-        var overloads = method.ContainingType.GetMembers(method.Name);
-        foreach (var overload in overloads.OfType<IMethodSymbol>())
-        {
-            if (IsValidOverload(analyzerContext, method, overload))
-                return;
-        }
-
-        context.ReportDiagnostic(Rule, method);
-    }
-
-    private static bool IsCandidateForSpanOrMemory(IParameterSymbol param)
-    {
-        return param.Type.TypeKind is TypeKind.Array && !param.IsParams && param.RefKind is RefKind.None;
-    }
-
-    private static bool IsValidOverload(AnalyzerContext analyzerContext, IMethodSymbol method, IMethodSymbol overload)
-    {
-        if (overload.IsEqualTo(method))
-            return false;
-
-        if (overload.Parameters.Length != method.Parameters.Length)
-            return false;
-
-        for (var i = 0; i < method.Parameters.Length; i++)
-        {
-            var methodParameter = method.Parameters[i].Type;
-            var overloadParameter = overload.Parameters[i].Type;
-
-            var methodParameterIsArray = methodParameter.TypeKind == TypeKind.Array;
-            if (methodParameterIsArray)
-            {
-                if (!IsCandidateForSpanOrMemory(method.Parameters[i]) && methodParameter.IsEqualTo(overloadParameter))
-                    continue;
-
-                if (!analyzerContext.IsSpanOrMemory(overloadParameter, methodParameter))
-                    return false;
-            }
-            else
-            {
-                if (!methodParameter.IsEqualTo(overloadParameter))
-                    return false;
-            }
-        }
-
-        return true;
     }
 
     private sealed class AnalyzerContext(Compilation compilation)
@@ -109,6 +43,35 @@ public sealed class AddOverloadWithSpanOrMemoryAnalyzer : DiagnosticAnalyzer
         private readonly INamedTypeSymbol? _readOnlyMemoryType = compilation.GetBestTypeByMetadataName("System.ReadOnlyMemory`1");
 
         public bool IsValid => _spanType is not null || _readOnlySpanType is not null || _memoryType is not null || _readOnlyMemoryType is not null;
+
+        public void AnalyzeMethod(SymbolAnalysisContext context)
+        {
+            var method = (IMethodSymbol)context.Symbol;
+            if (method.IsImplicitlyDeclared || method.IsOverrideOrInterfaceImplementation())
+                return;
+
+            if (!method.IsVisibleOutsideOfAssembly())
+                return;
+
+            if (method.MethodKind is not MethodKind.Ordinary and not MethodKind.Constructor)
+                return;
+
+            // Skip the program entry point (e.g., Main(string[] args)) as the signature is mandated by the runtime
+            if (method.IsEqualTo(context.Compilation.GetEntryPoint(context.CancellationToken)))
+                return;
+
+            if (!method.Parameters.Any(IsCandidateForSpanOrMemory))
+                return;
+
+            var overloads = method.ContainingType.GetMembers(method.Name);
+            foreach (var overload in overloads.OfType<IMethodSymbol>())
+            {
+                if (IsValidOverload(method, overload))
+                    return;
+            }
+
+            context.ReportDiagnostic(Rule, method);
+        }
 
         public bool IsSpanOrMemory(ITypeSymbol typeSymbol, ITypeSymbol arrayType)
         {
@@ -135,6 +98,43 @@ public sealed class AddOverloadWithSpanOrMemoryAnalyzer : DiagnosticAnalyzer
                 return true;
 
             return false;
+        }
+
+        private static bool IsCandidateForSpanOrMemory(IParameterSymbol param)
+        {
+            return param.Type.TypeKind is TypeKind.Array && !param.IsParams && param.RefKind is RefKind.None;
+        }
+
+        private bool IsValidOverload(IMethodSymbol method, IMethodSymbol overload)
+        {
+            if (overload.IsEqualTo(method))
+                return false;
+
+            if (overload.Parameters.Length != method.Parameters.Length)
+                return false;
+
+            for (var i = 0; i < method.Parameters.Length; i++)
+            {
+                var methodParameter = method.Parameters[i].Type;
+                var overloadParameter = overload.Parameters[i].Type;
+
+                var methodParameterIsArray = methodParameter.TypeKind == TypeKind.Array;
+                if (methodParameterIsArray)
+                {
+                    if (!IsCandidateForSpanOrMemory(method.Parameters[i]) && methodParameter.IsEqualTo(overloadParameter))
+                        continue;
+
+                    if (!IsSpanOrMemory(overloadParameter, methodParameter))
+                        return false;
+                }
+                else
+                {
+                    if (!methodParameter.IsEqualTo(overloadParameter))
+                        return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Meziantou.Analyzer/Rules/AddOverloadWithSpanOrMemoryAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AddOverloadWithSpanOrMemoryAnalyzer.cs
@@ -25,10 +25,17 @@ public sealed class AddOverloadWithSpanOrMemoryAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var analyzerContext = new AnalyzerContext(compilationContext.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            compilationContext.RegisterSymbolAction(context => AnalyzeMethod(context, analyzerContext), SymbolKind.Method);
+        });
     }
 
-    private static void AnalyzeMethod(SymbolAnalysisContext context)
+    private static void AnalyzeMethod(SymbolAnalysisContext context, AnalyzerContext analyzerContext)
     {
         var method = (IMethodSymbol)context.Symbol;
         if (method.IsImplicitlyDeclared || method.IsOverrideOrInterfaceImplementation())
@@ -50,7 +57,7 @@ public sealed class AddOverloadWithSpanOrMemoryAnalyzer : DiagnosticAnalyzer
         var overloads = method.ContainingType.GetMembers(method.Name);
         foreach (var overload in overloads.OfType<IMethodSymbol>())
         {
-            if (IsValidOverload(context.Compilation, method, overload))
+            if (IsValidOverload(analyzerContext, method, overload))
                 return;
         }
 
@@ -62,7 +69,7 @@ public sealed class AddOverloadWithSpanOrMemoryAnalyzer : DiagnosticAnalyzer
         return param.Type.TypeKind is TypeKind.Array && !param.IsParams && param.RefKind is RefKind.None;
     }
 
-    private static bool IsValidOverload(Compilation compilation, IMethodSymbol method, IMethodSymbol overload)
+    private static bool IsValidOverload(AnalyzerContext analyzerContext, IMethodSymbol method, IMethodSymbol overload)
     {
         if (overload.IsEqualTo(method))
             return false;
@@ -81,7 +88,7 @@ public sealed class AddOverloadWithSpanOrMemoryAnalyzer : DiagnosticAnalyzer
                 if (!IsCandidateForSpanOrMemory(method.Parameters[i]) && methodParameter.IsEqualTo(overloadParameter))
                     continue;
 
-                if (!IsSpanOrMemory(compilation, overloadParameter, methodParameter))
+                if (!analyzerContext.IsSpanOrMemory(overloadParameter, methodParameter))
                     return false;
             }
             else
@@ -94,25 +101,40 @@ public sealed class AddOverloadWithSpanOrMemoryAnalyzer : DiagnosticAnalyzer
         return true;
     }
 
-    private static bool IsSpanOrMemory(Compilation compilation, ITypeSymbol typeSymbol, ITypeSymbol arrayType)
+    private sealed class AnalyzerContext(Compilation compilation)
     {
-        ITypeSymbol elementType;
-        if (arrayType.IsString())
-        {
-            elementType = compilation.GetSpecialType(SpecialType.System_Char);
-        }
-        else
-        {
-            elementType = ((IArrayTypeSymbol)arrayType).ElementType;
-        }
+        private readonly INamedTypeSymbol? _spanType = compilation.GetBestTypeByMetadataName("System.Span`1");
+        private readonly INamedTypeSymbol? _readOnlySpanType = compilation.GetBestTypeByMetadataName("System.ReadOnlySpan`1");
+        private readonly INamedTypeSymbol? _memoryType = compilation.GetBestTypeByMetadataName("System.Memory`1");
+        private readonly INamedTypeSymbol? _readOnlyMemoryType = compilation.GetBestTypeByMetadataName("System.ReadOnlyMemory`1");
 
-        var types = new string[] { "System.Span`1", "System.ReadOnlySpan`1", "System.Memory`1", "System.ReadOnlyMemory`1" };
-        foreach (var type in types)
+        public bool IsValid => _spanType is not null || _readOnlySpanType is not null || _memoryType is not null || _readOnlyMemoryType is not null;
+
+        public bool IsSpanOrMemory(ITypeSymbol typeSymbol, ITypeSymbol arrayType)
         {
-            if (typeSymbol.IsEqualTo(compilation.GetBestTypeByMetadataName(type)?.Construct(elementType)))
+            ITypeSymbol elementType;
+            if (arrayType.IsString())
+            {
+                elementType = compilation.GetSpecialType(SpecialType.System_Char);
+            }
+            else
+            {
+                elementType = ((IArrayTypeSymbol)arrayType).ElementType;
+            }
+
+            if (typeSymbol.IsEqualTo(_spanType?.Construct(elementType)))
                 return true;
-        }
 
-        return false;
+            if (typeSymbol.IsEqualTo(_readOnlySpanType?.Construct(elementType)))
+                return true;
+
+            if (typeSymbol.IsEqualTo(_memoryType?.Construct(elementType)))
+                return true;
+
+            if (typeSymbol.IsEqualTo(_readOnlyMemoryType?.Construct(elementType)))
+                return true;
+
+            return false;
+        }
     }
 }

--- a/src/Meziantou.Analyzer/Rules/AttributeNameShouldEndWithAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AttributeNameShouldEndWithAttributeAnalyzer.cs
@@ -25,16 +25,23 @@ public sealed class AttributeNameShouldEndWithAttributeAnalyzer : DiagnosticAnal
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var attributeType = compilationContext.Compilation.GetBestTypeByMetadataName("System.Attribute");
+            if (attributeType is null)
+                return;
+
+            compilationContext.RegisterSymbolAction(context => AnalyzeSymbol(context, attributeType), SymbolKind.NamedType);
+        });
     }
 
-    private static void AnalyzeSymbol(SymbolAnalysisContext context)
+    private static void AnalyzeSymbol(SymbolAnalysisContext context, ITypeSymbol attributeType)
     {
         var symbol = (INamedTypeSymbol)context.Symbol;
         if (symbol.Name is null)
             return;
 
-        if (!symbol.Name.EndsWith("Attribute", System.StringComparison.Ordinal) && symbol.InheritsFrom(context.Compilation.GetBestTypeByMetadataName("System.Attribute")))
+        if (!symbol.Name.EndsWith("Attribute", System.StringComparison.Ordinal) && symbol.InheritsFrom(attributeType))
         {
             context.ReportDiagnostic(Rule, symbol);
         }

--- a/src/Meziantou.Analyzer/Rules/AvoidLockingOnPubliclyAccessibleInstanceAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidLockingOnPubliclyAccessibleInstanceAnalyzer.cs
@@ -26,10 +26,14 @@ public sealed class AvoidLockingOnPubliclyAccessibleInstanceAnalyzer : Diagnosti
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterOperationAction(AnalyzeOperation, OperationKind.Lock);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var typeSymbol = compilationContext.Compilation.GetBestTypeByMetadataName("System.Type");
+            compilationContext.RegisterOperationAction(context => AnalyzeOperation(context, typeSymbol), OperationKind.Lock);
+        });
     }
 
-    private static void AnalyzeOperation(OperationAnalysisContext context)
+    private static void AnalyzeOperation(OperationAnalysisContext context, ITypeSymbol? typeSymbol)
     {
         var operation = (ILockOperation)context.Operation;
         if (operation.LockedValue is ITypeOfOperation)
@@ -48,7 +52,7 @@ public sealed class AvoidLockingOnPubliclyAccessibleInstanceAnalyzer : Diagnosti
         {
             context.ReportDiagnostic(Rule, operation.LockedValue);
         }
-        else if (operation.LockedValue is ILocalReferenceOperation localReference && localReference.Local.Type.IsEqualTo(context.Compilation.GetBestTypeByMetadataName("System.Type")))
+        else if (operation.LockedValue is ILocalReferenceOperation localReference && localReference.Local.Type.IsEqualTo(typeSymbol))
         {
             context.ReportDiagnostic(Rule, operation.LockedValue);
         }

--- a/src/Meziantou.Analyzer/Rules/DoNotUseEqualityComparerDefaultOfStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseEqualityComparerDefaultOfStringAnalyzer.cs
@@ -26,20 +26,23 @@ public sealed class DoNotUseEqualityComparerDefaultOfStringAnalyzer : Diagnostic
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterOperationAction(Analyze, OperationKind.PropertyReference);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var equalityComparerSymbol = compilationContext.Compilation.GetBestTypeByMetadataName("System.Collections.Generic.EqualityComparer`1");
+            if (equalityComparerSymbol is null)
+                return;
+
+            var equalityComparerStringSymbol = equalityComparerSymbol.Construct(compilationContext.Compilation.GetSpecialType(SpecialType.System_String));
+            compilationContext.RegisterOperationAction(context => Analyze(context, equalityComparerStringSymbol), OperationKind.PropertyReference);
+        });
     }
 
-    private static void Analyze(OperationAnalysisContext context)
+    private static void Analyze(OperationAnalysisContext context, ITypeSymbol equalityComparerStringSymbol)
     {
         var operation = (IPropertyReferenceOperation)context.Operation;
         if (!string.Equals(operation.Member.Name, nameof(EqualityComparer<>.Default), StringComparison.Ordinal))
             return;
 
-        var equalityComparerSymbol = context.Compilation.GetBestTypeByMetadataName("System.Collections.Generic.EqualityComparer`1");
-        if (equalityComparerSymbol is null)
-            return;
-
-        var equalityComparerStringSymbol = equalityComparerSymbol.Construct(context.Compilation.GetSpecialType(SpecialType.System_String));
         if (operation.Member.ContainingType.IsEqualTo(equalityComparerStringSymbol))
         {
             if (operation.IsInNameofOperation())

--- a/src/Meziantou.Analyzer/Rules/DontTagInstanceFieldsWithThreadStaticAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DontTagInstanceFieldsWithThreadStaticAttributeAnalyzer.cs
@@ -25,16 +25,23 @@ public sealed class DontTagInstanceFieldsWithThreadStaticAttributeAnalyzer : Dia
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSymbolAction(Analyze, SymbolKind.Field);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var threadStaticAttributeType = compilationContext.Compilation.GetBestTypeByMetadataName("System.ThreadStaticAttribute");
+            if (threadStaticAttributeType is null)
+                return;
+
+            compilationContext.RegisterSymbolAction(context => Analyze(context, threadStaticAttributeType), SymbolKind.Field);
+        });
     }
 
-    private static void Analyze(SymbolAnalysisContext context)
+    private static void Analyze(SymbolAnalysisContext context, ITypeSymbol threadStaticAttributeType)
     {
         var field = (IFieldSymbol)context.Symbol;
         if (field.IsStatic)
             return;
 
-        if (field.HasAttribute(context.Compilation.GetBestTypeByMetadataName("System.ThreadStaticAttribute")))
+        if (field.HasAttribute(threadStaticAttributeType))
         {
             context.ReportDiagnostic(Rule, field);
         }

--- a/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
@@ -53,9 +53,10 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
         if (types!.TryGetValue(symbol.MetadataName, out var namespaces))
         {
             var regex = context.Options.GetConfigurationValue(symbol, RuleIdentifiers.DotNotUseNameFromBCL + ".namespaces_regex", context.Options.GetConfigurationValue(symbol, RuleIdentifiers.DotNotUseNameFromBCL + ".namepaces_regex", "^System($|\\.)"));
+            var namespaceRegex = RegexCache.GetOrCreate(regex, RegexOptions.None, Timeout.InfiniteTimeSpan);
             foreach (var ns in namespaces)
             {
-                if (Regex.IsMatch(ns, regex, RegexOptions.None, Timeout.InfiniteTimeSpan))
+                if (namespaceRegex.IsMatch(ns))
                 {
                     context.ReportDiagnostic(Rule, symbol, symbol.MetadataName, ns);
                     return;

--- a/src/Meziantou.Analyzer/Rules/EventArgsNameShouldEndWithEventArgsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventArgsNameShouldEndWithEventArgsAnalyzer.cs
@@ -25,16 +25,23 @@ public sealed class EventArgsNameShouldEndWithEventArgsAnalyzer : DiagnosticAnal
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var eventArgsType = compilationContext.Compilation.GetBestTypeByMetadataName("System.EventArgs");
+            if (eventArgsType is null)
+                return;
+
+            compilationContext.RegisterSymbolAction(context => AnalyzeSymbol(context, eventArgsType), SymbolKind.NamedType);
+        });
     }
 
-    private static void AnalyzeSymbol(SymbolAnalysisContext context)
+    private static void AnalyzeSymbol(SymbolAnalysisContext context, ITypeSymbol eventArgsType)
     {
         var symbol = (INamedTypeSymbol)context.Symbol;
         if (symbol.Name is null)
             return;
 
-        if (!symbol.Name.EndsWith("EventArgs", System.StringComparison.Ordinal) && symbol.InheritsFrom(context.Compilation.GetBestTypeByMetadataName("System.EventArgs")))
+        if (!symbol.Name.EndsWith("EventArgs", System.StringComparison.Ordinal) && symbol.InheritsFrom(eventArgsType))
         {
             context.ReportDiagnostic(Rule, symbol);
         }

--- a/src/Meziantou.Analyzer/Rules/EventsShouldHaveProperArgumentsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventsShouldHaveProperArgumentsAnalyzer.cs
@@ -46,10 +46,18 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterOperationAction(AnalyzeRaiseEvent, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var eventArgsSymbol = compilationContext.Compilation.GetBestTypeByMetadataName("System.EventArgs");
+            var multicastDelegateSymbol = compilationContext.Compilation.GetBestTypeByMetadataName("System.MulticastDelegate");
+            if (eventArgsSymbol is null || multicastDelegateSymbol is null)
+                return;
+
+            compilationContext.RegisterOperationAction(context => AnalyzeRaiseEvent(context, eventArgsSymbol, multicastDelegateSymbol), OperationKind.Invocation);
+        });
     }
 
-    private static void AnalyzeRaiseEvent(OperationAnalysisContext context)
+    private static void AnalyzeRaiseEvent(OperationAnalysisContext context, ITypeSymbol eventArgsSymbol, ITypeSymbol multicastDelegateSymbol)
     {
         var operation = (IInvocationOperation)context.Operation;
         var targetMethod = operation.TargetMethod;
@@ -63,11 +71,9 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzer : DiagnosticAnalyzer
         if (!targetMethod.Parameters[0].Type.IsObject())
             return;
 
-        var eventArgsSymbol = context.Compilation.GetBestTypeByMetadataName("System.EventArgs");
         if (!targetMethod.Parameters[1].Type.IsOrInheritFrom(eventArgsSymbol))
             return;
 
-        var multicastDelegateSymbol = context.Compilation.GetBestTypeByMetadataName("System.MulticastDelegate");
         if (!targetMethod.ContainingType.IsOrInheritFrom(multicastDelegateSymbol))
             return;
 

--- a/src/Meziantou.Analyzer/Rules/ExceptionNameShouldEndWithExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ExceptionNameShouldEndWithExceptionAnalyzer.cs
@@ -25,16 +25,23 @@ public sealed class ExceptionNameShouldEndWithExceptionAnalyzer : DiagnosticAnal
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var exceptionType = compilationContext.Compilation.GetBestTypeByMetadataName("System.Exception");
+            if (exceptionType is null)
+                return;
+
+            compilationContext.RegisterSymbolAction(context => AnalyzeSymbol(context, exceptionType), SymbolKind.NamedType);
+        });
     }
 
-    private static void AnalyzeSymbol(SymbolAnalysisContext context)
+    private static void AnalyzeSymbol(SymbolAnalysisContext context, ITypeSymbol exceptionType)
     {
         var symbol = (INamedTypeSymbol)context.Symbol;
         if (symbol.Name is null)
             return;
 
-        if (!symbol.Name.EndsWith("Exception", System.StringComparison.Ordinal) && symbol.InheritsFrom(context.Compilation.GetBestTypeByMetadataName("System.Exception")))
+        if (!symbol.Name.EndsWith("Exception", System.StringComparison.Ordinal) && symbol.InheritsFrom(exceptionType))
         {
             context.ReportDiagnostic(Rule, symbol);
         }

--- a/src/Meziantou.Analyzer/Rules/MarkAttributesWithAttributeUsageAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MarkAttributesWithAttributeUsageAttributeAnalyzer.cs
@@ -25,16 +25,19 @@ public sealed class MarkAttributesWithAttributeUsageAttributeAnalyzer : Diagnost
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSymbolAction(Analyze, SymbolKind.NamedType);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var attributeType = compilationContext.Compilation.GetBestTypeByMetadataName("System.Attribute");
+            var attributeUsageAttributeType = compilationContext.Compilation.GetBestTypeByMetadataName("System.AttributeUsageAttribute");
+            if (attributeType is null || attributeUsageAttributeType is null)
+                return;
+
+            compilationContext.RegisterSymbolAction(context => Analyze(context, attributeType, attributeUsageAttributeType), SymbolKind.NamedType);
+        });
     }
 
-    private static void Analyze(SymbolAnalysisContext context)
+    private static void Analyze(SymbolAnalysisContext context, ITypeSymbol attributeType, ITypeSymbol attributeUsageAttributeType)
     {
-        var attributeType = context.Compilation.GetBestTypeByMetadataName("System.Attribute");
-        var attributeUsageAttributeType = context.Compilation.GetBestTypeByMetadataName("System.AttributeUsageAttribute");
-        if (attributeType is null || attributeUsageAttributeType is null)
-            return;
-
         var symbol = (INamedTypeSymbol)context.Symbol;
         if (symbol.IsAbstract)
             return;

--- a/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -15,6 +16,11 @@ namespace Meziantou.Analyzer.Rules;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
 {
+    private static readonly string ExcludedMethodsRegexConfigurationKey = RuleIdentifiers.UseNamedParameter + ".excluded_methods_regex";
+    private static readonly string ExcludedMethodsConfigurationKey = RuleIdentifiers.UseNamedParameter + ".excluded_methods";
+    private static readonly string MinimumMethodParametersConfigurationKey = RuleIdentifiers.UseNamedParameter + ".minimum_method_parameters";
+    private static readonly string ExpressionKindsConfigurationKey = RuleIdentifiers.UseNamedParameter + ".expression_kinds";
+
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.UseNamedParameter,
         title: "Add parameter name to improve readability",
@@ -51,6 +57,7 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
             var syntaxNodeType = context.Compilation.GetBestTypeByMetadataName("Microsoft.CodeAnalysis.SyntaxNode");
             var expressionType = context.Compilation.GetBestTypeByMetadataName("System.Linq.Expressions.Expression");
             var operationUtilities = new OperationUtilities(context.Compilation);
+            var regexCache = new ConcurrentDictionary<string, Regex>(StringComparer.Ordinal);
 
             context.RegisterSyntaxNodeAction(syntaxContext =>
             {
@@ -261,21 +268,28 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
                         if (operation is not null && !operation.GetCSharpLanguageVersion().IsCSharp14OrAbove() && operationUtilities.IsInExpressionContext(operation))
                             return;
 
-                        if (syntaxContext.Options.TryGetConfigurationValue(expression.SyntaxTree, RuleIdentifiers.UseNamedParameter + ".excluded_methods_regex", out var excludedMethodsRegex))
+                        if (syntaxContext.Options.TryGetConfigurationValue(expression.SyntaxTree, ExcludedMethodsRegexConfigurationKey, out var excludedMethodsRegex))
                         {
                             var declarationId = DocumentationCommentId.CreateDeclarationId(invokedMethodSymbol);
-                            if (declarationId is not null && Regex.IsMatch(declarationId, excludedMethodsRegex, RegexOptions.None, Timeout.InfiniteTimeSpan))
-                                return;
+                            if (declarationId is not null)
+                            {
+                                var regex = regexCache.GetOrAdd(excludedMethodsRegex, static pattern => new Regex(pattern, RegexOptions.Compiled, Timeout.InfiniteTimeSpan));
+                                if (regex.IsMatch(declarationId))
+                                    return;
+                            }
                         }
 
-                        if (syntaxContext.Options.TryGetConfigurationValue(expression.SyntaxTree, RuleIdentifiers.UseNamedParameter + ".excluded_methods", out var excludedMethods))
+                        if (syntaxContext.Options.TryGetConfigurationValue(expression.SyntaxTree, ExcludedMethodsConfigurationKey, out var excludedMethods))
                         {
-                            var types = excludedMethods.Split('|');
-                            foreach (var type in types)
+                            var declarationId = DocumentationCommentId.CreateDeclarationId(invokedMethodSymbol);
+                            if (declarationId is not null)
                             {
-                                var declarationId = DocumentationCommentId.CreateDeclarationId(invokedMethodSymbol);
-                                if (type == declarationId)
-                                    return;
+                                var types = excludedMethods.Split('|');
+                                foreach (var type in types)
+                                {
+                                    if (type == declarationId)
+                                        return;
+                                }
                             }
                         }
                     }
@@ -306,7 +320,7 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
     private static int GetMinimumMethodArgumentsConfiguration(AnalyzerOptions analyzerOptions, SyntaxNode node)
     {
         var options = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(node.SyntaxTree);
-        if (options.TryGetValue(RuleIdentifiers.UseNamedParameter + ".minimum_method_parameters", out var value))
+        if (options.TryGetValue(MinimumMethodParametersConfigurationKey, out var value))
         {
             if (int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var result))
                 return result;
@@ -318,7 +332,7 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
     private static ArgumentExpressionKinds GetExpressionKindsConfiguration(AnalyzerOptions analyzerOptions, SyntaxNode node)
     {
         var options = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(node.SyntaxTree);
-        if (options.TryGetValue(RuleIdentifiers.UseNamedParameter + ".expression_kinds", out var value))
+        if (options.TryGetValue(ExpressionKindsConfigurationKey, out var value))
         {
             if (Enum.TryParse<ArgumentExpressionKinds>(value, ignoreCase: true, out var result))
                 return result;

--- a/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -57,7 +56,6 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
             var syntaxNodeType = context.Compilation.GetBestTypeByMetadataName("Microsoft.CodeAnalysis.SyntaxNode");
             var expressionType = context.Compilation.GetBestTypeByMetadataName("System.Linq.Expressions.Expression");
             var operationUtilities = new OperationUtilities(context.Compilation);
-            var regexCache = new ConcurrentDictionary<string, Regex>(StringComparer.Ordinal);
 
             context.RegisterSyntaxNodeAction(syntaxContext =>
             {
@@ -273,7 +271,7 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
                             var declarationId = DocumentationCommentId.CreateDeclarationId(invokedMethodSymbol);
                             if (declarationId is not null)
                             {
-                                var regex = regexCache.GetOrAdd(excludedMethodsRegex, static pattern => new Regex(pattern, RegexOptions.Compiled, Timeout.InfiniteTimeSpan));
+                                var regex = RegexCache.GetOrCreate(excludedMethodsRegex, RegexOptions.Compiled, Timeout.InfiniteTimeSpan);
                                 if (regex.IsMatch(declarationId))
                                     return;
                             }

--- a/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
@@ -16,10 +16,10 @@ namespace Meziantou.Analyzer.Rules;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly string ExcludedMethodsRegexConfigurationKey = RuleIdentifiers.UseNamedParameter + ".excluded_methods_regex";
-    private static readonly string ExcludedMethodsConfigurationKey = RuleIdentifiers.UseNamedParameter + ".excluded_methods";
-    private static readonly string MinimumMethodParametersConfigurationKey = RuleIdentifiers.UseNamedParameter + ".minimum_method_parameters";
-    private static readonly string ExpressionKindsConfigurationKey = RuleIdentifiers.UseNamedParameter + ".expression_kinds";
+    private const string ExcludedMethodsRegexConfigurationKey = RuleIdentifiers.UseNamedParameter + ".excluded_methods_regex";
+    private const string ExcludedMethodsConfigurationKey = RuleIdentifiers.UseNamedParameter + ".excluded_methods";
+    private const string MinimumMethodParametersConfigurationKey = RuleIdentifiers.UseNamedParameter + ".minimum_method_parameters";
+    private const string ExpressionKindsConfigurationKey = RuleIdentifiers.UseNamedParameter + ".expression_kinds";
 
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.UseNamedParameter,

--- a/src/Meziantou.Analyzer/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzer.cs
@@ -26,16 +26,23 @@ public sealed class NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzer : D
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var flagsAttributeType = compilationContext.Compilation.GetBestTypeByMetadataName("System.FlagsAttribute");
+            if (flagsAttributeType is null)
+                return;
+
+            compilationContext.RegisterSymbolAction(context => AnalyzeSymbol(context, flagsAttributeType), SymbolKind.NamedType);
+        });
     }
 
-    private static void AnalyzeSymbol(SymbolAnalysisContext context)
+    private static void AnalyzeSymbol(SymbolAnalysisContext context, ITypeSymbol flagsAttributeType)
     {
         var symbol = (INamedTypeSymbol)context.Symbol;
         if (symbol.EnumUnderlyingType is null)
             return;
 
-        if (!symbol.HasAttribute(context.Compilation.GetBestTypeByMetadataName("System.FlagsAttribute")))
+        if (!symbol.HasAttribute(flagsAttributeType))
             return;
 
         if (!symbol.GetMembers().OfType<IFieldSymbol>().All(member => member.HasConstantValue && member.ConstantValue is not null))

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -170,7 +170,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 return;
 
             var method = operation.TargetMethod;
-            if (!ExtensionMethodOwnerTypes.Contains(method.ContainingType))
+            if (!ExtensionMethodOwnerTypes.Contains(method.ContainingType, SymbolEqualityComparer.Default))
                 return;
 
             UseFindInsteadOfFirstOrDefault(context, operation);
@@ -189,7 +189,43 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
 
         private static ImmutableDictionary<string, string?> CreateProperties(OptimizeLinqUsageData data)
         {
-            return ImmutableDictionary.Create<string, string?>().Add("Data", data.ToString());
+            var builder = ImmutableDictionary.CreateBuilder<string, string?>();
+            builder.Add("Data", data.ToString());
+            return builder.ToImmutable();
+        }
+
+        private static ImmutableDictionary<string, string?> CreateLinqChainProperties(OptimizeLinqUsageData data, IInvocationOperation firstOperation, IInvocationOperation lastOperation, string methodName)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, string?>();
+            builder.Add("Data", data.ToString());
+            builder.Add("FirstOperationStart", firstOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add("FirstOperationLength", firstOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Add("LastOperationStart", lastOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add("LastOperationLength", lastOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Add("MethodName", methodName);
+            return builder.ToImmutable();
+        }
+
+        private static ImmutableDictionary<string, string?> CreateSingleOperationProperties(OptimizeLinqUsageData data, IInvocationOperation operation)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, string?>();
+            builder.Add("Data", data.ToString());
+            builder.Add("FirstOperationStart", operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add("FirstOperationLength", operation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            return builder.ToImmutable();
+        }
+
+        private static ImmutableDictionary<string, string?> CreateDuplicateOrderByProperties(OptimizeLinqUsageData data, IInvocationOperation firstOperation, IInvocationOperation lastOperation, string expectedMethodName, string methodName)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, string?>();
+            builder.Add("Data", data.ToString());
+            builder.Add("FirstOperationStart", firstOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add("FirstOperationLength", firstOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Add("LastOperationStart", lastOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add("LastOperationLength", lastOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Add("ExpectedMethodName", expectedMethodName);
+            builder.Add("MethodName", methodName);
+            return builder.ToImmutable();
         }
 
         private void WhereShouldBeBeforeOrderBy(OperationAnalysisContext context, IInvocationOperation operation)
@@ -201,12 +237,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 {
                     if (parent.TargetMethod.Name == nameof(Enumerable.Where))
                     {
-                        var properties = CreateProperties(OptimizeLinqUsageData.CombineWhereWithNextMethod)
-                           .Add("FirstOperationStart", operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-                           .Add("FirstOperationLength", operation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
-                           .Add("LastOperationStart", parent.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-                           .Add("LastOperationLength", parent.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
-                           .Add("MethodName", parent.TargetMethod.Name);
+                        var properties = CreateLinqChainProperties(OptimizeLinqUsageData.CombineWhereWithNextMethod, operation, parent, parent.TargetMethod.Name);
 
                         context.ReportDiagnostic(OptimizeWhereAndOrderByRule, properties, parent, operation.TargetMethod.Name);
                     }
@@ -446,12 +477,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                         if (QueryableSymbol is not null && operation.TargetMethod.ContainingType.IsEqualTo(QueryableSymbol) && parent.TargetMethod.ContainingType.IsEqualTo(QueryableSymbol))
                             return;
 
-                        var properties = CreateProperties(OptimizeLinqUsageData.CombineWhereWithNextMethod)
-                           .Add("FirstOperationStart", operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-                           .Add("FirstOperationLength", operation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
-                           .Add("LastOperationStart", parent.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-                           .Add("LastOperationLength", parent.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
-                           .Add("MethodName", parent.TargetMethod.Name);
+                        var properties = CreateLinqChainProperties(OptimizeLinqUsageData.CombineWhereWithNextMethod, operation, parent, parent.TargetMethod.Name);
 
                         if (parent.Arguments.Length > 1 && IsExpressionPredicateReference(parent.Arguments[1].Value))
                             return;
@@ -484,14 +510,13 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 {
                     if (parent.TargetMethod.Name is nameof(Enumerable.OrderBy) or nameof(Enumerable.OrderByDescending) or "Order" or "OrderDescending")
                     {
-                        var expectedMethodName = parent.TargetMethod.Name.Replace("OrderBy", "ThenBy", StringComparison.Ordinal);
-                        var properties = CreateProperties(OptimizeLinqUsageData.DuplicatedOrderBy)
-                            .Add("FirstOperationStart", operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-                            .Add("FirstOperationLength", operation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
-                            .Add("LastOperationStart", parent.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-                            .Add("LastOperationLength", parent.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
-                            .Add("ExpectedMethodName", expectedMethodName)
-                            .Add("MethodName", parent.TargetMethod.Name);
+                        var expectedMethodName = parent.TargetMethod.Name switch
+                        {
+                            nameof(Enumerable.OrderBy) or "Order" => nameof(Enumerable.ThenBy),
+                            nameof(Enumerable.OrderByDescending) or "OrderDescending" => nameof(Enumerable.ThenByDescending),
+                            _ => parent.TargetMethod.Name,
+                        };
+                        var properties = CreateDuplicateOrderByProperties(OptimizeLinqUsageData.DuplicatedOrderBy, operation, parent, expectedMethodName, parent.TargetMethod.Name);
 
                         context.ReportDiagnostic(DuplicateOrderByMethodsRule, properties, parent, operation.TargetMethod.Name, expectedMethodName);
                     }
@@ -511,9 +536,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 // x => x
                 if (arg is IDelegateCreationOperation { Target: IAnonymousFunctionOperation { Symbol.Parameters: [var delegateParameter], Body: IBlockOperation { Operations: [IReturnOperation { ReturnedValue: IParameterReferenceOperation parameterReference }] } } } && parameterReference.Parameter.IsEqualTo(delegateParameter))
                 {
-                    var properties = CreateProperties(OptimizeLinqUsageData.UseOrder)
-                        .Add("FirstOperationStart", operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-                        .Add("FirstOperationLength", operation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+                    var properties = CreateSingleOperationProperties(OptimizeLinqUsageData.UseOrder, operation);
 
                     var newMethodName = operation.TargetMethod.Name is "OrderBy" ? "Order" : "OrderDescending";
 


### PR DESCRIPTION
## Why
Analyzer callbacks run on every compilation and frequently during editing. Several hot paths were doing repeated LINQ enumerations, per-callback metadata type resolution, and repeated regex/config string work, creating avoidable CPU and allocation overhead.

## What changed
- Optimized shared internals used by many analyzers:
  - `MethodSymbolExtensions`: replaced `Any()/First()` on explicit interface implementations with direct `Length`/index access.
  - `ContextExtensions`: removed multiple re-enumerations of source locations when reporting diagnostics.
  - `TypeSymbolExtensions`: replaced LINQ predicate-based checks with loop-based implementations for interface and attribute lookups.
- Updated `OptimizeLinqUsageAnalyzer` to reduce diagnostic-property allocations by using dictionary builders and helper creators, and replaced `Replace("OrderBy", "ThenBy")` with explicit method-name mapping.
- Updated `NamedParameterAnalyzer` to cache config keys as static fields and cache compiled regex instances per compilation-start context.
- Hoisted repeated `GetBestTypeByMetadataName` lookups out of hot callbacks into compilation start for targeted analyzers (naming/design/usage/perf rules touched in this branch).

## Notes for reviewers
These are intended as behavior-preserving perf refactors. The changes focus on reducing hot-path allocations and repeated metadata lookups without changing diagnostics semantics.

## Validation
- `dotnet build`
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj`
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj /p:RoslynVersion=roslyn4.2 --filter 'FullyQualifiedName~AddOverloadWithSpanOrMemoryAnalyzerTests|FullyQualifiedName~AttributeNameShouldEndWithAttributeAnalyzerTests|FullyQualifiedName~AvoidLockingOnPubliclyAccessibleInstanceAnalyzerTests|FullyQualifiedName~DoNotUseEqualityComparerDefaultOfStringAnalyzerTests|FullyQualifiedName~DontTagInstanceFieldsWithThreadStaticAttributeAnalyzerTests|FullyQualifiedName~EventArgsNameShouldEndWithEventArgsAnalyzerTests|FullyQualifiedName~EventsShouldHaveProperArgumentsAnalyzerTests|FullyQualifiedName~ExceptionNameShouldEndWithExceptionAnalyzerTests|FullyQualifiedName~MarkAttributesWithAttributeUsageAttribute|FullyQualifiedName~NamedParameterAnalyzerTests|FullyQualifiedName~NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzerTests|FullyQualifiedName~OptimizeLinqUsageAnalyzer'`
- `dotnet run --project src/DocumentationGenerator`

A full Roslyn 4.2 run in this environment still reports one unrelated existing failure (`DoNotNaNInComparisonsAnalyzerTests.Comparisons_CodeFix_Half`, `NullReferenceException`).