### PR TITLE
Add analyzer for identical conditional compilation branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0199](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0199.md)|Design|Do not use inheritdoc on types without inheritance source|⚠️|✔️|❌|
 |[MA0200](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0200.md)|Usage|Do not use empty property patterns with non-nullable value types|ℹ️|✔️|✔️|
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|⚠️|✔️|❌|
-|[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|⚠️|✔️|❌|
+|[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|⚠️|✔️|✔️|
 
 <!-- rules -->
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0199](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0199.md)|Design|Do not use inheritdoc on types without inheritance source|⚠️|✔️|❌|
 |[MA0200](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0200.md)|Usage|Do not use empty property patterns with non-nullable value types|ℹ️|✔️|✔️|
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|⚠️|✔️|❌|
+|[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|⚠️|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -200,6 +200,7 @@
 |[MA0199](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0199.md)|Design|Do not use inheritdoc on types without inheritance source|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0200](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0200.md)|Usage|Do not use empty property patterns with non-nullable value types|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|<span title='Warning'>⚠️</span>|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|
@@ -815,6 +816,9 @@ dotnet_diagnostic.MA0200.severity = suggestion
 
 # MA0201: Do not use zero-valued enum flags in flag checks
 dotnet_diagnostic.MA0201.severity = warning
+
+# MA0202: Conditional compilation branches have identical code
+dotnet_diagnostic.MA0202.severity = warning
 ```
 
 # .editorconfig - all rules disabled
@@ -1416,4 +1420,7 @@ dotnet_diagnostic.MA0200.severity = none
 
 # MA0201: Do not use zero-valued enum flags in flag checks
 dotnet_diagnostic.MA0201.severity = none
+
+# MA0202: Conditional compilation branches have identical code
+dotnet_diagnostic.MA0202.severity = none
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -200,7 +200,7 @@
 |[MA0199](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0199.md)|Design|Do not use inheritdoc on types without inheritance source|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0200](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0200.md)|Usage|Do not use empty property patterns with non-nullable value types|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|<span title='Warning'>⚠️</span>|✔️|❌|
-|[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|<span title='Warning'>⚠️</span>|✔️|✔️|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0202.md
+++ b/docs/Rules/MA0202.md
@@ -1,6 +1,6 @@
 # MA0202 - Conditional compilation branches have identical code
 <!-- sources -->
-Source: [ConditionalCompilationBranchesAreIdenticalAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs)
+Sources: [ConditionalCompilationBranchesAreIdenticalAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs), [ConditionalCompilationBranchesAreIdenticalFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/ConditionalCompilationBranchesAreIdenticalFixer.cs)
 <!-- sources -->
 
 This rule reports duplicate code in a single `#if` / `#elif` / `#else` block.

--- a/docs/Rules/MA0202.md
+++ b/docs/Rules/MA0202.md
@@ -1,0 +1,15 @@
+# MA0202 - Conditional compilation branches have identical code
+<!-- sources -->
+Source: [ConditionalCompilationBranchesAreIdenticalAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs)
+<!-- sources -->
+
+````c#
+// non-compliant: #if and #elif branches contain the same code
+#if NET6_0_OR_GREATER
+Console.WriteLine("sample");
+#elif NET8_0_OR_GREATER
+Console.WriteLine("sample");
+#else
+Console.WriteLine("other");
+#endif
+````

--- a/docs/Rules/MA0202.md
+++ b/docs/Rules/MA0202.md
@@ -3,13 +3,34 @@
 Source: [ConditionalCompilationBranchesAreIdenticalAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs)
 <!-- sources -->
 
-````c#
-// non-compliant: #if and #elif branches contain the same code
+This rule reports duplicate code in a single `#if` / `#elif` / `#else` block.
+
+If a branch has the same code as any previous branch in the same conditional compilation block, the directive is redundant and should be simplified.
+
+The comparison ignores trivia (such as comments and whitespace), so only the actual code structure is considered.
+
+## Non-compliant code
+
+````csharp
+// #elif and #else duplicate earlier branches
 #if NET6_0_OR_GREATER
 Console.WriteLine("sample");
 #elif NET8_0_OR_GREATER
 Console.WriteLine("sample");
 #else
-Console.WriteLine("other");
+// same behavior as NET6_0_OR_GREATER
+Console.WriteLine("sample");
+#endif
+````
+
+## Compliant code
+
+````csharp
+#if NET9_0_OR_GREATER
+Console.WriteLine("net9");
+#elif NET8_0_OR_GREATER
+Console.WriteLine("net8");
+#else
+Console.WriteLine("legacy");
 #endif
 ````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ConditionalCompilationBranchesAreIdenticalFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ConditionalCompilationBranchesAreIdenticalFixer.cs
@@ -1,0 +1,162 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class ConditionalCompilationBranchesAreIdenticalFixer : CodeFixProvider
+{
+    private const string MergeTitle = "Merge duplicate conditional compilation branches";
+    private const string RemoveTitle = "Remove redundant conditional compilation block";
+
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.ConditionalCompilationBranchesAreIdentical);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var sourceText = await context.Document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+        if (!TryGetFixContext(root, sourceText, context.Span, out var fixContext))
+            return;
+
+        var currentBranch = fixContext.Group.Branches[fixContext.CurrentBranchIndex];
+        var duplicateBranch = fixContext.Group.Branches[fixContext.DuplicateBranchIndex];
+        if (currentBranch.Kind == ConditionalCompilationBranchesAreIdenticalCommon.BranchKind.Else &&
+            duplicateBranch.Kind == ConditionalCompilationBranchesAreIdenticalCommon.BranchKind.If &&
+            fixContext.Group.Branches.Count == 2 &&
+            fixContext.CurrentBranchIndex == 1)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    RemoveTitle,
+                    ct => RemoveRedundantConditionalCompilationAsync(context.Document, context.Diagnostics[0], ct),
+                    equivalenceKey: RemoveTitle),
+                context.Diagnostics);
+        }
+        else if (currentBranch.Kind == ConditionalCompilationBranchesAreIdenticalCommon.BranchKind.Elif &&
+                 duplicateBranch.Kind is ConditionalCompilationBranchesAreIdenticalCommon.BranchKind.If or ConditionalCompilationBranchesAreIdenticalCommon.BranchKind.Elif &&
+                 currentBranch.ConditionText is not null &&
+                 duplicateBranch.ConditionText is not null)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    MergeTitle,
+                    ct => MergeDuplicateConditionalCompilationBranchAsync(context.Document, context.Diagnostics[0], ct),
+                    equivalenceKey: MergeTitle),
+                context.Diagnostics);
+        }
+    }
+
+    private static async Task<Document> RemoveRedundantConditionalCompilationAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        if (!TryGetFixContext(root, sourceText, diagnostic.Location.SourceSpan, out var fixContext))
+            return document;
+
+        var firstBranch = fixContext.Group.Branches[0];
+        var replacementText = sourceText.ToString(firstBranch.ContentSpan);
+        var replacementSpan = TextSpan.FromBounds(fixContext.Group.FirstIfDirective.FullSpan.Start, fixContext.Group.EndIfDirective.FullSpan.End);
+        var updatedText = sourceText.WithChanges(new TextChange(replacementSpan, replacementText));
+        return document.WithText(updatedText);
+    }
+
+    private static async Task<Document> MergeDuplicateConditionalCompilationBranchAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        if (!TryGetFixContext(root, sourceText, diagnostic.Location.SourceSpan, out var fixContext))
+            return document;
+
+        var currentBranch = fixContext.Group.Branches[fixContext.CurrentBranchIndex];
+        var duplicateBranch = fixContext.Group.Branches[fixContext.DuplicateBranchIndex];
+        if (currentBranch.Kind != ConditionalCompilationBranchesAreIdenticalCommon.BranchKind.Elif ||
+            currentBranch.ConditionText is null ||
+            duplicateBranch.ConditionText is null)
+        {
+            return document;
+        }
+
+        var mergedCondition = $"({duplicateBranch.ConditionText}) || ({currentBranch.ConditionText})";
+        var mergedDirective = duplicateBranch.Kind switch
+        {
+            ConditionalCompilationBranchesAreIdenticalCommon.BranchKind.If => "#if " + mergedCondition,
+            ConditionalCompilationBranchesAreIdenticalCommon.BranchKind.Elif => "#elif " + mergedCondition,
+            _ => null,
+        };
+
+        if (mergedDirective is null)
+            return document;
+
+        var removeBranchSpan = TextSpan.FromBounds(currentBranch.StartDirective.FullSpan.Start, currentBranch.NextDirective.FullSpan.Start);
+        var updatedText = sourceText.WithChanges(
+            new TextChange(duplicateBranch.StartDirective.Span, mergedDirective),
+            new TextChange(removeBranchSpan, string.Empty));
+
+        return document.WithText(updatedText);
+    }
+
+    private static bool TryGetFixContext(SyntaxNode root, SourceText sourceText, TextSpan span, out FixContext fixContext)
+    {
+        var directive = FindDirective(root, span);
+        if (directive is null)
+        {
+            fixContext = default;
+            return false;
+        }
+
+        if (!ConditionalCompilationBranchesAreIdenticalCommon.TryCreateBranchGroup(directive, sourceText, out var branchGroup))
+        {
+            fixContext = default;
+            return false;
+        }
+
+        var currentBranchIndex = branchGroup.GetBranchIndex(directive);
+        if (currentBranchIndex <= 0)
+        {
+            fixContext = default;
+            return false;
+        }
+
+        var duplicateBranchIndex = branchGroup.FindPreviousDuplicateBranchIndex(currentBranchIndex);
+        if (duplicateBranchIndex < 0)
+        {
+            fixContext = default;
+            return false;
+        }
+
+        fixContext = new FixContext(branchGroup, currentBranchIndex, duplicateBranchIndex);
+        return true;
+    }
+
+    private static DirectiveTriviaSyntax? FindDirective(SyntaxNode root, TextSpan span)
+    {
+        foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+        {
+            if (!trivia.HasStructure || !trivia.FullSpan.Contains(span.Start))
+                continue;
+
+            if (trivia.GetStructure() is DirectiveTriviaSyntax directive)
+                return directive;
+        }
+
+        return null;
+    }
+
+    private readonly record struct FixContext(ConditionalCompilationBranchesAreIdenticalCommon.BranchGroup Group, int CurrentBranchIndex, int DuplicateBranchIndex);
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -598,3 +598,6 @@ dotnet_diagnostic.MA0200.severity = error
 
 # MA0201: Do not use zero-valued enum flags in flag checks
 dotnet_diagnostic.MA0201.severity = error
+
+# MA0202: Conditional compilation branches have identical code
+dotnet_diagnostic.MA0202.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -598,3 +598,6 @@ dotnet_diagnostic.MA0200.severity = suggestion
 
 # MA0201: Do not use zero-valued enum flags in flag checks
 dotnet_diagnostic.MA0201.severity = suggestion
+
+# MA0202: Conditional compilation branches have identical code
+dotnet_diagnostic.MA0202.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -598,3 +598,6 @@ dotnet_diagnostic.MA0200.severity = warning
 
 # MA0201: Do not use zero-valued enum flags in flag checks
 dotnet_diagnostic.MA0201.severity = warning
+
+# MA0202: Conditional compilation branches have identical code
+dotnet_diagnostic.MA0202.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -598,3 +598,6 @@ dotnet_diagnostic.MA0200.severity = suggestion
 
 # MA0201: Do not use zero-valued enum flags in flag checks
 dotnet_diagnostic.MA0201.severity = warning
+
+# MA0202: Conditional compilation branches have identical code
+dotnet_diagnostic.MA0202.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -598,3 +598,6 @@ dotnet_diagnostic.MA0200.severity = none
 
 # MA0201: Do not use zero-valued enum flags in flag checks
 dotnet_diagnostic.MA0201.severity = none
+
+# MA0202: Conditional compilation branches have identical code
+dotnet_diagnostic.MA0202.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -201,6 +201,7 @@ internal static class RuleIdentifiers
     public const string InheritdocShouldHaveSourceOnTypes = "MA0199";
     public const string DoNotUseEmptyPropertyPatternOnNonNullableValueType = "MA0200";
     public const string DoNotUseZeroValuedEnumFlagsInFlagChecks = "MA0201";
+    public const string ConditionalCompilationBranchesAreIdentical = "MA0202";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ConditionalCompilationBranchesAreIdenticalAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.ConditionalCompilationBranchesAreIdentical,
+        title: "Conditional compilation branches have identical code",
+        messageFormat: "Conditional compilation branches have identical code",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.ConditionalCompilationBranchesAreIdentical));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
+    }
+
+    private static void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
+    {
+        var root = context.Tree.GetRoot(context.CancellationToken);
+        var sourceText = context.Tree.GetText(context.CancellationToken);
+        foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+        {
+            if (!trivia.HasStructure)
+                continue;
+
+            if (trivia.GetStructure() is IfDirectiveTriviaSyntax ifDirective)
+            {
+                AnalyzeDirectiveGroup(context, sourceText, ifDirective);
+            }
+        }
+    }
+
+    private static void AnalyzeDirectiveGroup(SyntaxTreeAnalysisContext context, SourceText sourceText, IfDirectiveTriviaSyntax ifDirective)
+    {
+        var relatedDirectives = ifDirective.GetRelatedDirectives();
+        List<DirectiveTriviaSyntax> branchDirectives = [];
+        DirectiveTriviaSyntax? endIfDirective = null;
+        foreach (var directive in relatedDirectives)
+        {
+            if (directive.IsKind(SyntaxKind.IfDirectiveTrivia) || directive.IsKind(SyntaxKind.ElifDirectiveTrivia) || directive.IsKind(SyntaxKind.ElseDirectiveTrivia))
+            {
+                branchDirectives.Add(directive);
+            }
+            else if (directive.IsKind(SyntaxKind.EndIfDirectiveTrivia))
+            {
+                endIfDirective = directive;
+            }
+        }
+
+        if (endIfDirective is null || branchDirectives.Count < 2)
+            return;
+
+        Dictionary<string, DirectiveTriviaSyntax> previousBranchBySignature = new(StringComparer.Ordinal);
+        for (var i = 0; i < branchDirectives.Count; i++)
+        {
+            var startDirective = branchDirectives[i];
+            var endDirective = i + 1 < branchDirectives.Count ? branchDirectives[i + 1] : endIfDirective;
+            var branchSpan = TextSpan.FromBounds(startDirective.FullSpan.End, endDirective.FullSpan.Start);
+            var signature = ComputeBranchSignature(sourceText, branchSpan);
+            if (previousBranchBySignature.ContainsKey(signature))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, startDirective.GetLocation()));
+            }
+            else
+            {
+                previousBranchBySignature.Add(signature, startDirective);
+            }
+        }
+    }
+
+    private static string ComputeBranchSignature(SourceText sourceText, TextSpan span)
+    {
+        var text = sourceText.ToString(span);
+        var tokens = SyntaxFactory.ParseTokens(text);
+        var builder = new StringBuilder();
+        foreach (var token in tokens)
+        {
+            if (token.IsKind(SyntaxKind.EndOfFileToken))
+                continue;
+
+            builder.Append(token.RawKind);
+            builder.Append(':');
+            builder.Append(token.Text);
+            builder.Append(';');
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs
@@ -1,12 +1,8 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 using Meziantou.Analyzer.Internals;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Meziantou.Analyzer.Rules;
 
@@ -42,67 +38,27 @@ public sealed class ConditionalCompilationBranchesAreIdenticalAnalyzer : Diagnos
             if (!trivia.HasStructure)
                 continue;
 
-            if (trivia.GetStructure() is IfDirectiveTriviaSyntax ifDirective)
+            if (trivia.GetStructure() is IfDirectiveTriviaSyntax ifDirective &&
+                ConditionalCompilationBranchesAreIdenticalCommon.TryCreateBranchGroup(ifDirective, sourceText, out var group))
             {
-                AnalyzeDirectiveGroup(context, sourceText, ifDirective);
+                AnalyzeDirectiveGroup(context, group);
             }
         }
     }
 
-    private static void AnalyzeDirectiveGroup(SyntaxTreeAnalysisContext context, SourceText sourceText, IfDirectiveTriviaSyntax ifDirective)
+    private static void AnalyzeDirectiveGroup(SyntaxTreeAnalysisContext context, ConditionalCompilationBranchesAreIdenticalCommon.BranchGroup group)
     {
-        var relatedDirectives = ifDirective.GetRelatedDirectives();
-        List<DirectiveTriviaSyntax> branchDirectives = [];
-        DirectiveTriviaSyntax? endIfDirective = null;
-        foreach (var directive in relatedDirectives)
-        {
-            if (directive.IsKind(SyntaxKind.IfDirectiveTrivia) || directive.IsKind(SyntaxKind.ElifDirectiveTrivia) || directive.IsKind(SyntaxKind.ElseDirectiveTrivia))
-            {
-                branchDirectives.Add(directive);
-            }
-            else if (directive.IsKind(SyntaxKind.EndIfDirectiveTrivia))
-            {
-                endIfDirective = directive;
-            }
-        }
-
-        if (endIfDirective is null || branchDirectives.Count < 2)
-            return;
-
         Dictionary<string, DirectiveTriviaSyntax> previousBranchBySignature = new(StringComparer.Ordinal);
-        for (var i = 0; i < branchDirectives.Count; i++)
+        foreach (var branch in group.Branches)
         {
-            var startDirective = branchDirectives[i];
-            var endDirective = i + 1 < branchDirectives.Count ? branchDirectives[i + 1] : endIfDirective;
-            var branchSpan = TextSpan.FromBounds(startDirective.FullSpan.End, endDirective.FullSpan.Start);
-            var signature = ComputeBranchSignature(sourceText, branchSpan);
-            if (previousBranchBySignature.ContainsKey(signature))
+            if (previousBranchBySignature.ContainsKey(branch.Signature))
             {
-                context.ReportDiagnostic(Diagnostic.Create(Rule, startDirective.GetLocation()));
+                context.ReportDiagnostic(Diagnostic.Create(Rule, branch.StartDirective.GetLocation()));
             }
             else
             {
-                previousBranchBySignature.Add(signature, startDirective);
+                previousBranchBySignature.Add(branch.Signature, branch.StartDirective);
             }
         }
-    }
-
-    private static string ComputeBranchSignature(SourceText sourceText, TextSpan span)
-    {
-        var text = sourceText.ToString(span);
-        var tokens = SyntaxFactory.ParseTokens(text);
-        var builder = new StringBuilder();
-        foreach (var token in tokens)
-        {
-            if (token.IsKind(SyntaxKind.EndOfFileToken))
-                continue;
-
-            builder.Append(token.RawKind);
-            builder.Append(':');
-            builder.Append(token.Text);
-            builder.Append(';');
-        }
-
-        return builder.ToString();
     }
 }

--- a/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalCommon.cs
@@ -1,0 +1,150 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Meziantou.Analyzer.Rules;
+
+internal static class ConditionalCompilationBranchesAreIdenticalCommon
+{
+    internal static bool TryCreateBranchGroup(DirectiveTriviaSyntax directive, SourceText sourceText, [NotNullWhen(true)] out BranchGroup? group)
+    {
+        var relatedDirectives = directive.GetRelatedDirectives();
+        DirectiveTriviaSyntax? firstIfDirective = null;
+        DirectiveTriviaSyntax? endIfDirective = null;
+        List<DirectiveTriviaSyntax> branchDirectives = [];
+        foreach (var relatedDirective in relatedDirectives)
+        {
+            switch (relatedDirective)
+            {
+                case IfDirectiveTriviaSyntax:
+                    firstIfDirective ??= relatedDirective;
+                    branchDirectives.Add(relatedDirective);
+                    break;
+                case ElifDirectiveTriviaSyntax:
+                case ElseDirectiveTriviaSyntax:
+                    branchDirectives.Add(relatedDirective);
+                    break;
+                case EndIfDirectiveTriviaSyntax:
+                    endIfDirective = relatedDirective;
+                    break;
+            }
+        }
+
+        if (firstIfDirective is null || endIfDirective is null || branchDirectives.Count < 2)
+        {
+            group = null;
+            return false;
+        }
+
+        List<Branch> branches = [];
+        for (var i = 0; i < branchDirectives.Count; i++)
+        {
+            var startDirective = branchDirectives[i];
+            var endDirective = i + 1 < branchDirectives.Count ? branchDirectives[i + 1] : endIfDirective;
+            var contentSpan = TextSpan.FromBounds(startDirective.FullSpan.End, endDirective.FullSpan.Start);
+
+            var kind = startDirective switch
+            {
+                IfDirectiveTriviaSyntax => BranchKind.If,
+                ElifDirectiveTriviaSyntax => BranchKind.Elif,
+                ElseDirectiveTriviaSyntax => BranchKind.Else,
+                _ => throw new InvalidOperationException("Unexpected directive kind"),
+            };
+
+            string? conditionText = startDirective switch
+            {
+                IfDirectiveTriviaSyntax ifDirective => ifDirective.Condition.ToString(),
+                ElifDirectiveTriviaSyntax elifDirective => elifDirective.Condition.ToString(),
+                _ => null,
+            };
+
+            branches.Add(new Branch(
+                startDirective: startDirective,
+                nextDirective: endDirective,
+                contentSpan: contentSpan,
+                kind: kind,
+                conditionText: conditionText,
+                signature: ComputeBranchSignature(sourceText, contentSpan)));
+        }
+
+        group = new BranchGroup(firstIfDirective, endIfDirective, branches);
+        return true;
+    }
+
+    private static string ComputeBranchSignature(SourceText sourceText, TextSpan span)
+    {
+        var text = sourceText.ToString(span);
+        var tokens = SyntaxFactory.ParseTokens(text);
+        var builder = new StringBuilder();
+        foreach (var token in tokens)
+        {
+            if (token.RawKind == (int)SyntaxKind.EndOfFileToken)
+                continue;
+
+            builder.Append(token.RawKind);
+            builder.Append(':');
+            builder.Append(token.Text);
+            builder.Append(';');
+        }
+
+        return builder.ToString();
+    }
+
+    internal sealed class BranchGroup(
+        DirectiveTriviaSyntax firstIfDirective,
+        DirectiveTriviaSyntax endIfDirective,
+        IReadOnlyList<Branch> branches)
+    {
+        internal DirectiveTriviaSyntax FirstIfDirective { get; } = firstIfDirective;
+        internal DirectiveTriviaSyntax EndIfDirective { get; } = endIfDirective;
+        internal IReadOnlyList<Branch> Branches { get; } = branches;
+
+        internal int GetBranchIndex(DirectiveTriviaSyntax directive)
+        {
+            for (var i = 0; i < Branches.Count; i++)
+            {
+                if (Branches[i].StartDirective.SpanStart == directive.SpanStart)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        internal int FindPreviousDuplicateBranchIndex(int currentBranchIndex)
+        {
+            var signature = Branches[currentBranchIndex].Signature;
+            for (var i = 0; i < currentBranchIndex; i++)
+            {
+                if (string.Equals(Branches[i].Signature, signature, StringComparison.Ordinal))
+                    return i;
+            }
+
+            return -1;
+        }
+    }
+
+    internal sealed class Branch(
+        DirectiveTriviaSyntax startDirective,
+        DirectiveTriviaSyntax nextDirective,
+        TextSpan contentSpan,
+        BranchKind kind,
+        string? conditionText,
+        string signature)
+    {
+        internal DirectiveTriviaSyntax StartDirective { get; } = startDirective;
+        internal DirectiveTriviaSyntax NextDirective { get; } = nextDirective;
+        internal TextSpan ContentSpan { get; } = contentSpan;
+        internal BranchKind Kind { get; } = kind;
+        internal string? ConditionText { get; } = conditionText;
+        internal string Signature { get; } = signature;
+    }
+
+    internal enum BranchKind
+    {
+        If,
+        Elif,
+        Else,
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
@@ -1,0 +1,76 @@
+using Meziantou.Analyzer.Rules;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class ConditionalCompilationBranchesAreIdenticalAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder() =>
+        new ProjectBuilder()
+            .WithOutputKind(Microsoft.CodeAnalysis.OutputKind.ConsoleApplication)
+            .WithAnalyzer<ConditionalCompilationBranchesAreIdenticalAnalyzer>();
+
+    [Fact]
+    public Task IfElif_SameCode() => CreateProjectBuilder()
+        .WithSourceCode("""
+            #if A
+            _ = 0;
+            {|MA0202:#elif B|}
+            _ = 0;
+            #else
+            _ = 1;
+            #endif
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task IfElse_SameCode() => CreateProjectBuilder()
+        .WithSourceCode("""
+            #if A
+            _ = 0;
+            {|MA0202:#else|}
+            _ = 0;
+            #endif
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task NonAdjacentDuplicateBranch() => CreateProjectBuilder()
+        .WithSourceCode("""
+            #if A
+            _ = 0;
+            #elif B
+            _ = 1;
+            {|MA0202:#else|}
+            _ = 0;
+            #endif
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task SameCodeWithDifferentComments() => CreateProjectBuilder()
+        .WithSourceCode("""
+            #if A
+            _ = 0;
+            {|MA0202:#elif B|}
+            // comment
+            _ = 0;
+            #else
+            _ = 1;
+            #endif
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task DifferentBranches() => CreateProjectBuilder()
+        .WithSourceCode("""
+            #if A
+            _ = 0;
+            #elif B
+            _ = 1;
+            #else
+            _ = 2;
+            #endif
+            """)
+        .ValidateAsync();
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
@@ -73,4 +73,39 @@ public sealed class ConditionalCompilationBranchesAreIdenticalAnalyzerTests
             #endif
             """)
         .ValidateAsync();
+
+    [Fact]
+    public Task IfElse_SameCode_PartialExpression() => CreateProjectBuilder()
+        .WithSourceCode("""
+            _ =
+            #if A
+             1;
+            {|MA0202:#else|}
+             1;
+            #endif
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task IfElse_SameCode_PartialTypeDeclaration() => CreateProjectBuilder()
+        .WithSourceCode("""
+            interface ISample { }
+            interface ISpanFormattable { }
+
+            #if A
+             public
+            #else
+             internal
+            #endif
+            class Sample : ISample
+            #if NET10_0
+            , ISpanFormattable
+            {|MA0202:#else|}
+            , ISpanFormattable
+            #endif
+            { }
+
+            static class Program { static void Main() { } }
+            """)
+        .ValidateAsync();
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
@@ -8,7 +8,8 @@ public sealed class ConditionalCompilationBranchesAreIdenticalAnalyzerTests
     private static ProjectBuilder CreateProjectBuilder() =>
         new ProjectBuilder()
             .WithOutputKind(Microsoft.CodeAnalysis.OutputKind.ConsoleApplication)
-            .WithAnalyzer<ConditionalCompilationBranchesAreIdenticalAnalyzer>();
+            .WithAnalyzer<ConditionalCompilationBranchesAreIdenticalAnalyzer>()
+            .WithCodeFixProvider<ConditionalCompilationBranchesAreIdenticalFixer>();
 
     [Fact]
     public Task IfElif_SameCode() => CreateProjectBuilder()
@@ -103,6 +104,89 @@ public sealed class ConditionalCompilationBranchesAreIdenticalAnalyzerTests
             {|MA0202:#else|}
             , ISpanFormattable
             #endif
+            { }
+
+            static class Program { static void Main() { } }
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task Fix_IfElif_SameCode_MergesConditions() => CreateProjectBuilder()
+        .WithSourceCode("""
+            #if A
+            _ = 0;
+            {|MA0202:#elif B|}
+            _ = 0;
+            #else
+            _ = 1;
+            #endif
+            """)
+        .ShouldFixCodeWith("""
+            #if (A) || (B)
+            _ = 0;
+            #else
+            _ = 1;
+            #endif
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task Fix_IfElse_SameCode_RemovesPreprocessor() => CreateProjectBuilder()
+        .WithSourceCode("""
+            #if A
+            _ = 0;
+            {|MA0202:#else|}
+            _ = 0;
+            #endif
+            """)
+        .ShouldFixCodeWith("_ = 0;\n")
+        .ValidateAsync();
+
+    [Fact]
+    public Task Fix_IfElse_SameCode_PartialExpression_RemovesPreprocessor() => CreateProjectBuilder()
+        .WithSourceCode("""
+            _ =
+            #if A
+             1;
+            {|MA0202:#else|}
+             1;
+            #endif
+            """)
+        .ShouldFixCodeWith("_ =\n 1;\n")
+        .ValidateAsync();
+
+    [Fact]
+    public Task Fix_IfElse_SameCode_PartialTypeDeclaration_RemovesPreprocessor() => CreateProjectBuilder()
+        .WithSourceCode("""
+            interface ISample { }
+            interface ISpanFormattable { }
+
+            #if A
+             public
+            #else
+             internal
+            #endif
+            class Sample : ISample
+            #if NET10_0
+            , ISpanFormattable
+            {|MA0202:#else|}
+            , ISpanFormattable
+            #endif
+            { }
+
+            static class Program { static void Main() { } }
+            """)
+        .ShouldFixCodeWith("""
+            interface ISample { }
+            interface ISpanFormattable { }
+
+            #if A
+             public
+            #else
+             internal
+            #endif
+            class Sample : ISample
+            , ISpanFormattable
             { }
 
             static class Program { static void Main() { } }


### PR DESCRIPTION
## Why
Conditional compilation blocks can easily accumulate duplicated branches (for example `#if` and `#elif` with the same body), which adds noise and can hide unnecessary conditions. This change adds an explicit analyzer rule to surface those duplicates.

## What changed
- Added new rule identifier `MA0202` and a new analyzer: `ConditionalCompilationBranchesAreIdenticalAnalyzer`.
- The analyzer walks `#if ... #endif` directive groups and compares branch bodies (`#if`, `#elif`, `#else`) using token-based signatures so trivia differences (whitespace/comments) do not prevent detection.
- A diagnostic is reported on the duplicated branch directive when it matches any earlier branch in the same group.
- Added focused tests for:
  - `#if` vs `#elif` duplicates
  - `#if` vs `#else` duplicates
  - non-adjacent duplicates
  - duplicates with comment differences
  - non-duplicate branches
- Added rule documentation (`docs/Rules/MA0202.md`) and regenerated rule listings/editorconfig outputs.

## Validation
- `dotnet build`
- `dotnet test --filter "FullyQualifiedName~ConditionalCompilationBranchesAreIdenticalAnalyzerTests"`
- `dotnet test /p:RoslynVersion=roslyn4.2 --filter "FullyQualifiedName~ConditionalCompilationBranchesAreIdenticalAnalyzerTests"`
- `dotnet test /p:RoslynVersion=roslyn4.14 --filter "FullyQualifiedName~ConditionalCompilationBranchesAreIdenticalAnalyzerTests"`