### PR TITLE
Add NonAsyncDisposableTypeAttribute for await using

### DIFF
--- a/docs/Rules/MA0042.md
+++ b/docs/Rules/MA0042.md
@@ -123,11 +123,20 @@ The attribute supports:
 - a documentation ID (`M:...` for methods, `P:...` for properties) for exact matching
 - `Type` + member name (+ optional parameter types) for direct signature-based matching
 
-You can also exclude `await` / `await using` recommendations for specific types using `NonAwaitableTypeAttribute`:
+You can also exclude `await` recommendations for specific types using `NonAwaitableTypeAttribute`:
 To use `Meziantou.Analyzer.Annotations.NonAwaitableTypeAttribute`, add the `Meziantou.Analyzer.Annotations` NuGet package (or copy the attribute source into your project). See [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md).
 
 ```csharp
 [assembly: Meziantou.Analyzer.Annotations.NonAwaitableTypeAttribute(typeof(System.Data.Common.DbCommand))]
+```
+
+The match is exact-type only. Derived types are not excluded unless explicitly listed.
+
+You can also exclude `await using` recommendations for specific types using `NonAsyncDisposableTypeAttribute`:
+To use `Meziantou.Analyzer.Annotations.NonAsyncDisposableTypeAttribute`, add the `Meziantou.Analyzer.Annotations` NuGet package (or copy the attribute source into your project). See [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md).
+
+```csharp
+[assembly: Meziantou.Analyzer.Annotations.NonAsyncDisposableTypeAttribute(typeof(System.Data.Common.DbCommand))]
 ```
 
 The match is exact-type only. Derived types are not excluded unless explicitly listed.

--- a/docs/Rules/MA0045.md
+++ b/docs/Rules/MA0045.md
@@ -66,11 +66,20 @@ The attribute supports:
 - a documentation ID (`M:...` for methods, `P:...` for properties) for exact matching
 - `Type` + member name (+ optional parameter types) for direct signature-based matching
 
-You can also exclude `await` / `await using` recommendations for specific types using `NonAwaitableTypeAttribute`:
+You can also exclude `await` recommendations for specific types using `NonAwaitableTypeAttribute`:
 To use `Meziantou.Analyzer.Annotations.NonAwaitableTypeAttribute`, add the `Meziantou.Analyzer.Annotations` NuGet package (or copy the attribute source into your project). See [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md).
 
 ```csharp
 [assembly: Meziantou.Analyzer.Annotations.NonAwaitableTypeAttribute(typeof(System.Data.Common.DbCommand))]
+```
+
+The match is exact-type only. Derived types are not excluded unless explicitly listed.
+
+You can also exclude `await using` recommendations for specific types using `NonAsyncDisposableTypeAttribute`:
+To use `Meziantou.Analyzer.Annotations.NonAsyncDisposableTypeAttribute`, add the `Meziantou.Analyzer.Annotations` NuGet package (or copy the attribute source into your project). See [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md).
+
+```csharp
+[assembly: Meziantou.Analyzer.Annotations.NonAsyncDisposableTypeAttribute(typeof(System.Data.Common.DbCommand))]
 ```
 
 The match is exact-type only. Derived types are not excluded unless explicitly listed.

--- a/src/Meziantou.Analyzer.Annotations/Meziantou.Analyzer.Annotations.csproj
+++ b/src/Meziantou.Analyzer.Annotations/Meziantou.Analyzer.Annotations.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <Description>Annotations to configure Meziantou.Analyzer</Description>
     <PackageTags>Meziantou.Analyzer, analyzers</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Meziantou.Analyzer.Annotations/NonAsyncDisposableTypeAttribute.cs
+++ b/src/Meziantou.Analyzer.Annotations/NonAsyncDisposableTypeAttribute.cs
@@ -1,0 +1,12 @@
+#pragma warning disable CS1591
+#pragma warning disable IDE0060
+#pragma warning disable CA1019
+
+namespace Meziantou.Analyzer.Annotations;
+
+[System.Diagnostics.Conditional("MEZIANTOU_ANALYZER_ANNOTATIONS")]
+[System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+public sealed class NonAsyncDisposableTypeAttribute : System.Attribute
+{
+    public NonAsyncDisposableTypeAttribute(System.Type type) { }
+}

--- a/src/Meziantou.Analyzer.Annotations/README.md
+++ b/src/Meziantou.Analyzer.Annotations/README.md
@@ -19,7 +19,8 @@ If you want to keep these attributes in the metadata (for example, for reflectio
 | Attribute | Purpose | Related rules |
 | --- | --- | --- |
 | `CultureInsensitiveTypeAttribute` | Marks a type (or a specific format) as culture-insensitive. | [MA0011](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0011.md), [MA0075](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0075.md), [MA0076](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0076.md), [MA0185](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0185.md) |
-| `NonAwaitableTypeAttribute` | Excludes await/await-using recommendations for specific types. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md), [MA0134](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md), [MA0137](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0137.md), [MA0138](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0138.md) |
+| `NonAwaitableTypeAttribute` | Excludes await recommendations for specific types. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md), [MA0134](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md), [MA0137](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0137.md), [MA0138](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0138.md) |
+| `NonAsyncDisposableTypeAttribute` | Excludes `await using` recommendations for specific types. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md) |
 | `ExcludeFromBlockingCallAnalysisAttribute` | Excludes specific methods/properties from blocking-call diagnostics. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md) |
 | `RequireNamedArgumentAttribute` | Requires named arguments for decorated parameters. | [MA0003](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0003.md) |
 | `StructuredLogFieldAttribute` | Declares allowed types for named log properties in an assembly. | [MA0124](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0124.md), [MA0139](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0139.md) |
@@ -35,9 +36,18 @@ Use `ExcludeFromBlockingCallAnalysisAttribute` to exclude specific MA0042/MA0045
 
 ## NonAwaitableTypeAttribute
 
-Use `NonAwaitableTypeAttribute` to exclude MA0042/MA0045 `await`/`await using` recommendations for specific types at the assembly level.
+Use `NonAwaitableTypeAttribute` to exclude MA0042/MA0045 `await` recommendations for specific types at the assembly level.
 The match is exact-type only. Derived types are not excluded unless explicitly listed.
 
 ```csharp
 [assembly: Meziantou.Analyzer.Annotations.NonAwaitableTypeAttribute(typeof(System.Data.Common.DbCommand))]
+```
+
+## NonAsyncDisposableTypeAttribute
+
+Use `NonAsyncDisposableTypeAttribute` to exclude MA0042/MA0045 `await using` recommendations for specific types at the assembly level.
+The match is exact-type only. Derived types are not excluded unless explicitly listed.
+
+```csharp
+[assembly: Meziantou.Analyzer.Annotations.NonAsyncDisposableTypeAttribute(typeof(System.Data.Common.DbCommand))]
 ```

--- a/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
+++ b/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
@@ -92,4 +92,26 @@ internal static class AnnotationAttributes
             }
         };
     }
+
+    public static bool IsNonAsyncDisposableTypeAttributeSymbol(ITypeSymbol? symbol)
+    {
+        // Meziantou.Analyzer.Annotations.NonAsyncDisposableTypeAttribute
+        return symbol is INamedTypeSymbol
+        {
+            Name: "NonAsyncDisposableTypeAttribute",
+            ContainingSymbol: INamespaceSymbol
+            {
+                Name: "Annotations",
+                ContainingSymbol: INamespaceSymbol
+                {
+                    Name: "Analyzer",
+                    ContainingSymbol: INamespaceSymbol
+                    {
+                        Name: "Meziantou",
+                        ContainingSymbol: INamespaceSymbol { IsGlobalNamespace: true }
+                    }
+                }
+            }
+        };
+    }
 }

--- a/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
+++ b/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
@@ -7,6 +7,7 @@ internal sealed class AwaitableTypes
 {
     private readonly INamedTypeSymbol[] _taskOrValueTaskSymbols;
     private readonly HashSet<INamedTypeSymbol> _nonAwaitableTypes;
+    private readonly HashSet<INamedTypeSymbol> _nonAsyncDisposableTypes;
     private readonly Compilation _compilation;
     private readonly ConcurrentDictionary<ITypeSymbol, bool> _isAwaitableCache = new(SymbolEqualityComparer.Default);
 
@@ -34,6 +35,7 @@ internal sealed class AwaitableTypes
         }
 
         _nonAwaitableTypes = CreateNonAwaitableTypes(compilation);
+        _nonAsyncDisposableTypes = CreateNonAsyncDisposableTypes(compilation);
         _compilation = compilation;
     }
 
@@ -49,15 +51,23 @@ internal sealed class AwaitableTypes
         if (_nonAwaitableTypes.Count == 0 || symbol is not INamedTypeSymbol namedType)
             return false;
 
-        return IsNonAwaitableTypeCore(namedType);
+        return IsConfiguredTypeCore(namedType, _nonAwaitableTypes);
     }
 
-    private bool IsNonAwaitableTypeCore(INamedTypeSymbol type)
+    public bool IsNonAsyncDisposableType(ITypeSymbol? symbol)
     {
-        if (_nonAwaitableTypes.Contains(type))
+        if (_nonAsyncDisposableTypes.Count == 0 || symbol is not INamedTypeSymbol namedType)
+            return false;
+
+        return IsConfiguredTypeCore(namedType, _nonAsyncDisposableTypes);
+    }
+
+    private static bool IsConfiguredTypeCore(INamedTypeSymbol type, HashSet<INamedTypeSymbol> configuredTypes)
+    {
+        if (configuredTypes.Contains(type))
             return true;
 
-        if (!ReferenceEquals(type, type.OriginalDefinition) && _nonAwaitableTypes.Contains(type.OriginalDefinition))
+        if (!ReferenceEquals(type, type.OriginalDefinition) && configuredTypes.Contains(type.OriginalDefinition))
             return true;
 
         return false;
@@ -69,6 +79,28 @@ internal sealed class AwaitableTypes
         foreach (var attribute in compilation.Assembly.GetAttributes())
         {
             if (!AnnotationAttributes.IsNonAwaitableTypeAttributeSymbol(attribute.AttributeClass))
+                continue;
+
+            var constructorArguments = attribute.ConstructorArguments;
+            if (constructorArguments is [{ Value: INamedTypeSymbol type }])
+            {
+                result.Add(type);
+                if (!ReferenceEquals(type.OriginalDefinition, type))
+                {
+                    result.Add(type.OriginalDefinition);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static HashSet<INamedTypeSymbol> CreateNonAsyncDisposableTypes(Compilation compilation)
+    {
+        var result = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        foreach (var attribute in compilation.Assembly.GetAttributes())
+        {
+            if (!AnnotationAttributes.IsNonAsyncDisposableTypeAttributeSymbol(attribute.AttributeClass))
                 continue;
 
             var constructorArguments = attribute.ConstructorArguments;

--- a/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
+++ b/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
@@ -7,7 +7,6 @@ internal sealed class AwaitableTypes
 {
     private readonly INamedTypeSymbol[] _taskOrValueTaskSymbols;
     private readonly HashSet<INamedTypeSymbol> _nonAwaitableTypes;
-    private readonly HashSet<INamedTypeSymbol> _nonAsyncDisposableTypes;
     private readonly Compilation _compilation;
     private readonly ConcurrentDictionary<ITypeSymbol, bool> _isAwaitableCache = new(SymbolEqualityComparer.Default);
 
@@ -35,7 +34,6 @@ internal sealed class AwaitableTypes
         }
 
         _nonAwaitableTypes = CreateNonAwaitableTypes(compilation);
-        _nonAsyncDisposableTypes = CreateNonAsyncDisposableTypes(compilation);
         _compilation = compilation;
     }
 
@@ -52,14 +50,6 @@ internal sealed class AwaitableTypes
             return false;
 
         return IsConfiguredTypeCore(namedType, _nonAwaitableTypes);
-    }
-
-    public bool IsNonAsyncDisposableType(ITypeSymbol? symbol)
-    {
-        if (_nonAsyncDisposableTypes.Count == 0 || symbol is not INamedTypeSymbol namedType)
-            return false;
-
-        return IsConfiguredTypeCore(namedType, _nonAsyncDisposableTypes);
     }
 
     private static bool IsConfiguredTypeCore(INamedTypeSymbol type, HashSet<INamedTypeSymbol> configuredTypes)
@@ -79,28 +69,6 @@ internal sealed class AwaitableTypes
         foreach (var attribute in compilation.Assembly.GetAttributes())
         {
             if (!AnnotationAttributes.IsNonAwaitableTypeAttributeSymbol(attribute.AttributeClass))
-                continue;
-
-            var constructorArguments = attribute.ConstructorArguments;
-            if (constructorArguments is [{ Value: INamedTypeSymbol type }])
-            {
-                result.Add(type);
-                if (!ReferenceEquals(type.OriginalDefinition, type))
-                {
-                    result.Add(type.OriginalDefinition);
-                }
-            }
-        }
-
-        return result;
-    }
-
-    private static HashSet<INamedTypeSymbol> CreateNonAsyncDisposableTypes(Compilation compilation)
-    {
-        var result = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-        foreach (var attribute in compilation.Assembly.GetAttributes())
-        {
-            if (!AnnotationAttributes.IsNonAsyncDisposableTypeAttributeSymbol(attribute.AttributeClass))
                 continue;
 
             var constructorArguments = attribute.ConstructorArguments;

--- a/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
+++ b/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
@@ -52,7 +52,7 @@ internal sealed class AwaitableTypes
         return IsConfiguredTypeCore(namedType, _nonAwaitableTypes);
     }
 
-    private static bool IsConfiguredTypeCore(INamedTypeSymbol type, HashSet<INamedTypeSymbol> configuredTypes)
+    private bool IsConfiguredTypeCore(INamedTypeSymbol type, HashSet<INamedTypeSymbol> configuredTypes)
     {
         if (configuredTypes.Contains(type))
             return true;

--- a/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
+++ b/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
@@ -49,15 +49,15 @@ internal sealed class AwaitableTypes
         if (_nonAwaitableTypes.Count == 0 || symbol is not INamedTypeSymbol namedType)
             return false;
 
-        return IsConfiguredTypeCore(namedType, _nonAwaitableTypes);
+        return IsNonAwaitableTypeCore(namedType);
     }
 
-    private bool IsConfiguredTypeCore(INamedTypeSymbol type, HashSet<INamedTypeSymbol> configuredTypes)
+    private bool IsNonAwaitableTypeCore(INamedTypeSymbol type)
     {
-        if (configuredTypes.Contains(type))
+        if (_nonAwaitableTypes.Contains(type))
             return true;
 
-        if (!ReferenceEquals(type, type.OriginalDefinition) && configuredTypes.Contains(type.OriginalDefinition))
+        if (!ReferenceEquals(type, type.OriginalDefinition) && _nonAwaitableTypes.Contains(type.OriginalDefinition))
             return true;
 
         return false;

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -59,6 +59,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
 
         private readonly INamedTypeSymbol[] _taskAwaiterLikeSymbols;
         private readonly HashSet<ISymbol> _excludedDiagnosticSymbols;
+        private readonly HashSet<INamedTypeSymbol> _nonAsyncDisposableTypes;
         private readonly ConcurrentHashSet<IMethodSymbol> _symbolsWithNoAsyncOverloads = new(SymbolEqualityComparer.Default);
 
         public Context(Compilation compilation)
@@ -132,6 +133,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             taskAwaiterLikeSymbols.AddIfNotNull(ValueTaskAwaiterOfTSymbol);
             _taskAwaiterLikeSymbols = [.. taskAwaiterLikeSymbols];
             _excludedDiagnosticSymbols = CreateExcludedDiagnosticSymbols(compilation);
+            _nonAsyncDisposableTypes = CreateNonAsyncDisposableTypes(compilation);
         }
 
         private ISymbol? StreamSymbol { get; }
@@ -419,6 +421,47 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             }
         }
 
+        private bool IsNonAsyncDisposableType(ITypeSymbol? symbol)
+        {
+            if (_nonAsyncDisposableTypes.Count == 0 || symbol is not INamedTypeSymbol namedType)
+                return false;
+
+            return IsConfiguredType(namedType, _nonAsyncDisposableTypes);
+        }
+
+        private static HashSet<INamedTypeSymbol> CreateNonAsyncDisposableTypes(Compilation compilation)
+        {
+            var result = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            foreach (var attribute in compilation.Assembly.GetAttributes())
+            {
+                if (!AnnotationAttributes.IsNonAsyncDisposableTypeAttributeSymbol(attribute.AttributeClass))
+                    continue;
+
+                var constructorArguments = attribute.ConstructorArguments;
+                if (constructorArguments is [{ Value: INamedTypeSymbol type }])
+                {
+                    result.Add(type);
+                    if (!ReferenceEquals(type, type.OriginalDefinition))
+                    {
+                        result.Add(type.OriginalDefinition);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static bool IsConfiguredType(INamedTypeSymbol type, HashSet<INamedTypeSymbol> configuredTypes)
+        {
+            if (configuredTypes.Contains(type))
+                return true;
+
+            if (!ReferenceEquals(type, type.OriginalDefinition) && configuredTypes.Contains(type.OriginalDefinition))
+                return true;
+
+            return false;
+        }
+
         private bool IsExcludedDiagnosticSymbol(ISymbol symbol)
         {
             if (_excludedDiagnosticSymbols.Count == 0)
@@ -662,7 +705,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             if (operation.GetActualType() is not INamedTypeSymbol type)
                 return false;
 
-            if (_awaitableTypes.IsNonAsyncDisposableType(type))
+            if (IsNonAsyncDisposableType(type))
                 return false;
 
             var isSqliteSpecialCaseType = IsSqliteSpecialCaseType(type);

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -662,7 +662,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             if (operation.GetActualType() is not INamedTypeSymbol type)
                 return false;
 
-            if (_awaitableTypes.IsNonAwaitableType(type))
+            if (_awaitableTypes.IsNonAsyncDisposableType(type))
                 return false;
 
             var isSqliteSpecialCaseType = IsSqliteSpecialCaseType(type);

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -3617,7 +3617,7 @@ class Sample
     }
 
     [Fact]
-    public async Task NonAwaitableTypeAttribute_DoesAffectAwaitUsing()
+    public async Task NonAwaitableTypeAttribute_DoesNotAffectAwaitUsing()
     {
         await CreateProjectBuilder()
               .AddMeziantouAttributes()
@@ -3625,6 +3625,33 @@ class Sample
                 using System;
                 using System.Threading.Tasks;
                 [assembly: Meziantou.Analyzer.Annotations.NonAwaitableTypeAttribute(typeof(AsyncDisposable))]
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        [|using var value = new AsyncDisposable();|]
+                    }
+                }
+
+                class AsyncDisposable : IDisposable, IAsyncDisposable
+                {
+                    public void Dispose() { }
+                    public ValueTask DisposeAsync() => default;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NonAsyncDisposableTypeAttribute_DoesAffectAwaitUsing()
+    {
+        await CreateProjectBuilder()
+              .AddMeziantouAttributes()
+              .WithSourceCode("""
+                using System;
+                using System.Threading.Tasks;
+                [assembly: Meziantou.Analyzer.Annotations.NonAsyncDisposableTypeAttribute(typeof(AsyncDisposable))]
 
                 class Test
                 {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
@@ -419,7 +419,7 @@ public class Test
     }
 
     [Fact]
-    public async Task NonAwaitableTypeAttribute_DoesAffectAwaitUsing()
+    public async Task NonAwaitableTypeAttribute_DoesNotAffectAwaitUsing()
     {
         await CreateProjectBuilder()
               .AddMeziantouAttributes()
@@ -427,6 +427,33 @@ public class Test
                 using System;
                 using System.Threading.Tasks;
                 [assembly: Meziantou.Analyzer.Annotations.NonAwaitableTypeAttribute(typeof(AsyncDisposable))]
+
+                class Test
+                {
+                    private void A()
+                    {
+                        [|using var value = new AsyncDisposable();|]
+                    }
+                }
+
+                class AsyncDisposable : IDisposable, IAsyncDisposable
+                {
+                    public void Dispose() { }
+                    public ValueTask DisposeAsync() => default;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NonAsyncDisposableTypeAttribute_DoesAffectAwaitUsing()
+    {
+        await CreateProjectBuilder()
+              .AddMeziantouAttributes()
+              .WithSourceCode("""
+                using System;
+                using System.Threading.Tasks;
+                [assembly: Meziantou.Analyzer.Annotations.NonAsyncDisposableTypeAttribute(typeof(AsyncDisposable))]
 
                 class Test
                 {


### PR DESCRIPTION
`NonAwaitableTypeAttribute` was suppressing both `await` and `await using` recommendations, which made it impossible to opt out of only `await using` guidance. This change separates those concerns so projects can configure each behavior independently.

## What changed
- Added `NonAsyncDisposableTypeAttribute` in `Meziantou.Analyzer.Annotations` for `await using` suppression.
- Updated MA0042/MA0045 await-using analysis to honor only `NonAsyncDisposableTypeAttribute`.
- Kept `NonAwaitableTypeAttribute` for awaitability checks (`await`) only.
- Updated analyzer internals to detect both attributes separately.
- Updated tests in async and non-async MA0042 suites to lock the new behavior.
- Updated documentation for MA0042, MA0045, and annotations README.
- Bumped `Meziantou.Analyzer.Annotations` version to `1.5.0`.

## Notes for reviewers
This intentionally changes behavior: existing projects that used `NonAwaitableTypeAttribute` to suppress `await using` diagnostics now need to use `NonAsyncDisposableTypeAttribute`.

Fix https://github.com/meziantou/Meziantou.Analyzer/issues/1152