### PR TITLE
Document comparison page maintenance expectations

### DIFF
--- a/docs/comparison-with-other-analyzers.md
+++ b/docs/comparison-with-other-analyzers.md
@@ -1,5 +1,11 @@
 # Comparison with other analyzers
 
+This page is maintained on a best-effort basis and may be out of date.
+
+It is mostly driven by community feedback. If you notice missing or outdated mappings, please create an issue.
+
+I do not control other analyzers' roadmaps, and I do not regularly read their changelogs to keep this page up to date.
+
 ## Equivalent rules
 
 |                                                                                                                           |                                                                                            |


### PR DESCRIPTION
## Summary
The comparison table can be read as fully current, which can create the wrong expectation. This updates the page to clearly state that it is maintained on a best-effort basis and may be out of date.

## What changed
- Added a disclaimer at the top of `docs/comparison-with-other-analyzers.md`.
- Clarified that updates are mostly driven by community feedback.
- Added guidance to create an issue for missing or outdated mappings.
- Clarified that other analyzer roadmaps and changelogs are not tracked regularly for this page.