### PR TITLE
Add MA0207/MA0208 for FixedAddressValueTypeAttribute validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0204](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0204.md)|Design|Remove unnecessary partial modifier|ℹ️|✔️|✔️|
 |[MA0205](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0205.md)|Style|Use exclusive or operator|ℹ️|✔️|✔️|
 |[MA0206](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0206.md)|Style|Remove unnecessary braces in type declaration|ℹ️|✔️|✔️|
+|[MA0207](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0207.md)|Usage|\[FixedAddressValueType\] fields must be static|⚠️|✔️|❌|
+|[MA0208](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0208.md)|Usage|\[FixedAddressValueType\] fields must be value types|⚠️|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -205,6 +205,8 @@
 |[MA0204](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0204.md)|Design|Remove unnecessary partial modifier|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0205](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0205.md)|Style|Use exclusive or operator|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0206](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0206.md)|Style|Remove unnecessary braces in type declaration|<span title='Info'>ℹ️</span>|✔️|✔️|
+|[MA0207](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0207.md)|Usage|\[FixedAddressValueType\] fields must be static|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0208](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0208.md)|Usage|\[FixedAddressValueType\] fields must be value types|<span title='Warning'>⚠️</span>|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0207.md
+++ b/docs/Rules/MA0207.md
@@ -1,0 +1,17 @@
+# MA0207 - \[FixedAddressValueType\] fields must be static
+<!-- sources -->
+Source: [ValidateFixedAddressValueTypeAttributeUsageAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzer.cs)
+<!-- sources -->
+
+`[FixedAddressValueType]` can only be applied to static fields.
+
+```csharp
+class Sample
+{
+    [System.Runtime.CompilerServices.FixedAddressValueType]
+    int _field; // Non-compliant
+
+    [System.Runtime.CompilerServices.FixedAddressValueType]
+    static int _staticField; // Compliant
+}
+```

--- a/docs/Rules/MA0208.md
+++ b/docs/Rules/MA0208.md
@@ -1,0 +1,17 @@
+# MA0208 - \[FixedAddressValueType\] fields must be value types
+<!-- sources -->
+Source: [ValidateFixedAddressValueTypeAttributeUsageAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzer.cs)
+<!-- sources -->
+
+`[FixedAddressValueType]` can only be applied to fields of value type (`struct`).
+
+```csharp
+class Sample
+{
+    [System.Runtime.CompilerServices.FixedAddressValueType]
+    static string _field; // Non-compliant
+
+    [System.Runtime.CompilerServices.FixedAddressValueType]
+    static int _valueTypeField; // Compliant
+}
+```

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -613,3 +613,9 @@ dotnet_diagnostic.MA0205.severity = error
 
 # MA0206: Remove unnecessary braces in type declaration
 dotnet_diagnostic.MA0206.severity = error
+
+# MA0207: [FixedAddressValueType] fields must be static
+dotnet_diagnostic.MA0207.severity = error
+
+# MA0208: [FixedAddressValueType] fields must be value types
+dotnet_diagnostic.MA0208.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -613,3 +613,9 @@ dotnet_diagnostic.MA0205.severity = suggestion
 
 # MA0206: Remove unnecessary braces in type declaration
 dotnet_diagnostic.MA0206.severity = suggestion
+
+# MA0207: [FixedAddressValueType] fields must be static
+dotnet_diagnostic.MA0207.severity = suggestion
+
+# MA0208: [FixedAddressValueType] fields must be value types
+dotnet_diagnostic.MA0208.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -613,3 +613,9 @@ dotnet_diagnostic.MA0205.severity = warning
 
 # MA0206: Remove unnecessary braces in type declaration
 dotnet_diagnostic.MA0206.severity = warning
+
+# MA0207: [FixedAddressValueType] fields must be static
+dotnet_diagnostic.MA0207.severity = warning
+
+# MA0208: [FixedAddressValueType] fields must be value types
+dotnet_diagnostic.MA0208.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -613,3 +613,9 @@ dotnet_diagnostic.MA0205.severity = suggestion
 
 # MA0206: Remove unnecessary braces in type declaration
 dotnet_diagnostic.MA0206.severity = suggestion
+
+# MA0207: [FixedAddressValueType] fields must be static
+dotnet_diagnostic.MA0207.severity = warning
+
+# MA0208: [FixedAddressValueType] fields must be value types
+dotnet_diagnostic.MA0208.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -613,3 +613,9 @@ dotnet_diagnostic.MA0205.severity = none
 
 # MA0206: Remove unnecessary braces in type declaration
 dotnet_diagnostic.MA0206.severity = none
+
+# MA0207: [FixedAddressValueType] fields must be static
+dotnet_diagnostic.MA0207.severity = none
+
+# MA0208: [FixedAddressValueType] fields must be value types
+dotnet_diagnostic.MA0208.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -206,6 +206,8 @@ internal static class RuleIdentifiers
     public const string RemoveUnnecessaryPartialModifier = "MA0204";
     public const string UseExclusiveOrOperator = "MA0205";
     public const string RemoveUnnecessaryBracesInTypeDeclaration = "MA0206";
+    public const string FixedAddressValueTypeAttribute_FieldMustBeStatic = "MA0207";
+    public const string FixedAddressValueTypeAttribute_FieldTypeMustBeValueType = "MA0208";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzer.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ValidateFixedAddressValueTypeAttributeUsageAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor FieldMustBeStaticRule = new(
+        RuleIdentifiers.FixedAddressValueTypeAttribute_FieldMustBeStatic,
+        title: "[FixedAddressValueType] fields must be static",
+        messageFormat: "[FixedAddressValueType] can only be applied to static fields",
+        RuleCategories.Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.FixedAddressValueTypeAttribute_FieldMustBeStatic));
+
+    private static readonly DiagnosticDescriptor FieldTypeMustBeValueTypeRule = new(
+        RuleIdentifiers.FixedAddressValueTypeAttribute_FieldTypeMustBeValueType,
+        title: "[FixedAddressValueType] fields must be value types",
+        messageFormat: "[FixedAddressValueType] can only be applied to fields of value type",
+        RuleCategories.Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.FixedAddressValueTypeAttribute_FieldTypeMustBeValueType));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(FieldMustBeStaticRule, FieldTypeMustBeValueTypeRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var attributeType = compilationContext.Compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.FixedAddressValueTypeAttribute");
+            if (attributeType is null)
+                return;
+
+            compilationContext.RegisterSymbolAction(context => Analyze(context, attributeType), SymbolKind.Field);
+        });
+    }
+
+    private static void Analyze(SymbolAnalysisContext context, ITypeSymbol attributeType)
+    {
+        var field = (IFieldSymbol)context.Symbol;
+        if (field.GetAttribute(attributeType, inherits: false) is null)
+            return;
+
+        if (!field.IsStatic)
+        {
+            context.ReportDiagnostic(FieldMustBeStaticRule, field);
+        }
+
+        if (!field.Type.IsValueType)
+        {
+            context.ReportDiagnostic(FieldTypeMustBeValueTypeRule, field, DiagnosticFieldReportOptions.ReportOnReturnType);
+        }
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests.cs
@@ -1,0 +1,68 @@
+using Meziantou.Analyzer.Rules;
+using Meziantou.Analyzer.Test.Helpers;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder() => new ProjectBuilder()
+        .WithTargetFramework(TargetFramework.Net10_0)
+        .WithAnalyzer<ValidateFixedAddressValueTypeAttributeUsageAnalyzer>();
+
+    [Fact]
+    public async Task ValidField()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                class Sample
+                {
+                    [System.Runtime.CompilerServices.FixedAddressValueType]
+                    static int _field;
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task FieldMustBeStatic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                class Sample
+                {
+                    [System.Runtime.CompilerServices.FixedAddressValueType]
+                    int {|MA0207:_field|};
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task FieldTypeMustBeValueType()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                class Sample
+                {
+                    [System.Runtime.CompilerServices.FixedAddressValueType]
+                    static [|string|] _field;
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task BothDiagnostics()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                class Sample
+                {
+                    [System.Runtime.CompilerServices.FixedAddressValueType]
+                    [|string|] {|MA0207:_field|};
+                }
+                """)
+            .ValidateAsync();
+    }
+}


### PR DESCRIPTION
## Why
`[FixedAddressValueType]` has strict usage constraints, and incorrect usage should be flagged at analysis time to prevent invalid field declarations.

## What changed
- Added `ValidateFixedAddressValueTypeAttributeUsageAnalyzer`.
- Added two warning diagnostics (enabled by default):
  - `MA0207`: `[FixedAddressValueType]` field must be `static`.
  - `MA0208`: `[FixedAddressValueType]` field type must be a value type.
- Added rule identifiers in `RuleIdentifiers`.
- Added analyzer tests covering valid usage, each individual violation, and both violations together.
- Added dedicated rule docs: `docs/Rules/MA0207.md` and `docs/Rules/MA0208.md`.
- Regenerated generated documentation/configuration files (`README.md`, `docs/README.md`, and analyzer pack editorconfig files).

## Notes
- No code fixers were added for these diagnostics.