### PR TITLE
Fix MA0194 merge with existing and-patterns

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MergeIsPatternChecksFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MergeIsPatternChecksFixer.cs
@@ -207,8 +207,7 @@ public sealed class MergeIsPatternChecksFixer : CodeFixProvider
             return pattern;
 
         if (pattern is BinaryPatternSyntax binaryPattern &&
-            parentPatternKind is SyntaxKind.AndPattern &&
-            binaryPattern.Kind() is SyntaxKind.OrPattern)
+            (parentPatternKind, binaryPattern.Kind()) is (SyntaxKind.AndPattern, SyntaxKind.OrPattern) or (SyntaxKind.OrPattern, SyntaxKind.AndPattern))
         {
             return ParenthesizedPattern(pattern);
         }
@@ -266,6 +265,12 @@ public sealed class MergeIsPatternChecksFixer : CodeFixProvider
 
     private static bool TryCreatePatternSyntax(IPatternOperation patternOperation, out PatternSyntax patternSyntax)
     {
+        if (patternOperation.Syntax is PatternSyntax patternFromSyntax)
+        {
+            patternSyntax = patternFromSyntax;
+            return true;
+        }
+
         switch (patternOperation)
         {
             case IConstantPatternOperation constantPatternOperation:

--- a/tests/Meziantou.Analyzer.Test/Rules/MergeIsPatternChecksAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MergeIsPatternChecksAnalyzerTests.cs
@@ -90,6 +90,21 @@ public sealed class MergeIsPatternChecksAnalyzerTests
     }
 
     [Fact]
+    public async Task LogicalOr_ParenthesizeAndPattern()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  byte marker = 0;
+                  _ = [|marker is 0x01 || marker is >= 0xD0 and <= 0xD7|];
+                  """)
+              .ShouldFixCodeWith("""
+                  byte marker = 0;
+                  _ = marker is 0x01 or (>= 0xD0 and <= 0xD7);
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task DifferentExpressions_DoNotReport()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
## Why
MA0194 did not merge some valid `is` expressions when one side already used a relational `and` pattern. It could also produce ambiguous output without explicit grouping when `or` combined with an `and` subpattern.

## What changed
- Reused existing pattern syntax in `TryCreatePatternSyntax` when Roslyn already provides a `PatternSyntax`, so relational patterns remain mergeable.
- Updated parenthesizing logic to add parentheses for mixed precedence in both directions (`and` with `or`, and `or` with `and`).
- Added a regression test (`LogicalOr_ParenthesizeAndPattern`) to verify:
  - `marker is 0x01 || marker is >= 0xD0 and <= 0xD7`
  - becomes `marker is 0x01 or (>= 0xD0 and <= 0xD7)`.

## Validation
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj --filter "FullyQualifiedName~MergeIsPatternChecksAnalyzerTests" --nologo`