### PR TITLE
Enable MA0192 by default as suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0189](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0189.md)|Design|Use InlineArray instead of fixed-size buffers|ℹ️|✔️|✔️|
 |[MA0190](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0190.md)|Design|Use partial property instead of partial method for GeneratedRegex|ℹ️|✔️|✔️|
 |[MA0191](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0191.md)|Design|Do not use the null-forgiving operator|⚠️|❌|❌|
-|[MA0192](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0192.md)|Usage|Use HasFlag instead of bitwise checks|ℹ️|❌|✔️|
+|[MA0192](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0192.md)|Usage|Use HasFlag instead of bitwise checks|ℹ️|✔️|✔️|
 |[MA0193](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0193.md)|Usage|Use an overload with a MidpointRounding argument|ℹ️|✔️|✔️|
 |[MA0194](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0194.md)|Usage|Merge is expressions on the same value|ℹ️|✔️|✔️|
 |[MA0195](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0195.md)|Usage|Do not use static fields before they are initialized|⚠️|✔️|❌|

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,7 +190,7 @@
 |[MA0189](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0189.md)|Design|Use InlineArray instead of fixed-size buffers|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0190](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0190.md)|Design|Use partial property instead of partial method for GeneratedRegex|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0191](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0191.md)|Design|Do not use the null-forgiving operator|<span title='Warning'>⚠️</span>|❌|❌|
-|[MA0192](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0192.md)|Usage|Use HasFlag instead of bitwise checks|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0192](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0192.md)|Usage|Use HasFlag instead of bitwise checks|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0193](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0193.md)|Usage|Use an overload with a MidpointRounding argument|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0194](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0194.md)|Usage|Merge is expressions on the same value|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0195](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0195.md)|Usage|Do not use static fields before they are initialized|<span title='Warning'>⚠️</span>|✔️|❌|
@@ -788,7 +788,7 @@ dotnet_diagnostic.MA0190.severity = suggestion
 dotnet_diagnostic.MA0191.severity = none
 
 # MA0192: Use HasFlag instead of bitwise checks
-dotnet_diagnostic.MA0192.severity = none
+dotnet_diagnostic.MA0192.severity = suggestion
 
 # MA0193: Use an overload with a MidpointRounding argument
 dotnet_diagnostic.MA0193.severity = suggestion

--- a/docs/Rules/MA0192.md
+++ b/docs/Rules/MA0192.md
@@ -53,11 +53,3 @@ bool M(MyEnum value)
     return value.HasFlag(MyEnum.Flag1);
 }
 ````
-
-## Configuration
-
-This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
-
-````editorconfig
-dotnet_diagnostic.MA0192.severity = suggestion
-````

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -570,7 +570,7 @@ dotnet_diagnostic.MA0190.severity = suggestion
 dotnet_diagnostic.MA0191.severity = none
 
 # MA0192: Use HasFlag instead of bitwise checks
-dotnet_diagnostic.MA0192.severity = none
+dotnet_diagnostic.MA0192.severity = suggestion
 
 # MA0193: Use an overload with a MidpointRounding argument
 dotnet_diagnostic.MA0193.severity = suggestion

--- a/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
@@ -17,7 +17,7 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
         messageFormat: "Use HasFlag instead of bitwise checks",
         RuleCategories.Usage,
         DiagnosticSeverity.Info,
-        isEnabledByDefault: false,
+        isEnabledByDefault: true,
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseHasFlagMethod));
 


### PR DESCRIPTION
## Why
MA0192 (`Use HasFlag instead of bitwise checks`) was implemented with `DiagnosticSeverity.Info` but disabled by default, so it did not show up in the default analyzer configuration. Enabling it by default makes the rule available out of the box as a suggestion.

## What changed
- Set `UseHasFlagMethodAnalyzer` to `isEnabledByDefault: true` for MA0192.
- Regenerated generated configuration/docs so defaults stay consistent:
  - `src/Meziantou.Analyzer.Pack/configuration/default.editorconfig` now sets `dotnet_diagnostic.MA0192.severity = suggestion`.
  - Generated rule tables in `README.md` and `docs/README.md` now show MA0192 as enabled by default.
- Updated `docs/Rules/MA0192.md` configuration text to state the rule is enabled by default as a suggestion.

## Notes
This is a default-configuration and documentation alignment change for MA0192; no rule logic was changed.