### PR TITLE
Handle local-variable hiding in local functions

### DIFF
--- a/docs/Rules/MA0084.md
+++ b/docs/Rules/MA0084.md
@@ -11,6 +11,11 @@ class Test
     void A()
     {
         string a; // not-compliant as it hides the field
+
+        void LocalFunction()
+        {
+            string a; // not-compliant as it hides the local variable
+        }
     }
 }
 ````

--- a/src/Meziantou.Analyzer/Rules/LocalVariablesShouldNotHideSymbolsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/LocalVariablesShouldNotHideSymbolsAnalyzer.cs
@@ -41,6 +41,26 @@ public sealed class LocalVariablesShouldNotHideSymbolsAnalyzer : DiagnosticAnaly
         if (containingType is null)
             return;
 
+        foreach (var ancestor in operation.Ancestors())
+        {
+            if (ancestor is not ILocalFunctionOperation localFunction)
+                continue;
+
+            if (!localFunction.Symbol.IsStatic)
+            {
+                foreach (var symbol in semanticModel.LookupSymbols(localFunction.Syntax.SpanStart, name: localSymbol.Name))
+                {
+                    if (symbol is ILocalSymbol hiddenLocal && CanAccessLocal(localFunction.Symbol, hiddenLocal))
+                    {
+                        ReportDiagnostic("local variable");
+                        return;
+                    }
+                }
+            }
+
+            break;
+        }
+
         foreach (var member in GetSymbols(containingType, localSymbol.Name, context.CancellationToken))
         {
             if (!semanticModel.IsAccessible(operation.Syntax.SpanStart, member))
@@ -76,6 +96,26 @@ public sealed class LocalVariablesShouldNotHideSymbolsAnalyzer : DiagnosticAnaly
                 context.ReportDiagnostic(Rule, operation, localSymbol.Name, type);
             }
         }
+    }
+
+    private static bool CanAccessLocal(IMethodSymbol localFunction, ILocalSymbol local)
+    {
+        var currentLocalFunction = localFunction;
+        while (currentLocalFunction.MethodKind is MethodKind.LocalFunction)
+        {
+            if (currentLocalFunction.IsStatic)
+                return false;
+
+            if (currentLocalFunction.ContainingSymbol.IsEqualTo(local.ContainingSymbol))
+                return true;
+
+            if (currentLocalFunction.ContainingSymbol is not IMethodSymbol containingMethod)
+                return false;
+
+            currentLocalFunction = containingMethod;
+        }
+
+        return false;
     }
 
     private static IEnumerable<ISymbol> GetSymbols(INamedTypeSymbol? type, string name, CancellationToken cancellationToken)

--- a/tests/Meziantou.Analyzer.Test/Rules/LocalVariablesShouldNotHideSymbolsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LocalVariablesShouldNotHideSymbolsAnalyzerTests.cs
@@ -165,4 +165,73 @@ public sealed class LocalVariablesShouldNotHideSymbolsAnalyzerTests
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task LocalVariableInLocalFunctionHidesLocalVariableFromContainingMethod()
+    {
+        const string SourceCode = """
+            class Test
+            {
+                void A()
+                {
+                    var a = 10;
+
+                    void LocalFunction()
+                    {
+                        var [|a|] = 10;
+                    }
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LocalVariableInStaticLocalFunctionDoesNotHideLocalVariableFromContainingMethod()
+    {
+        const string SourceCode = """
+            class Test
+            {
+                void A()
+                {
+                    var a = 10;
+
+                    static void LocalFunction()
+                    {
+                        var a = 10;
+                    }
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LocalVariableInNestedLocalFunctionDoesNotHideLocalVariableAcrossStaticLocalFunction()
+    {
+        const string SourceCode = """
+            class Test
+            {
+                void A()
+                {
+                    var a = 10;
+
+                    static void LocalFunction()
+                    {
+                        void NestedLocalFunction()
+                        {
+                            var a = 10;
+                        }
+                    }
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- Report MA0084 when a local function declares a variable that hides a local from an enclosing method
- Skip the diagnostic for static local functions and nested cases that cannot access the outer local
- Add analyzer coverage for the new local-function scenarios and update the rule docs

## Testing
- Added unit tests for local, static local, and nested local function hiding cases
- Not run (not requested)