### PR TITLE
Add annotation-based exclusions for MA0042 and MA0045

### DIFF
--- a/docs/Rules/MA0042.md
+++ b/docs/Rules/MA0042.md
@@ -111,6 +111,17 @@ MA0042.enable_sqlite_special_cases = true
 MA0042.enable_db_special_cases = true
 ````
 
+You can also exclude specific method/property diagnostics for MA0042/MA0045 using assembly-level annotations:
+
+```csharp
+[assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute("M:System.Threading.Tasks.Task.Wait")]
+[assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute(typeof(System.Threading.Thread), "Sleep", typeof(int))]
+```
+
+The attribute supports:
+- a documentation ID (`M:...` for methods, `P:...` for properties) for exact matching
+- `Type` + member name (+ optional parameter types) for direct signature-based matching
+
 ## Additional resources
 
 - [Enforcing asynchronous code good practices using a Roslyn analyzer](https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm)

--- a/docs/Rules/MA0045.md
+++ b/docs/Rules/MA0045.md
@@ -54,6 +54,17 @@ MA0042.enable_sqlite_special_cases = true
 MA0042.enable_db_special_cases = true
 ````
 
+You can also exclude specific method/property diagnostics for MA0042/MA0045 using assembly-level annotations:
+
+```csharp
+[assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute("M:System.Threading.Tasks.Task.Wait")]
+[assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute(typeof(System.Threading.Thread), "Sleep", typeof(int))]
+```
+
+The attribute supports:
+- a documentation ID (`M:...` for methods, `P:...` for properties) for exact matching
+- `Type` + member name (+ optional parameter types) for direct signature-based matching
+
 ## Additional resources
 
 - [Enforcing asynchronous code good practices using a Roslyn analyzer](https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm)

--- a/src/Meziantou.Analyzer.Annotations/ExcludeFromBlockingCallAnalysisAttribute.cs
+++ b/src/Meziantou.Analyzer.Annotations/ExcludeFromBlockingCallAnalysisAttribute.cs
@@ -1,0 +1,16 @@
+#pragma warning disable CS1591
+#pragma warning disable IDE0060
+#pragma warning disable CA1019
+
+namespace Meziantou.Analyzer.Annotations;
+
+[System.Diagnostics.Conditional("MEZIANTOU_ANALYZER_ANNOTATIONS")]
+[System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+public sealed class ExcludeFromBlockingCallAnalysisAttribute : System.Attribute
+{
+    public ExcludeFromBlockingCallAnalysisAttribute(string documentationId) { }
+
+    public ExcludeFromBlockingCallAnalysisAttribute(System.Type containingType, string memberName) { }
+
+    public ExcludeFromBlockingCallAnalysisAttribute(System.Type containingType, string memberName, params System.Type[] parameterTypes) { }
+}

--- a/src/Meziantou.Analyzer.Annotations/README.md
+++ b/src/Meziantou.Analyzer.Annotations/README.md
@@ -3,3 +3,12 @@
 By default, all usages of attributes from `Meziantou.Analyzer.Annotations` are removed from the compiled assembly metadata. This means your binaries will not reference the `Meziantou.Analyzer.Annotations.dll` assembly.
 
 If you want to keep these attributes in the metadata (for example, for reflection or tooling purposes), define the `MEZIANTOU_ANALYZER_ANNOTATIONS` conditional compilation symbol in your project settings.
+
+## ExcludeFromBlockingCallAnalysisAttribute
+
+Use `ExcludeFromBlockingCallAnalysisAttribute` to exclude specific MA0042/MA0045 method/property diagnostics at the assembly level.
+
+```csharp
+[assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute("M:System.Threading.Tasks.Task.Wait")]
+[assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute(typeof(System.Threading.Thread), "Sleep", typeof(int))]
+```

--- a/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
+++ b/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
@@ -48,4 +48,26 @@ internal static class AnnotationAttributes
             }
         };
     }
+
+    public static bool IsExcludeFromBlockingCallAnalysisAttributeSymbol(ITypeSymbol? symbol)
+    {
+        // Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute        
+        return symbol is INamedTypeSymbol
+        {
+            Name: "ExcludeFromBlockingCallAnalysisAttribute",
+            ContainingSymbol: INamespaceSymbol
+            {
+                Name: "Annotations",
+                ContainingSymbol: INamespaceSymbol
+                {
+                    Name: "Analyzer",
+                    ContainingSymbol: INamespaceSymbol
+                    {
+                        Name: "Meziantou",
+                        ContainingSymbol: INamespaceSymbol { IsGlobalNamespace: true }
+                    }
+                }
+            }
+        };
+    }
 }

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -58,6 +58,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             private readonly OverloadFinder _overloadFinder;
 
         private readonly INamedTypeSymbol[] _taskAwaiterLikeSymbols;
+        private readonly HashSet<ISymbol> _excludedDiagnosticSymbols;
         private readonly ConcurrentHashSet<IMethodSymbol> _symbolsWithNoAsyncOverloads = new(SymbolEqualityComparer.Default);
 
         public Context(Compilation compilation)
@@ -130,6 +131,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             taskAwaiterLikeSymbols.AddIfNotNull(ValueTaskAwaiterSymbol);
             taskAwaiterLikeSymbols.AddIfNotNull(ValueTaskAwaiterOfTSymbol);
             _taskAwaiterLikeSymbols = [.. taskAwaiterLikeSymbols];
+            _excludedDiagnosticSymbols = CreateExcludedDiagnosticSymbols(compilation);
         }
 
         private ISymbol? StreamSymbol { get; }
@@ -179,6 +181,9 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
         {
             var operation = (IInvocationOperation)context.Operation;
             var targetMethod = operation.TargetMethod;
+            if (IsExcludedDiagnosticSymbol(targetMethod))
+                return;
+
             var sqliteSpecialCasesEnabled = IsSqliteSpecialCasesEnabled(context, operation);
             var isSqliteSpecialCaseMethod = IsSqliteSpecialCaseMethod(operation);
 
@@ -335,6 +340,97 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             return context.Options.GetConfigurationValue(operation, RuleIdentifiers.DoNotUseBlockingCall + ".enable_db_special_cases", defaultValue);
         }
 
+        private static HashSet<ISymbol> CreateExcludedDiagnosticSymbols(Compilation compilation)
+        {
+            var result = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            foreach (var attribute in compilation.Assembly.GetAttributes())
+            {
+                if (!AnnotationAttributes.IsExcludeFromBlockingCallAnalysisAttributeSymbol(attribute.AttributeClass))
+                    continue;
+
+                var constructorArguments = attribute.ConstructorArguments;
+                if (constructorArguments is [{ Type.SpecialType: SpecialType.System_String, IsNull: false, Value: string documentationId }])
+                {
+                    foreach (var symbol in DocumentationCommentId.GetSymbolsForDeclarationId(documentationId, compilation))
+                    {
+                        AddExcludedSymbol(result, symbol);
+                    }
+
+                    continue;
+                }
+
+                if (constructorArguments.Length is not 2 and not 3)
+                    continue;
+
+                if (constructorArguments[0].Value is not INamedTypeSymbol containingType)
+                    continue;
+
+                if (constructorArguments[1] is not { Type.SpecialType: SpecialType.System_String, IsNull: false, Value: string memberName } || string.IsNullOrWhiteSpace(memberName))
+                    continue;
+
+                if (constructorArguments.Length == 2)
+                {
+                    foreach (var member in containingType.GetMembers(memberName))
+                    {
+                        AddExcludedSymbol(result, member);
+                    }
+
+                    continue;
+                }
+
+                if (constructorArguments[2].Kind != TypedConstantKind.Array)
+                    continue;
+
+                var parameterTypes = constructorArguments[2].Values;
+                foreach (var method in containingType.GetMembers(memberName).OfType<IMethodSymbol>())
+                {
+                    if (method.Parameters.Length != parameterTypes.Length)
+                        continue;
+
+                    var match = true;
+                    for (var i = 0; i < parameterTypes.Length; i++)
+                    {
+                        if (parameterTypes[i].Value is not ITypeSymbol parameterType || !method.Parameters[i].Type.IsEqualTo(parameterType))
+                        {
+                            match = false;
+                            break;
+                        }
+                    }
+
+                    if (match)
+                    {
+                        AddExcludedSymbol(result, method);
+                    }
+                }
+            }
+
+            return result;
+
+            static void AddExcludedSymbol(HashSet<ISymbol> symbols, ISymbol symbol)
+            {
+                if (symbol is not IMethodSymbol and not IPropertySymbol)
+                    return;
+
+                symbols.Add(symbol);
+                if (!ReferenceEquals(symbol.OriginalDefinition, symbol))
+                {
+                    symbols.Add(symbol.OriginalDefinition);
+                }
+            }
+        }
+
+        private bool IsExcludedDiagnosticSymbol(ISymbol symbol)
+        {
+            if (_excludedDiagnosticSymbols.Count == 0)
+                return false;
+
+            if (_excludedDiagnosticSymbols.Contains(symbol))
+                return true;
+
+            var originalDefinition = symbol.OriginalDefinition;
+            return !ReferenceEquals(symbol, originalDefinition) && _excludedDiagnosticSymbols.Contains(originalDefinition);
+        }
+
         private bool IsSqliteSpecialCaseType(INamedTypeSymbol type)
         {
             return type.IsEqualToAny(SqliteConnectionSymbol, SqliteCommandSymbol, SqliteDataReaderSymbol);
@@ -433,6 +529,9 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             var operation = (IPropertyReferenceOperation)context.Operation;
 
             if (operation.IsInNameofOperation())
+                return;
+
+            if (IsExcludedDiagnosticSymbol(operation.Property))
                 return;
 
             // Task`1.Result

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -3519,4 +3519,71 @@ class Sample
                 """)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task ExcludeFromBlockingCallAnalysisAttribute_DocumentationIdMethod()
+    {
+        await CreateProjectBuilder()
+              .AddMeziantouAttributes()
+              .WithSourceCode("""
+                using System.Threading.Tasks;
+                [assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute("M:System.Threading.Tasks.Task.Wait")]
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        Task.Delay(1).Wait();
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ExcludeFromBlockingCallAnalysisAttribute_DocumentationIdProperty()
+    {
+        await CreateProjectBuilder()
+              .AddMeziantouAttributes()
+              .WithSourceCode("""
+                using System.Threading.Tasks;
+                [assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute("P:System.Threading.Tasks.Task`1.Result")]
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        _ = Task.FromResult(1).Result;
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ExcludeFromBlockingCallAnalysisAttribute_DoesNotAffectAwaitUsing()
+    {
+        await CreateProjectBuilder()
+              .AddMeziantouAttributes()
+              .WithSourceCode("""
+                using System;
+                using System.Threading.Tasks;
+                [assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute("M:System.Threading.Tasks.Task.Wait")]
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        [|using var value = new AsyncDisposable();|]
+                    }
+                }
+
+                class AsyncDisposable : IDisposable, IAsyncDisposable
+                {
+                    public void Dispose() { }
+                    public ValueTask DisposeAsync() => default;
+                }
+                """)
+              .ValidateAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
@@ -329,4 +329,63 @@ public class Test
                 """)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task ExcludeFromBlockingCallAnalysisAttribute_DocumentationIdMethod()
+    {
+        await CreateProjectBuilder()
+              .AddMeziantouAttributes()
+              .WithSourceCode("""
+                using System.Threading.Tasks;
+                [assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute("M:System.Threading.Tasks.Task.Wait")]
+
+                class Test
+                {
+                    private void A()
+                    {
+                        Task.Delay(1).Wait();
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ExcludeFromBlockingCallAnalysisAttribute_MethodSignature()
+    {
+        await CreateProjectBuilder()
+              .AddMeziantouAttributes()
+              .WithSourceCode("""
+                [assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute(typeof(System.Threading.Thread), "Sleep", typeof(int))]
+
+                class Test
+                {
+                    private void A()
+                    {
+                        System.Threading.Thread.Sleep(1);
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ExcludeFromBlockingCallAnalysisAttribute_MethodSignature_OnlyMatchingOverload()
+    {
+        await CreateProjectBuilder()
+              .AddMeziantouAttributes()
+              .WithSourceCode("""
+                using System;
+                [assembly: Meziantou.Analyzer.Annotations.ExcludeFromBlockingCallAnalysisAttribute(typeof(System.Threading.Thread), "Sleep", typeof(int))]
+
+                class Test
+                {
+                    private void A()
+                    {
+                        [|System.Threading.Thread.Sleep(TimeSpan.FromSeconds(1))|];
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
## Why
MA0042 and MA0045 had no annotation-based way to suppress known intentional blocking members. This made per-signature opt-out difficult in projects that prefer code-based configuration over editorconfig-only switches.

## What changed
- Added `ExcludeFromBlockingCallAnalysisAttribute` in `Meziantou.Analyzer.Annotations` with three forms:
  - documentation ID (`"M:..."`, `"P:..."`)
  - `Type + member name`
  - `Type + member name + parameter types`
- Extended `DoNotUseBlockingCallInAsyncContextAnalyzer` to read assembly attributes at compilation start, resolve excluded symbols, and skip MA0042/MA0045 diagnostics for matching invocations and property references.
- Kept await-using diagnostics unchanged. Exclusions only apply to method/property blocking-call diagnostics.
- Added regression tests for documentation ID exclusions, type/signature exclusions, overload-specific behavior, and non-impact on await-using diagnostics.
- Updated MA0042/MA0045 docs and annotations README with usage examples.

## Notes
- `Type + member name` excludes all matching members with that name on the type.
- Adding parameter types narrows exclusion to a specific overload.
- Only method/property symbols are considered for exclusion.

Fix https://github.com/meziantou/Meziantou.Analyzer/issues/1147