### PR TITLE
Add MA0203 to flag `<returns>` tags on `void` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0200](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0200.md)|Usage|Do not use empty property patterns with non-nullable value types|ℹ️|✔️|✔️|
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|⚠️|✔️|❌|
 |[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|⚠️|✔️|✔️|
+|[MA0203](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0203.md)|Design|Do not use return tag for void method|⚠️|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -201,6 +201,7 @@
 |[MA0200](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0200.md)|Usage|Do not use empty property patterns with non-nullable value types|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|<span title='Warning'>⚠️</span>|✔️|✔️|
+|[MA0203](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0203.md)|Design|Do not use return tag for void method|<span title='Warning'>⚠️</span>|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0203.md
+++ b/docs/Rules/MA0203.md
@@ -1,0 +1,33 @@
+# MA0203 - Do not use return tag for void method
+<!-- sources -->
+Source: [DoNotUseReturnTagForVoidMethodAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/DoNotUseReturnTagForVoidMethodAnalyzer.cs)
+<!-- sources -->
+
+This rule reports XML documentation return tags on methods that return `void`.
+
+`<returns>` should document the value returned by a method. A `void` method does not return a value, so the tag should be removed.
+
+## Non-compliant code
+
+````csharp
+class Sample
+{
+    /// <summary>Does something.</summary>
+    /// <returns>The result.</returns>
+    void M()
+    {
+    }
+}
+````
+
+## Compliant code
+
+````csharp
+class Sample
+{
+    /// <summary>Does something.</summary>
+    void M()
+    {
+    }
+}
+````

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -601,3 +601,6 @@ dotnet_diagnostic.MA0201.severity = error
 
 # MA0202: Conditional compilation branches have identical code
 dotnet_diagnostic.MA0202.severity = error
+
+# MA0203: Do not use return tag for void method
+dotnet_diagnostic.MA0203.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -601,3 +601,6 @@ dotnet_diagnostic.MA0201.severity = suggestion
 
 # MA0202: Conditional compilation branches have identical code
 dotnet_diagnostic.MA0202.severity = suggestion
+
+# MA0203: Do not use return tag for void method
+dotnet_diagnostic.MA0203.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -601,3 +601,6 @@ dotnet_diagnostic.MA0201.severity = warning
 
 # MA0202: Conditional compilation branches have identical code
 dotnet_diagnostic.MA0202.severity = warning
+
+# MA0203: Do not use return tag for void method
+dotnet_diagnostic.MA0203.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -601,3 +601,6 @@ dotnet_diagnostic.MA0201.severity = warning
 
 # MA0202: Conditional compilation branches have identical code
 dotnet_diagnostic.MA0202.severity = warning
+
+# MA0203: Do not use return tag for void method
+dotnet_diagnostic.MA0203.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -601,3 +601,6 @@ dotnet_diagnostic.MA0201.severity = none
 
 # MA0202: Conditional compilation branches have identical code
 dotnet_diagnostic.MA0202.severity = none
+
+# MA0203: Do not use return tag for void method
+dotnet_diagnostic.MA0203.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -202,6 +202,7 @@ internal static class RuleIdentifiers
     public const string DoNotUseEmptyPropertyPatternOnNonNullableValueType = "MA0200";
     public const string DoNotUseZeroValuedEnumFlagsInFlagChecks = "MA0201";
     public const string ConditionalCompilationBranchesAreIdentical = "MA0202";
+    public const string DoNotUseReturnTagForVoidMethod = "MA0203";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/DoNotUseReturnTagForVoidMethodAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseReturnTagForVoidMethodAnalyzer.cs
@@ -1,0 +1,74 @@
+using System.Collections.Immutable;
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DoNotUseReturnTagForVoidMethodAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.DoNotUseReturnTagForVoidMethod,
+        title: "Do not use return tag for void method",
+        messageFormat: "Do not use return tag for void method",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.DoNotUseReturnTagForVoidMethod));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
+    }
+
+    private static void AnalyzeMethod(SymbolAnalysisContext context)
+    {
+        if (context.Symbol is not IMethodSymbol { IsImplicitlyDeclared: false, ReturnsVoid: true } methodSymbol)
+            return;
+
+        if (methodSymbol.MethodKind is not MethodKind.Ordinary and not MethodKind.ExplicitInterfaceImplementation)
+            return;
+
+        foreach (var syntaxReference in methodSymbol.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+            if (!syntax.HasStructuredTrivia)
+                continue;
+
+            foreach (var trivia in syntax.GetLeadingTrivia())
+            {
+                if (trivia.GetStructure() is not DocumentationCommentTriviaSyntax documentation)
+                    continue;
+
+                foreach (var element in documentation.DescendantNodes().OfType<XmlEmptyElementSyntax>())
+                {
+                    if (IsReturnElement(element.Name))
+                    {
+                        context.ReportDiagnostic(Rule, element);
+                    }
+                }
+
+                foreach (var element in documentation.DescendantNodes().OfType<XmlElementSyntax>())
+                {
+                    if (IsReturnElement(element.StartTag.Name))
+                    {
+                        context.ReportDiagnostic(Rule, element.StartTag);
+                    }
+                }
+            }
+        }
+    }
+
+    private static bool IsReturnElement(XmlNameSyntax name)
+    {
+        return name.LocalName.Text is "returns" or "return";
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseReturnTagForVoidMethodAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseReturnTagForVoidMethodAnalyzerTests.cs
@@ -1,0 +1,82 @@
+using Meziantou.Analyzer.Rules;
+using Meziantou.Analyzer.Test.Helpers;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class DoNotUseReturnTagForVoidMethodAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder() =>
+        new ProjectBuilder()
+            .WithAnalyzer<DoNotUseReturnTagForVoidMethodAnalyzer>()
+            .WithTargetFramework(TargetFramework.NetLatest);
+
+    [Theory]
+    [InlineData("returns")]
+    [InlineData("return")]
+    public Task VoidMethod_ReturnTag(string tag) => CreateProjectBuilder()
+        .WithSourceCode($$"""
+            class Sample
+            {
+                /// <summary>Does something.</summary>
+                /// {|MA0203:<{{tag}}>|}The result.</{{tag}}>
+                void M()
+                {
+                }
+            }
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task VoidMethod_EmptyReturnTag() => CreateProjectBuilder()
+        .WithSourceCode("""
+            class Sample
+            {
+                /// <summary>Does something.</summary>
+                /// {|MA0203:<returns />|}
+                void M()
+                {
+                }
+            }
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task NonVoidMethod_ReturnTag() => CreateProjectBuilder()
+        .WithSourceCode("""
+            class Sample
+            {
+                /// <summary>Gets a value.</summary>
+                /// <returns>The result.</returns>
+                int M() => 0;
+            }
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task VoidMethod_NoReturnTag() => CreateProjectBuilder()
+        .WithSourceCode("""
+            class Sample
+            {
+                /// <summary>Does something.</summary>
+                void M()
+                {
+                }
+            }
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task Constructor_ReturnTag() => CreateProjectBuilder()
+        .WithSourceCode("""
+            class Sample
+            {
+                /// <summary>Initializes a new instance.</summary>
+                /// <returns>The result.</returns>
+                public Sample()
+                {
+                }
+            }
+            """)
+        .ValidateAsync();
+}


### PR DESCRIPTION
## Summary
- Add analyzer rule `MA0203` to report XML documentation `<returns>` tags on `void` methods.
- Document the rule in the README and add the rule metadata to the analyzer pack configurations.
- Cover the new behavior with unit tests for normal, empty, and non-applicable cases.

## Testing
- Not run (not requested)
- Added analyzer tests for `void` methods with `<returns>` and verified non-void methods and constructors are not flagged