### PR TITLE
Allow MA0196 inheritdoc on constructors matching base signatures

### DIFF
--- a/docs/Rules/MA0196.md
+++ b/docs/Rules/MA0196.md
@@ -7,7 +7,8 @@ Use `<inheritdoc />` only when documentation is inherited from a base member imp
 
 This rule reports `<inheritdoc />` when the member is not:
 - an override, and
-- an interface implementation.
+- an interface implementation,
+- a constructor with the same signature as a constructor on the base type.
 
 Primary constructors are ignored because their XML documentation is shared with the containing type declaration.
 
@@ -38,5 +39,19 @@ class OtherSample
 {
     /// <inheritdoc cref="object.ToString" />
     public void M() { }
+}
+
+// Compliant (constructor signature matches base constructor)
+class BaseTypeWithCtor
+{
+    public BaseTypeWithCtor(int value) { }
+}
+
+class DerivedTypeWithCtor : BaseTypeWithCtor
+{
+    /// <inheritdoc />
+    public DerivedTypeWithCtor(int value) : this() { }
+
+    private DerivedTypeWithCtor() : base(0) { }
 }
 ````

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzer.cs
@@ -12,7 +12,7 @@ public sealed class InheritdocShouldBeUsedOnInheritingMemberAnalyzer : Diagnosti
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.InheritdocShouldBeUsedOnInheritingMember,
         title: "Do not use inheritdoc on non-inheriting members",
-        messageFormat: "Do not use '<inheritdoc />' on members that are not overrides or interface implementations",
+        messageFormat: "Do not use '<inheritdoc />' on members that do not inherit documentation",
         RuleCategories.Design,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -34,8 +34,14 @@ public sealed class InheritdocShouldBeUsedOnInheritingMemberAnalyzer : Diagnosti
         if (context.Symbol is not (IMethodSymbol or IPropertySymbol or IEventSymbol))
             return;
 
-        if (context.Symbol is IMethodSymbol methodSymbol && methodSymbol.IsPrimaryConstructor(context.CancellationToken, includeRecordDeclarations: true))
-            return;
+        if (context.Symbol is IMethodSymbol methodSymbol)
+        {
+            if (methodSymbol.IsPrimaryConstructor(context.CancellationToken, includeRecordDeclarations: true))
+                return;
+
+            if (IsInheritingConstructor(methodSymbol))
+                return;
+        }
 
         if (context.Symbol.IsImplicitlyDeclared || context.Symbol.IsOverrideOrInterfaceImplementation())
             return;
@@ -84,5 +90,45 @@ public sealed class InheritdocShouldBeUsedOnInheritingMemberAnalyzer : Diagnosti
         }
 
         return false;
+    }
+
+    private static bool IsInheritingConstructor(IMethodSymbol methodSymbol)
+    {
+        if (methodSymbol.MethodKind is not MethodKind.Constructor)
+            return false;
+
+        var baseType = methodSymbol.ContainingType.BaseType;
+        if (baseType is null)
+            return false;
+
+        foreach (var baseConstructor in baseType.InstanceConstructors)
+        {
+            if (HasSameSignature(methodSymbol, baseConstructor))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasSameSignature(IMethodSymbol method, IMethodSymbol otherMethod)
+    {
+        if (method.Parameters.Length != otherMethod.Parameters.Length)
+            return false;
+
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            var parameter = method.Parameters[i];
+            var otherParameter = otherMethod.Parameters[i];
+            if (parameter.RefKind != otherParameter.RefKind)
+                return false;
+
+            if (parameter.IsParams != otherParameter.IsParams)
+                return false;
+
+            if (!SymbolEqualityComparer.Default.Equals(parameter.Type, otherParameter.Type))
+                return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzerTests.cs
@@ -49,7 +49,66 @@ public sealed class InheritdocShouldBeUsedOnInheritingMemberAnalyzerTests
                   class Sample
                   {
                       /// [|<inheritdoc />|]
+                      public Sample(int value) { }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_ConstructorHasSameSignatureAsBaseConstructor()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class BaseType
+                  {
+                      public BaseType(int value) { }
+                  }
+
+                  class Sample : BaseType
+                  {
+                      /// <inheritdoc />
+                      public Sample(int value) : this() { }
+
+                      private Sample() : base(0) { }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_ConstructorHasSameSignatureAsBaseParameterlessConstructor()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class BaseType
+                  {
+                      public BaseType() { }
+                  }
+
+                  class Sample : BaseType
+                  {
+                      /// <inheritdoc />
                       public Sample() { }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_ConstructorDoesNotMatchBaseConstructorSignature()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class BaseType
+                  {
+                      public BaseType(int value) { }
+                  }
+
+                  class Sample : BaseType
+                  {
+                      /// [|<inheritdoc />|]
+                      public Sample(string value) : base(0) { }
                   }
                   """)
               .ValidateAsync();


### PR DESCRIPTION
MA0196 was reporting `<inheritdoc />` on constructors even in cases where constructor documentation is effectively inherited from a base constructor with the same signature. This created noise compared to the behavior users see in Visual Studio.

This change updates MA0196 to treat constructors as inheriting members when their signature matches a constructor on the base type.

## What changed
- Updated `InheritdocShouldBeUsedOnInheritingMemberAnalyzer` to allow constructor `<inheritdoc />` when a base constructor has the same signature.
- Signature matching is semantic and checks parameter count, parameter types, ref kind, and `params` shape.
- Kept diagnostics for constructors that do not match any base constructor signature.
- Added test coverage for matching and non-matching constructor signatures, including parameterless constructors.
- Updated `docs/Rules/MA0196.md` to document the constructor behavior and include an example.

## Validation
- Ran targeted MA0196 analyzer tests on default Roslyn and on `roslyn4.2` and `roslyn4.14`.
- Regenerated documentation with `dotnet run --project src/DocumentationGenerator`.

Fix https://github.com/meziantou/Meziantou.Analyzer/issues/1145