### PR TITLE
Support GeneratedRegex diagnostics on partial properties

### DIFF
--- a/docs/Rules/MA0009.md
+++ b/docs/Rules/MA0009.md
@@ -5,15 +5,21 @@ Sources: [GeneratedRegexAttributeUsageAnalyzer.cs](https://github.com/meziantou/
 
 ````csharp
 new Regex(""); // not compliant
-new Regex("", RegexOptions.None); // notcompliant
+new Regex("", RegexOptions.None); // not compliant
 
 new Regex("", RegexOptions.None, TimeSpan.FromSeconds(1)); // ok
 
 [GeneratedRegex(""pattern"", RegexOptions.None)] // not compliant
 private static partial Regex Test();
 
-[GeneratedRegex(""pattern"", RegexOptions.None, matchTimeoutMilliseconds: 1000)] // ok compliant
+[GeneratedRegex(""pattern"", RegexOptions.None, matchTimeoutMilliseconds: 1000)] // compliant
 private static partial Regex Test();
+
+[GeneratedRegex(""pattern"", RegexOptions.None)] // not compliant
+private static partial Regex Test { get; }
+
+[GeneratedRegex(""pattern"", RegexOptions.None, matchTimeoutMilliseconds: 1000)] // compliant
+private static partial Regex Test { get; }
 ````
 
 

--- a/docs/Rules/MA0023.md
+++ b/docs/Rules/MA0023.md
@@ -9,4 +9,10 @@ Using named groups clarifies what is to be captured. It also makes the regex mor
 new Regex("a(b)"); // non-compliant
 new Regex("a(b)", RegexOptions.ExplicitCapture); // ok
 new Regex("a(?<name>b)"); // ok
+
+[GeneratedRegex("a(b)", RegexOptions.None, matchTimeoutMilliseconds: 1000)] // non-compliant
+private static partial Regex SampleRegex { get; }
+
+[GeneratedRegex("a(b)", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)] // ok
+private static partial Regex SampleRegex { get; }
 ````

--- a/src/Meziantou.Analyzer/Rules/GeneratedRegexAttributeUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/GeneratedRegexAttributeUsageAnalyzer.cs
@@ -11,6 +11,6 @@ public sealed class GeneratedRegexAttributeUsageAnalyzer : RegexUsageAnalyzerBas
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
-        context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
+        context.RegisterSymbolAction(AnalyzeGeneratedRegexSymbol, SymbolKind.Method, SymbolKind.Property);
     }
 }

--- a/src/Meziantou.Analyzer/Rules/RegexUsageAnalyzerBase.cs
+++ b/src/Meziantou.Analyzer/Rules/RegexUsageAnalyzerBase.cs
@@ -33,21 +33,27 @@ public abstract class RegexUsageAnalyzerBase : DiagnosticAnalyzer
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(TimeoutRule, ExplicitCaptureRule);
 
-    protected static void AnalyzeMethod(SymbolAnalysisContext context)
+    protected static void AnalyzeGeneratedRegexSymbol(SymbolAnalysisContext context)
     {
-        var method = (IMethodSymbol)context.Symbol;
-        if (method.MethodKind is not MethodKind.Ordinary)
+        if (context.Symbol is IMethodSymbol method && method.MethodKind is not MethodKind.Ordinary)
+            return;
+
+        if (context.Symbol is not IMethodSymbol and not IPropertySymbol)
             return;
 
         var generatorAttributeSymbol = context.Compilation.GetBestTypeByMetadataName("System.Text.RegularExpressions.GeneratedRegexAttribute");
         if (generatorAttributeSymbol is null)
             return;
 
-        foreach (var attribute in method.GetAttributes())
+        foreach (var attribute in context.Symbol.GetAttributes())
         {
             // https://github.com/dotnet/runtime/issues/58880
             if (attribute.AttributeClass.IsEqualTo(generatorAttributeSymbol))
             {
+                var attributeSyntaxReference = attribute.ApplicationSyntaxReference;
+                if (attributeSyntaxReference is not null && !context.Symbol.DeclaringSyntaxReferences.Any(reference => reference.SyntaxTree == attributeSyntaxReference.SyntaxTree && reference.Span.Contains(attributeSyntaxReference.Span)))
+                    continue;
+
                 var regexOptions = RegexOptions.None;
 
                 // RegexOptions.ExplicitCapture
@@ -57,13 +63,13 @@ public abstract class RegexUsageAnalyzerBase : DiagnosticAnalyzer
                     regexOptions = (RegexOptions)(int)attribute.ConstructorArguments[1].Value!;
                     if (pattern is not null && ShouldAddExplicitCapture(pattern, regexOptions))
                     {
-                        if (attribute.ApplicationSyntaxReference is not null)
+                        if (attributeSyntaxReference is not null)
                         {
-                            context.ReportDiagnostic(ExplicitCaptureRule, attribute.ApplicationSyntaxReference);
+                            context.ReportDiagnostic(ExplicitCaptureRule, attributeSyntaxReference);
                         }
                         else
                         {
-                            context.ReportDiagnostic(ExplicitCaptureRule, method);
+                            context.ReportDiagnostic(ExplicitCaptureRule, context.Symbol);
                         }
                     }
                 }
@@ -71,13 +77,13 @@ public abstract class RegexUsageAnalyzerBase : DiagnosticAnalyzer
                 // Timeout
                 if (!HasNonBacktracking(regexOptions) && attribute.ConstructorArguments.Length < 3)
                 {
-                    if (attribute.ApplicationSyntaxReference is not null)
+                    if (attributeSyntaxReference is not null)
                     {
-                        context.ReportDiagnostic(TimeoutRule, attribute.ApplicationSyntaxReference);
+                        context.ReportDiagnostic(TimeoutRule, attributeSyntaxReference);
                     }
                     else
                     {
-                        context.ReportDiagnostic(TimeoutRule, method);
+                        context.ReportDiagnostic(TimeoutRule, context.Symbol);
                     }
                 }
             }

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
@@ -75,6 +75,31 @@ public sealed partial class ProjectBuilder
 
             if (!IsCacheValid())
             {
+                await DownloadPackageWithRetries().ConfigureAwait(false);
+            }
+
+            async Task DownloadPackageWithRetries()
+            {
+                const int MaxAttempts = 5;
+                for (var attempt = 1; ; attempt++)
+                {
+                    try
+                    {
+                        await DownloadPackage().ConfigureAwait(false);
+                        return;
+                    }
+                    catch (Exception ex) when (!IsLastAttempt(attempt) && IsTransientException(ex))
+                    {
+                        await Task.Delay(100 * attempt).ConfigureAwait(false);
+                    }
+                }
+
+                static bool IsLastAttempt(int attempt) => attempt >= MaxAttempts;
+                static bool IsTransientException(Exception exception) => exception is HttpRequestException or IOException or InvalidDataException;
+            }
+
+            async Task DownloadPackage()
+            {
                 var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
                 try
                 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
@@ -9,6 +9,7 @@ public sealed class UseRegexOptionsAnalyzerTests
     private static ProjectBuilder CreateProjectBuilder()
     {
         return new ProjectBuilder()
+            .WithFrameworkSourceGenerators()
             .WithAnalyzer<RegexMethodUsageAnalyzer>()
             .WithAnalyzer<GeneratedRegexAttributeUsageAnalyzer>()
             .WithCodeFixProvider<UseRegexExplicitCaptureOptionsFixer>();
@@ -121,12 +122,7 @@ partial class TestClass
 partial class TestClass
 {
     private static partial Regex Test() => throw null;
-}")
-              .ShouldReportDiagnostic(new DiagnosticResult
-              {
-                  Id = "MA0023",
-                  Locations = [new DiagnosticResultLocation("Test0.cs", 4, 6, 4, 92)],
-              });
+}");
 
         await project.ValidateAsync();
     }
@@ -151,11 +147,6 @@ partial class TestClass
                       private static partial Regex Test() => throw null;
                   }
                   """)
-              .ShouldReportDiagnostic(new DiagnosticResult
-              {
-                  Id = "MA0023",
-                  Locations = [new DiagnosticResultLocation("Test0.cs", 4, 6, 4, 92)],
-              })
               .ShouldFixCodeWith("""
                   using System.Text.RegularExpressions;
                   partial class TestClass
@@ -171,4 +162,87 @@ partial class TestClass
 
         await project.ValidateAsync();
     }
+
+#if CSHARP13_OR_GREATER
+    [Fact]
+    public async Task GeneratedRegexProperty_RegexOptions_Valid()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
+              .WithTargetFramework(TargetFramework.Net9_0)
+              .WithSourceCode("""
+                  using System.Text.RegularExpressions;
+
+                  partial class TestClass
+                  {
+                      [GeneratedRegex("(?<test>[a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, 0)]
+                      private static partial Regex Test { get; }
+                  }
+                  partial class TestClass
+                  {
+                      private static partial Regex Test { get => throw null; }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GeneratedRegexProperty_RegexOptions_Invalid()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
+              .WithTargetFramework(TargetFramework.Net9_0)
+              .WithSourceCode("""
+                  using System.Text.RegularExpressions;
+
+                  partial class TestClass
+                  {
+                      [[|GeneratedRegex("([a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, 0)|]]
+                      private static partial Regex Test { get; }
+                  }
+                  partial class TestClass
+                  {
+                      private static partial Regex Test { get => throw null; }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GeneratedRegexProperty_RegexOptions_Invalid_CodeFix()
+    {
+        await new ProjectBuilder()
+              .WithAnalyzer<GeneratedRegexAttributeUsageAnalyzer>()
+              .WithCodeFixProvider<UseRegexExplicitCaptureOptionsFixer>()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
+              .WithTargetFramework(TargetFramework.Net9_0)
+              .WithSourceCode("""
+                  using System.Text.RegularExpressions;
+
+                  partial class TestClass
+                  {
+                      [[|GeneratedRegex("([a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, 0)|]]
+                      private static partial Regex Test { get; }
+                  }
+                  partial class TestClass
+                  {
+                      private static partial Regex Test { get => throw null; }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System.Text.RegularExpressions;
+
+                  partial class TestClass
+                  {
+                      [GeneratedRegex("([a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture, 0)]
+                      private static partial Regex Test { get; }
+                  }
+                  partial class TestClass
+                  {
+                      private static partial Regex Test { get => throw null; }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+#endif
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexTimeoutAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexTimeoutAnalyzerTests.cs
@@ -159,12 +159,7 @@ class TestClass
         var project = CreateProjectBuilder()
               .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
               .WithTargetFramework(TargetFramework.Net7_0)
-              .WithSourceCode(SourceCode)
-              .ShouldReportDiagnostic(new DiagnosticResult
-              {
-                  Id = RuleIdentifiers.MissingTimeoutParameterForRegex,
-                  Locations = [new DiagnosticResultLocation("Test0.cs", 4, 6, 4, 50)],
-              });
+              .WithSourceCode(SourceCode);
 
         await project.ValidateAsync();
     }
@@ -230,4 +225,60 @@ partial class TestClass
 
         await project.ValidateAsync();
     }
+
+#if CSHARP13_OR_GREATER
+    [Fact]
+    public async Task GeneratedRegexProperty_WithoutTimeout()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
+              .WithTargetFramework(TargetFramework.Net9_0)
+              .WithSourceCode("""
+                  using System.Text.RegularExpressions;
+
+                  partial class TestClass
+                  {
+                      [[|GeneratedRegex("pattern", RegexOptions.None)|]]
+                      private static partial Regex Test { get; }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GeneratedRegexProperty_WithTimeout()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
+              .WithTargetFramework(TargetFramework.Net9_0)
+              .WithSourceCode("""
+                  using System.Text.RegularExpressions;
+
+                  partial class TestClass
+                  {
+                      [GeneratedRegex("pattern", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+                      private static partial Regex Test { get; }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GeneratedRegexProperty_WithoutTimeout_NonBacktracking()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
+              .WithTargetFramework(TargetFramework.Net9_0)
+              .WithSourceCode("""
+                  using System.Text.RegularExpressions;
+
+                  partial class TestClass
+                  {
+                      [GeneratedRegex("pattern", RegexOptions.NonBacktracking)]
+                      private static partial Regex Test { get; }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+#endif
 }


### PR DESCRIPTION
GeneratedRegex-specific diagnostics (MA0009 and MA0023) previously only analyzed methods. With C# 13 partial properties, `[GeneratedRegex]` can be applied to properties too, so those cases were silently missed.

## What changed
- Updated `GeneratedRegexAttributeUsageAnalyzer` to analyze both `SymbolKind.Method` and `SymbolKind.Property`.
- Refactored shared logic in `RegexUsageAnalyzerBase` to handle GeneratedRegex analysis for both symbols while preserving method-specific checks.
- Added a declaration filter so diagnostics are only reported from the declaration that contains the attribute syntax, avoiding duplicate reports on partial members.
- Extended tests in `UseRegexTimeoutAnalyzerTests` and `UseRegexOptionsAnalyzerTests` with GeneratedRegex property scenarios, including code-fix coverage.
- Updated MA0009 and MA0023 documentation examples to include GeneratedRegex property usage.

## Validation
- Ran targeted analyzer tests for regex timeout/options on default, `roslyn4.2`, and `roslyn4.14`.
- Ran `dotnet build`.
- Ran `dotnet run --project src/DocumentationGenerator` and kept generated markdown changes in sync.