### PR TITLE
Add MA0205 rule to suggest using the XOR operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|⚠️|✔️|❌|
 |[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|⚠️|✔️|✔️|
 |[MA0203](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0203.md)|Design|Do not use return tag for void method|⚠️|✔️|❌|
+|[MA0205](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0205.md)|Style|Use exclusive or operator|ℹ️|✔️|✔️|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -202,6 +202,7 @@
 |[MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md)|Usage|Do not use zero-valued enum flags in flag checks|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0202](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0202.md)|Design|Conditional compilation branches have identical code|<span title='Warning'>⚠️</span>|✔️|✔️|
 |[MA0203](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0203.md)|Design|Do not use return tag for void method|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0205](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0205.md)|Style|Use exclusive or operator|<span title='Info'>ℹ️</span>|✔️|✔️|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0205.md
+++ b/docs/Rules/MA0205.md
@@ -1,0 +1,18 @@
+# MA0205 - Use exclusive or operator
+<!-- sources -->
+Sources: [UseExclusiveOrOperatorAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseExclusiveOrOperatorAnalyzer.cs), [UseExclusiveOrOperatorFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseExclusiveOrOperatorFixer.cs)
+<!-- sources -->
+
+This rule reports boolean expressions that can be simplified by using the exclusive or (`^`) operator.
+
+## Non-compliant code
+
+````csharp
+var result = (x && !y) || (!x && y);
+````
+
+## Compliant code
+
+````csharp
+var result = x ^ y;
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseExclusiveOrOperatorFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseExclusiveOrOperatorFixer.cs
@@ -1,0 +1,82 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class UseExclusiveOrOperatorFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.UseExclusiveOrOperator);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
+        if (nodeToFix is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        if (!TryGetExclusiveOrOperation(semanticModel, nodeToFix, context.CancellationToken, out _))
+            return;
+
+        const string Title = "Use ^ operator";
+        context.RegisterCodeFix(
+            CodeAction.Create(Title, ct => UseExclusiveOrOperator(context.Document, nodeToFix, ct), equivalenceKey: Title),
+            context.Diagnostics);
+    }
+
+    private static async Task<Document> UseExclusiveOrOperator(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        if (!TryGetExclusiveOrOperation(editor.SemanticModel, nodeToFix, cancellationToken, out var operation))
+            return document;
+
+        if (operation.Syntax is not BinaryExpressionSyntax binaryExpression)
+            return document;
+
+        if (!UseExclusiveOrOperatorCommon.TryMatch(operation, out var leftOperand, out var rightOperand))
+            return document;
+
+        if (leftOperand.Syntax is not ExpressionSyntax leftExpression || rightOperand.Syntax is not ExpressionSyntax rightExpression)
+            return document;
+
+        var newExpression = BinaryExpression(
+            SyntaxKind.ExclusiveOrExpression,
+            leftExpression.WithoutTrivia(),
+            Token(SyntaxKind.CaretToken),
+            rightExpression.WithoutTrivia());
+
+        editor.ReplaceNode(binaryExpression, newExpression.WithTriviaFrom(binaryExpression).WithAdditionalAnnotations(Formatter.Annotation));
+        return editor.GetChangedDocument();
+    }
+
+    private static bool TryGetExclusiveOrOperation(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken, out IBinaryOperation operation)
+    {
+        foreach (var candidate in node.AncestorsAndSelf())
+        {
+            if (semanticModel.GetOperation(candidate, cancellationToken) is IBinaryOperation binaryOperation &&
+                UseExclusiveOrOperatorCommon.TryMatch(binaryOperation, out _, out _))
+            {
+                operation = binaryOperation;
+                return true;
+            }
+        }
+
+        operation = null!;
+        return false;
+    }
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = error
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = error
+
+# MA0205: Use exclusive or operator
+dotnet_diagnostic.MA0205.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = suggestion
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = suggestion
+
+# MA0205: Use exclusive or operator
+dotnet_diagnostic.MA0205.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = warning
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = warning
+
+# MA0205: Use exclusive or operator
+dotnet_diagnostic.MA0205.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = warning
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = warning
+
+# MA0205: Use exclusive or operator
+dotnet_diagnostic.MA0205.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -604,3 +604,6 @@ dotnet_diagnostic.MA0202.severity = none
 
 # MA0203: Do not use return tag for void method
 dotnet_diagnostic.MA0203.severity = none
+
+# MA0205: Use exclusive or operator
+dotnet_diagnostic.MA0205.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -203,6 +203,7 @@ internal static class RuleIdentifiers
     public const string DoNotUseZeroValuedEnumFlagsInFlagChecks = "MA0201";
     public const string ConditionalCompilationBranchesAreIdentical = "MA0202";
     public const string DoNotUseReturnTagForVoidMethod = "MA0203";
+    public const string UseExclusiveOrOperator = "MA0205";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/UseExclusiveOrOperatorAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseExclusiveOrOperatorAnalyzer.cs
@@ -1,0 +1,39 @@
+using System.Collections.Immutable;
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseExclusiveOrOperatorAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.UseExclusiveOrOperator,
+        title: "Use exclusive or operator",
+        messageFormat: "Use exclusive or operator",
+        RuleCategories.Style,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseExclusiveOrOperator));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterOperationAction(AnalyzeBinaryOperation, OperationKind.Binary);
+    }
+
+    private static void AnalyzeBinaryOperation(OperationAnalysisContext context)
+    {
+        var operation = (IBinaryOperation)context.Operation;
+        if (UseExclusiveOrOperatorCommon.TryMatch(operation, out _, out _))
+        {
+            context.ReportDiagnostic(Rule, operation);
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/UseExclusiveOrOperatorCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseExclusiveOrOperatorCommon.cs
@@ -1,0 +1,103 @@
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Analyzer.Rules;
+
+internal static class UseExclusiveOrOperatorCommon
+{
+    public static bool TryMatch(IBinaryOperation operation, out IOperation leftOperand, out IOperation rightOperand)
+    {
+        leftOperand = null!;
+        rightOperand = null!;
+
+        if (operation.OperatorKind is not BinaryOperatorKind.ConditionalOr || !operation.Type.IsBoolean())
+            return false;
+
+        if (operation.LeftOperand.UnwrapImplicitConversionOperations() is not IBinaryOperation leftOperation)
+            return false;
+
+        if (operation.RightOperand.UnwrapImplicitConversionOperations() is not IBinaryOperation rightOperation)
+            return false;
+
+        if (!TryGetExclusiveOrBranch(leftOperation, out var leftPositiveOperand, out var leftNegativeOperand))
+            return false;
+
+        if (!TryGetExclusiveOrBranch(rightOperation, out var rightPositiveOperand, out var rightNegativeOperand))
+            return false;
+
+        var leftPositiveSymbol = GetReferenceSymbol(leftPositiveOperand);
+        var leftNegativeSymbol = GetReferenceSymbol(leftNegativeOperand);
+        var rightPositiveSymbol = GetReferenceSymbol(rightPositiveOperand);
+        var rightNegativeSymbol = GetReferenceSymbol(rightNegativeOperand);
+        if (leftPositiveSymbol is null || leftNegativeSymbol is null || rightPositiveSymbol is null || rightNegativeSymbol is null)
+            return false;
+
+        if (!SymbolEqualityComparer.Default.Equals(leftPositiveSymbol, rightNegativeSymbol))
+            return false;
+
+        if (!SymbolEqualityComparer.Default.Equals(leftNegativeSymbol, rightPositiveSymbol))
+            return false;
+
+        leftOperand = leftPositiveOperand;
+        rightOperand = leftNegativeOperand;
+        return true;
+    }
+
+    private static bool TryGetExclusiveOrBranch(IBinaryOperation operation, out IOperation positiveOperand, out IOperation negativeOperand)
+    {
+        positiveOperand = null!;
+        negativeOperand = null!;
+
+        if (operation.OperatorKind is not BinaryOperatorKind.ConditionalAnd || !operation.Type.IsBoolean())
+            return false;
+
+        var left = operation.LeftOperand.UnwrapImplicitConversionOperations();
+        var right = operation.RightOperand.UnwrapImplicitConversionOperations();
+        if (TryGetNegatedOperand(left, out var leftNegatedOperand))
+        {
+            positiveOperand = right;
+            negativeOperand = leftNegatedOperand;
+        }
+        else if (TryGetNegatedOperand(right, out var rightNegatedOperand))
+        {
+            positiveOperand = left;
+            negativeOperand = rightNegatedOperand;
+        }
+        else
+        {
+            return false;
+        }
+
+        return IsSimpleBooleanReference(positiveOperand) && IsSimpleBooleanReference(negativeOperand);
+    }
+
+    private static bool TryGetNegatedOperand(IOperation operation, out IOperation operand)
+    {
+        operation = operation.UnwrapImplicitConversionOperations();
+        if (operation is IUnaryOperation { OperatorKind: UnaryOperatorKind.Not } unaryOperation)
+        {
+            operand = unaryOperation.Operand.UnwrapImplicitConversionOperations();
+            return true;
+        }
+
+        operand = null!;
+        return false;
+    }
+
+    private static bool IsSimpleBooleanReference(IOperation operation)
+    {
+        return operation.Type.IsBoolean() && GetReferenceSymbol(operation) is not null;
+    }
+
+    private static ISymbol? GetReferenceSymbol(IOperation operation)
+    {
+        operation = operation.UnwrapImplicitConversionOperations();
+        return operation switch
+        {
+            ILocalReferenceOperation localReference => localReference.Local,
+            IParameterReferenceOperation parameterReference => parameterReference.Parameter,
+            _ => null,
+        };
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/UseExclusiveOrOperatorAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseExclusiveOrOperatorAnalyzerTests.cs
@@ -1,0 +1,118 @@
+using Meziantou.Analyzer.Rules;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class UseExclusiveOrOperatorAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<UseExclusiveOrOperatorAnalyzer>()
+            .WithCodeFixProvider<UseExclusiveOrOperatorFixer>();
+    }
+
+    [Theory]
+    [InlineData("(x && !y) || (!x && y)", "x ^ y")]
+    [InlineData("(!x && y) || (x && !y)", "y ^ x")]
+    [InlineData("(x && !y) || (y && !x)", "x ^ y")]
+    [InlineData("(!y && x) || (!x && y)", "x ^ y")]
+    public async Task UseExclusiveOrOperator(string expression, string fixedExpression)
+    {
+        var originalCode = $$"""
+            class TestClass
+            {
+                void Test(bool x, bool y)
+                {
+                    _ = [|{{expression}}|];
+                }
+            }
+            """;
+        var fixedCode = $$"""
+            class TestClass
+            {
+                void Test(bool x, bool y)
+                {
+                    _ = {{fixedExpression}};
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ShouldFixCodeWith(fixedCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task UseExclusiveOrOperator_LocalVariables()
+    {
+        var originalCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    var x = true;
+                    var y = false;
+                    _ = [|(x && !y) || (!x && y)|];
+                }
+            }
+            """;
+        var fixedCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    var x = true;
+                    var y = false;
+                    _ = x ^ y;
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ShouldFixCodeWith(fixedCode)
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("(x && y) || (!x && !y)")]
+    [InlineData("(x && !y) || (x && y)")]
+    [InlineData("(x || !y) || (!x && y)")]
+    [InlineData("(x && !y) && (!x && y)")]
+    [InlineData("x ^ y")]
+    public async Task NoDiagnostic(string expression)
+    {
+        var originalCode = $$"""
+            class TestClass
+            {
+                void Test(bool x, bool y)
+                {
+                    _ = {{expression}};
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_ForMemberAccess()
+    {
+        var originalCode = """
+            class TestClass
+            {
+                bool X { get; }
+                bool Y { get; }
+
+                void Test()
+                {
+                    _ = (X && !Y) || (!X && Y);
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ValidateAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- Add MA0205 analyzer and code fix to detect boolean expressions that can be simplified with `^`
- Include tests covering supported expression shapes and non-matches
- Update rule documentation and analyzer pack severity presets

## Testing
- Added analyzer and code fix tests for valid replacements and no-diagnostic cases
- Documentation generation and repository validation were not run in this turn