### PR TITLE
Add MA0204 to remove unnecessary partial modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|⚠️|✔️|❌|
 |[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|⚠️|✔️|✔️|
 |[MA0203](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0203.md)|Design|Do not use return tag for void method|⚠️|✔️|❌|
+|[MA0204](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0204.md)|Design|Remove unnecessary partial modifier|ℹ️|✔️|✔️|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -202,6 +202,7 @@
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|<span title='Warning'>⚠️</span>|✔️|✔️|
 |[MA0203](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0203.md)|Design|Do not use return tag for void method|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0204](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0204.md)|Design|Remove unnecessary partial modifier|<span title='Info'>ℹ️</span>|✔️|✔️|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0204.md
+++ b/docs/Rules/MA0204.md
@@ -1,0 +1,24 @@
+# MA0204 - Remove unnecessary partial modifier
+<!-- sources -->
+Sources: [RemoveUnnecessaryPartialModifierAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryPartialModifierAnalyzer.cs), [RemoveUnnecessaryPartialModifierFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryPartialModifierFixer.cs)
+<!-- sources -->
+
+This rule reports a `partial` modifier on a type when the type has a single declaration and no partial members.
+
+The `partial` modifier can be removed when there is no other declaration to merge with.
+
+## Non-compliant code
+
+````csharp
+partial class Sample
+{
+}
+````
+
+## Compliant code
+
+````csharp
+class Sample
+{
+}
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryPartialModifierFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryPartialModifierFixer.cs
@@ -1,0 +1,79 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class RemoveUnnecessaryPartialModifierFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.RemoveUnnecessaryPartialModifier);
+
+    public override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var partialKeyword = root.FindToken(context.Span.Start);
+        if (!partialKeyword.IsKind(SyntaxKind.PartialKeyword))
+            return;
+
+        var typeDeclaration = partialKeyword.Parent?.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+        if (typeDeclaration is null || !typeDeclaration.Modifiers.Contains(partialKeyword))
+            return;
+
+        var title = "Remove partial modifier";
+        var codeAction = CodeAction.Create(
+            title,
+            ct => RemovePartialModifierAsync(context.Document, partialKeyword, ct),
+            equivalenceKey: title);
+
+        context.RegisterCodeFix(codeAction, context.Diagnostics);
+    }
+
+    private static async Task<Document> RemovePartialModifierAsync(Document document, SyntaxToken partialKeyword, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var currentPartialKeyword = root.FindToken(partialKeyword.SpanStart);
+        var typeDeclaration = currentPartialKeyword.Parent?.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+        if (typeDeclaration is null || !typeDeclaration.Modifiers.Contains(currentPartialKeyword))
+            return document;
+
+        var newTypeDeclaration = RemovePartialModifier(typeDeclaration, currentPartialKeyword);
+        return document.WithSyntaxRoot(root.ReplaceNode(typeDeclaration, newTypeDeclaration));
+    }
+
+    private static TypeDeclarationSyntax RemovePartialModifier(TypeDeclarationSyntax typeDeclaration, SyntaxToken partialKeyword)
+    {
+        var modifiers = typeDeclaration.Modifiers;
+        var partialKeywordIndex = modifiers.IndexOf(partialKeyword);
+        if (partialKeywordIndex < 0)
+            return typeDeclaration;
+
+        var nonspaceTrivia = partialKeyword.LeadingTrivia.Concat(partialKeyword.TrailingTrivia).Where(t => !t.IsKind(SyntaxKind.WhitespaceTrivia) && !t.IsKind(SyntaxKind.EndOfLineTrivia)).ToList();
+
+        if (partialKeywordIndex + 1 < modifiers.Count)
+        {
+            var nextModifier = modifiers[partialKeywordIndex + 1];
+            modifiers = modifiers.Replace(nextModifier, nextModifier.WithLeadingTrivia(nonspaceTrivia.Concat(nextModifier.LeadingTrivia)));
+            return typeDeclaration.WithModifiers(modifiers.Remove(partialKeyword));
+        }
+
+        return typeDeclaration.WithModifiers(modifiers.Remove(partialKeyword));
+    }
+}

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryPartialModifierFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryPartialModifierFixer.cs
@@ -74,6 +74,8 @@ public sealed class RemoveUnnecessaryPartialModifierFixer : CodeFixProvider
             return typeDeclaration.WithModifiers(modifiers.Remove(partialKeyword));
         }
 
-        return typeDeclaration.WithModifiers(modifiers.Remove(partialKeyword));
+        return typeDeclaration
+            .WithModifiers(modifiers.Remove(partialKeyword))
+            .WithKeyword(typeDeclaration.Keyword.WithLeadingTrivia(nonspaceTrivia.Concat(typeDeclaration.Keyword.LeadingTrivia)));
     }
 }

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = error
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = error
+
+# MA0204: Remove unnecessary partial modifier
+dotnet_diagnostic.MA0204.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = suggestion
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = suggestion
+
+# MA0204: Remove unnecessary partial modifier
+dotnet_diagnostic.MA0204.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = warning
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = warning
+
+# MA0204: Remove unnecessary partial modifier
+dotnet_diagnostic.MA0204.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = warning
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = warning
+
+# MA0204: Remove unnecessary partial modifier
+dotnet_diagnostic.MA0204.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = none
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = none
+
+# MA0204: Remove unnecessary partial modifier
+dotnet_diagnostic.MA0204.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -203,6 +203,7 @@ internal static class RuleIdentifiers
     public const string DoNotUseZeroValuedEnumFlagsInFlagChecks = "MA0201";
     public const string ConditionalCompilationBranchesAreIdentical = "MA0202";
     public const string DoNotUseReturnTagForVoidMethod = "MA0203";
+    public const string RemoveUnnecessaryPartialModifier = "MA0204";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryPartialModifierAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryPartialModifierAnalyzer.cs
@@ -1,0 +1,51 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RemoveUnnecessaryPartialModifierAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.RemoveUnnecessaryPartialModifier,
+        title: "Remove unnecessary partial modifier",
+        messageFormat: "Remove unnecessary partial modifier",
+        RuleCategories.Design,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.RemoveUnnecessaryPartialModifier));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+        context.RegisterSymbolAction(AnalyzeNamedTypeSymbol, SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeNamedTypeSymbol(SymbolAnalysisContext context)
+    {
+        var symbol = (INamedTypeSymbol)context.Symbol;
+        if (symbol.TypeKind is not (TypeKind.Class or TypeKind.Struct or TypeKind.Interface))
+            return;
+
+        if (symbol.DeclaringSyntaxReferences.Length != 1)
+            return;
+
+        var typeDeclaration = symbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken) as TypeDeclarationSyntax;
+        if (typeDeclaration is null)
+            return;
+
+        var partialToken = typeDeclaration.Modifiers.FirstOrDefault(modifier => modifier.IsKind(SyntaxKind.PartialKeyword));
+        if (partialToken == default)
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, partialToken.GetLocation()));
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryPartialModifierAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryPartialModifierAnalyzerTests.cs
@@ -1,0 +1,204 @@
+using Meziantou.Analyzer.Rules;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class RemoveUnnecessaryPartialModifierAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<RemoveUnnecessaryPartialModifierAnalyzer>()
+            .WithCodeFixProvider<RemoveUnnecessaryPartialModifierFixer>();
+    }
+
+    [Fact]
+    public async Task PartialClass_WithSingleDeclaration_ReportsDiagnostic()
+    {
+        const string SourceCode = """
+            [|partial|] class Sample
+            {
+            }
+            """;
+
+        const string CodeFix = """
+            class Sample
+            {
+            }
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith(CodeFix)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PartialClass_WithSingleDeclaration_PreserveComments_ReportsDiagnostic()
+    {
+        const string SourceCode = """
+            /*sample*/[|partial|] class Sample
+            {
+            }
+            """;
+
+        const string CodeFix = """
+            /*sample*/class Sample
+            {
+            }
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith(CodeFix)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PartialClass_WithOtherModifiers_ReportsDiagnostic()
+    {
+        const string SourceCode = """
+            public sealed [|partial|] class Sample
+            {
+            }
+            """;
+
+        const string CodeFix = """
+            public sealed class Sample
+            {
+            }
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith(CodeFix)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PartialRecord_WithSingleDeclaration_ReportsDiagnostic()
+    {
+        const string SourceCode = """
+            [|partial|] record Sample;
+            """;
+
+        const string CodeFix = """
+            record Sample;
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith(CodeFix)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PartialStruct_WithSingleDeclaration_ReportsDiagnostic()
+    {
+        const string SourceCode = """
+            [|partial|] struct Sample
+            {
+            }
+            """;
+
+        const string CodeFix = """
+            struct Sample
+            {
+            }
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith(CodeFix)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PartialInterface_WithSingleDeclaration_ReportsDiagnostic()
+    {
+        const string SourceCode = """
+            [|partial|] interface ISample
+            {
+            }
+            """;
+
+        const string CodeFix = """
+            interface ISample
+            {
+            }
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith(CodeFix)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PartialClass_WithMultipleDeclarations_NoDiagnostic()
+    {
+        const string SourceCode = """
+            partial class Sample
+            {
+            }
+
+            partial class Sample
+            {
+            }
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PartialClass_WithPartialMethod_NoDiagnostic()
+    {
+        const string SourceCode = """
+            [|partial|] class Sample
+            {
+                partial void M();
+            }
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PartialClass_WithNestedPartialType_ReportsDiagnostic()
+    {
+        const string SourceCode = """
+            [|partial|] class Sample
+            {
+                partial class Nested
+                {
+                }
+
+                partial class Nested
+                {
+                }
+            }
+            """;
+
+        const string CodeFix = """
+            class Sample
+            {
+                partial class Nested
+                {
+                }
+
+                partial class Nested
+                {
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith(CodeFix)
+            .ValidateAsync();
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryPartialModifierAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryPartialModifierAnalyzerTests.cs
@@ -34,7 +34,7 @@ public sealed class RemoveUnnecessaryPartialModifierAnalyzerTests
     }
 
     [Fact]
-    public async Task PartialClass_WithSingleDeclaration_PreserveComments_ReportsDiagnostic()
+    public async Task PartialClass_WithSingleDeclaration_PreserveComments_Keyword_ReportsDiagnostic()
     {
         const string SourceCode = """
             /*sample*/[|partial|] class Sample
@@ -44,6 +44,27 @@ public sealed class RemoveUnnecessaryPartialModifierAnalyzerTests
 
         const string CodeFix = """
             /*sample*/class Sample
+            {
+            }
+            """;
+
+        await CreateProjectBuilder()
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith(CodeFix)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PartialClass_WithSingleDeclaration_PreserveComments_Modifier_ReportsDiagnostic()
+    {
+        const string SourceCode = """
+            static /*sample*/[|partial|] class Sample
+            {
+            }
+            """;
+
+        const string CodeFix = """
+            static /*sample*/class Sample
             {
             }
             """;


### PR DESCRIPTION
## Summary
- Add MA0204 analyzer and code fix to report and remove `partial` when a type has a single declaration.
- Cover classes, structs, interfaces, and records, while preserving trivia during the fix.
- Update rule documentation, rule identifiers, and analyzer pack severity presets.
- Add unit tests for compliant and non-compliant cases, including nested partial types and partial members.

## Testing
- Not run (not requested)