### PR TITLE
Improve MA0192 HasFlag detection for zero comparisons

### DIFF
--- a/docs/Rules/MA0192.md
+++ b/docs/Rules/MA0192.md
@@ -11,6 +11,12 @@ This rule reports patterns such as:
 - `(value & MyEnum.Flag1) != MyEnum.Flag1`
 - `(value & MyEnum.Flag1) is MyEnum.Flag1`
 - `(value & MyEnum.Flag1) is not MyEnum.Flag1`
+- `(value & MyEnum.Flag1) == 0`
+- `(value & MyEnum.Flag1) != 0`
+- `(value & MyEnum.Flag1) is 0`
+- `(value & MyEnum.Flag1) is not 0`
+
+For comparisons against `0`, the enum member used in the bitwise `&` must be a single-bit value (for example `1`, `2`, `4`, `8`, ...). Combined values are ignored.
 
 ## Non-compliant code
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseHasFlagMethodFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseHasFlagMethodFixer.cs
@@ -184,42 +184,53 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
         var rightOperand = bitwiseAndOperation.RightOperand.UnwrapImplicitConversionOperations();
         comparedOperand = comparedOperand.UnwrapImplicitConversionOperations();
 
-        if (TryGetEnumFlagReference(rightOperand, comparedOperand, out var flagOperation) &&
+        if (TryGetEnumFlagReference(rightOperand, comparedOperand, out var flagOperation, out var comparedWithZero) &&
             IsValidPattern(leftOperand, flagOperation) &&
             leftOperand.Syntax is ExpressionSyntax enumValueExpression &&
             flagOperation.Syntax is ExpressionSyntax flagExpression)
         {
-            return new(operationExpression, enumValueExpression, flagExpression, negate);
+            return new(operationExpression, enumValueExpression, flagExpression, comparedWithZero ? !negate : negate);
         }
 
-        if (TryGetEnumFlagReference(leftOperand, comparedOperand, out flagOperation) &&
+        if (TryGetEnumFlagReference(leftOperand, comparedOperand, out flagOperation, out comparedWithZero) &&
             IsValidPattern(rightOperand, flagOperation) &&
             rightOperand.Syntax is ExpressionSyntax enumValueExpression2 &&
             flagOperation.Syntax is ExpressionSyntax flagExpression2)
         {
-            return new(operationExpression, enumValueExpression2, flagExpression2, negate);
+            return new(operationExpression, enumValueExpression2, flagExpression2, comparedWithZero ? !negate : negate);
         }
 
         return null;
     }
 
-    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IFieldReferenceOperation? flagOperation)
+    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IFieldReferenceOperation? flagOperation, out bool comparedWithZero)
     {
         potentialFlag = potentialFlag.UnwrapImplicitConversionOperations();
         comparedOperand = comparedOperand.UnwrapImplicitConversionOperations();
 
         if (potentialFlag is IFieldReferenceOperation firstFieldReference &&
-            comparedOperand is IFieldReferenceOperation secondFieldReference &&
             firstFieldReference.Field.HasConstantValue &&
-            secondFieldReference.Field.HasConstantValue &&
-            firstFieldReference.Field.IsEqualTo(secondFieldReference.Field) &&
             firstFieldReference.Field.ContainingType.IsEnumeration())
         {
-            flagOperation = secondFieldReference;
-            return true;
+            if (comparedOperand is IFieldReferenceOperation secondFieldReference &&
+                secondFieldReference.Field.HasConstantValue &&
+                firstFieldReference.Field.IsEqualTo(secondFieldReference.Field))
+            {
+                flagOperation = secondFieldReference;
+                comparedWithZero = false;
+                return true;
+            }
+
+            if (comparedOperand.IsConstantZero() && IsSingleBitSet(firstFieldReference.Field.ConstantValue))
+            {
+                flagOperation = firstFieldReference;
+                comparedWithZero = true;
+                return true;
+            }
         }
 
         flagOperation = null;
+        comparedWithZero = false;
         return false;
     }
 
@@ -235,6 +246,23 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
             return false;
 
         return enumValueOperation.Type.IsEqualTo(flagOperation.Type);
+    }
+
+    private static bool IsSingleBitSet(object? value)
+    {
+        return value switch
+        {
+            null => false,
+            sbyte x => IsSingleBitSet((byte)x),
+            byte x => x > 0 && (x & (x - 1)) == 0,
+            short x => IsSingleBitSet((ushort)x),
+            ushort x => x > 0 && (x & (x - 1)) == 0,
+            int x => IsSingleBitSet((uint)x),
+            uint x => x > 0 && (x & (x - 1)) == 0,
+            long x => IsSingleBitSet((ulong)x),
+            ulong x => x > 0 && (x & (x - 1)) == 0,
+            _ => false,
+        };
     }
 
     private sealed record HasFlagPattern(ExpressionSyntax OperationExpression, ExpressionSyntax EnumValueExpression, ExpressionSyntax FlagExpression, bool Negate)

--- a/src/Meziantou.Analyzer/Internals/NumericHelpers.cs
+++ b/src/Meziantou.Analyzer/Internals/NumericHelpers.cs
@@ -20,4 +20,21 @@ internal static class NumericHelpers
             _ => false,
         };
     }
+
+    public static bool IsSingleBitSet(object? value)
+    {
+        return value switch
+        {
+            null => false,
+            sbyte x => IsSingleBitSet((byte)x),
+            byte x => x > 0 && (x & (x - 1)) == 0,
+            short x => IsSingleBitSet((ushort)x),
+            ushort x => x > 0 && (x & (x - 1)) == 0,
+            int x => IsSingleBitSet((uint)x),
+            uint x => x > 0 && (x & (x - 1)) == 0,
+            long x => IsSingleBitSet((ulong)x),
+            ulong x => x > 0 && (x & (x - 1)) == 0,
+            _ => false,
+        };
+    }
 }

--- a/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
@@ -141,14 +141,22 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
         comparedOperand = comparedOperand.UnwrapImplicitConversionOperations();
 
         if (potentialFlag is IFieldReferenceOperation firstFieldReference &&
-            comparedOperand is IFieldReferenceOperation secondFieldReference &&
             firstFieldReference.Field.HasConstantValue &&
-            secondFieldReference.Field.HasConstantValue &&
-            firstFieldReference.Field.IsEqualTo(secondFieldReference.Field) &&
             firstFieldReference.Field.ContainingType.IsEnumeration())
         {
-            flagOperation = secondFieldReference;
-            return true;
+            if (comparedOperand is IFieldReferenceOperation secondFieldReference &&
+                secondFieldReference.Field.HasConstantValue &&
+                firstFieldReference.Field.IsEqualTo(secondFieldReference.Field))
+            {
+                flagOperation = secondFieldReference;
+                return true;
+            }
+
+            if (comparedOperand.IsConstantZero() && NumericHelpers.IsSingleBitSet(firstFieldReference.Field.ConstantValue))
+            {
+                flagOperation = firstFieldReference;
+                return true;
+            }
         }
 
         flagOperation = null;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
@@ -187,6 +187,146 @@ public sealed class UseHasFlagMethodAnalyzerTests
     }
 
     [Fact]
+    public async Task EqualsZeroCheck_ReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value) => [|(value & MyEnum.Flag1) == 0|];
+                }
+                """)
+            .ShouldFixCodeWith("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value) => !value.HasFlag(MyEnum.Flag1);
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NotEqualsZeroCheck_ReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value) => [|(value & MyEnum.Flag1) != 0|];
+                }
+                """)
+            .ShouldFixCodeWith("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value) => value.HasFlag(MyEnum.Flag1);
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task IsPatternZeroCheck_ReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value) => [|(value & MyEnum.Flag1) is 0|];
+                }
+                """)
+            .ShouldFixCodeWith("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value) => !value.HasFlag(MyEnum.Flag1);
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task IsNotPatternZeroCheck_ReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value) => [|(value & MyEnum.Flag1) is not 0|];
+                }
+                """)
+            .ShouldFixCodeWith("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value) => value.HasFlag(MyEnum.Flag1);
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
     public async Task DifferentFlag_NoDiagnostic()
     {
         await CreateProjectBuilder()
@@ -202,6 +342,28 @@ public sealed class UseHasFlagMethodAnalyzerTests
                 class Sample
                 {
                     bool M(MyEnum value) => (value & MyEnum.Flag1) == MyEnum.Flag2;
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CombinedFlag_NotEqualsZero_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                    Flag1AndFlag2 = Flag1 | Flag2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value) => (value & MyEnum.Flag1AndFlag2) != 0;
                 }
                 """)
             .ValidateAsync();


### PR DESCRIPTION
MA0192 currently catches `(value & Flag) == Flag` style checks, but it misses the common zero-comparison form used to test bit presence. This makes the rule inconsistent and leaves valid `HasFlag` simplifications unreported.

## What changed

- Extend MA0192 analyzer detection to support:
  - `(value & Flag) == 0`
  - `(value & Flag) != 0`
  - `(value & Flag) is 0`
  - `(value & Flag) is not 0`
- Keep existing same-flag patterns (`== Flag`, `!= Flag`, `is Flag`, `is not Flag`).
- Restrict zero-based detections to single-bit enum members only (non-zero power-of-two values), so combined flags do not trigger diagnostics.
- Update the code fix logic to preserve correct semantics for zero comparisons (`== 0`/`is 0` -> `!HasFlag`, `!= 0`/`is not 0` -> `HasFlag`).
- Add/extend tests for new positive and negative scenarios.
- Update MA0192 documentation to describe the new supported patterns and single-bit constraint.

## Notes for reviewers

The main non-obvious behavior is the single-bit guard for zero comparisons. This is intentional to avoid changing meaning for combined flag constants where `HasFlag` and `!= 0` are not equivalent.