### PR TITLE
Fix MA0148/MA0149 false positives with implicit conversions

### DIFF
--- a/docs/Rules/MA0148.md
+++ b/docs/Rules/MA0148.md
@@ -12,3 +12,15 @@ value == 0 || value == 1; // not compliant
 
 value is 0 or 1; // ok
 ````
+
+Cases that rely on implicit user-defined conversions are ignored because replacing `==` with `is` would be invalid:
+
+````c#
+class Sample
+{
+    public static implicit operator int(Sample value) => 0;
+}
+
+Sample value = null;
+_ = value == 0; // ok
+````

--- a/docs/Rules/MA0149.md
+++ b/docs/Rules/MA0149.md
@@ -12,3 +12,15 @@ value != 0 && value != 1; // not compliant
 
 value is not (0 or 1); // ok
 ````
+
+Cases that rely on implicit user-defined conversions are ignored because replacing `!=` with `is not` would be invalid:
+
+````c#
+class Sample
+{
+    public static implicit operator int(Sample value) => 0;
+}
+
+Sample value = null;
+_ = value != 0; // ok
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
@@ -222,6 +222,9 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
             return false;
 
         var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
+        if (UsePatternMatchingForEqualityComparisonsCommon.HasImplicitUserDefinedConversion(expressionOperation))
+            return false;
+
         if (expressionOperation.Syntax is not ExpressionSyntax valueExpression || constantOperation.Syntax is not ExpressionSyntax constantExpression)
             return false;
 
@@ -255,6 +258,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
 
         var constantOperation = leftIsConstant ? operation.LeftOperand : operation.RightOperand;
         var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
+        if (UsePatternMatchingForEqualityComparisonsCommon.HasImplicitUserDefinedConversion(expressionOperation))
+            return false;
 
         if (constantOperation.Syntax is not ExpressionSyntax constantExpression || expressionOperation.Syntax is not ExpressionSyntax valueExpression)
             return false;

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
@@ -94,6 +94,10 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzer : Diagnosti
                     var rightIsConstant = UsePatternMatchingForEqualityComparisonsCommon.IsConstantLiteral(operation.RightOperand);
                     if (leftIsConstant ^ rightIsConstant)
                     {
+                        var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
+                        if (UsePatternMatchingForEqualityComparisonsCommon.HasImplicitUserDefinedConversion(expressionOperation))
+                            return;
+
                         if (_operationUtilities.IsInExpressionContext(operation))
                             return;
 

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsCommon.cs
@@ -23,4 +23,17 @@ internal static class UsePatternMatchingForEqualityComparisonsCommon
 
         return false;
     }
+
+    public static bool HasImplicitUserDefinedConversion(IOperation operation)
+    {
+        while (operation is IConversionOperation { IsImplicit: true } conversionOperation)
+        {
+            if (conversionOperation.Conversion.IsUserDefined)
+                return true;
+
+            operation = conversionOperation.Operand;
+        }
+
+        return false;
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
@@ -260,4 +260,63 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
                 """)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task EqualityComparison_ImplicitConversion_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  Sample value = null;
+                  _ = value == 0;
+
+                  class Sample
+                  {
+                      public static implicit operator int(Sample value) => 0;
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InequalityComparison_ImplicitConversion_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  Sample value = null;
+                  _ = value != 0;
+
+                  class Sample
+                  {
+                      public static implicit operator int(Sample value) => 0;
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task EqualityComparison_MixedWithImplicitConversion_OnlyFixValidExpression()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  var number = 0;
+                  Sample value = null;
+                  _ = [|number == 0|] || value == 0;
+
+                  class Sample
+                  {
+                      public static implicit operator int(Sample value) => 0;
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  var number = 0;
+                  Sample value = null;
+                  _ = number is 0 || value == 0;
+
+                  class Sample
+                  {
+                      public static implicit operator int(Sample value) => 0;
+                  }
+                  """)
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
## Summary
MA0148 and MA0149 could suggest replacing `==` or `!=` with `is` patterns when the comparison only worked through an implicit user-defined conversion. In those cases, the suggested `is`/`is not` rewrite is invalid C#.

This change makes the analyzer and fixer skip those cases so diagnostics are only reported when the pattern-matching rewrite is valid.

## What changed
- Added `HasImplicitUserDefinedConversion` in `UsePatternMatchingForEqualityComparisonsCommon`.
- Updated the MA0148/MA0149 analyzer path to skip constant-comparison diagnostics when the non-constant operand depends on an implicit user-defined conversion.
- Updated the fixer to apply the same guard for single comparisons and logical merge candidates.
- Added regression tests for implicit-conversion equality and inequality cases, plus a mixed-expression case to ensure only valid expressions are rewritten.
- Updated `docs/Rules/MA0148.md` and `docs/Rules/MA0149.md` with explicit examples of ignored implicit-conversion scenarios.

## Validation
- `dotnet test tests/Meziantou.Analyzer.Test --filter "FullyQualifiedName~UsePatternMatchingForEqualityComparisonsAnalyzerTests"`
- `dotnet test tests/Meziantou.Analyzer.Test /p:RoslynVersion=roslyn4.2 --filter "FullyQualifiedName~UsePatternMatchingForEqualityComparisonsAnalyzerTests"`
- `dotnet build Meziantou.Analyzer.slnx`
- `dotnet run --project src/DocumentationGenerator`