### PR TITLE
Fix MA0206 for documented class declarations

### DIFF
--- a/docs/Rules/MA0206.md
+++ b/docs/Rules/MA0206.md
@@ -5,7 +5,7 @@ Sources: [RemoveUnnecessaryBracesInTypeDeclarationAnalyzer.cs](https://github.co
 
 This rule reports empty braces in type declarations that can be replaced with a semicolon.
 
-The rule applies to positional records and to C# 12 type declarations with primary constructors when the type body contains no members, comments, or directives.
+The rule applies to records and to C# 12 class/struct declarations when the type body contains no members, comments, or directives.
 
 ## Non-compliant code
 
@@ -13,6 +13,7 @@ The rule applies to positional records and to C# 12 type declarations with prima
 public record Foo(string Value1, string Value2) { }
 
 public class Bar(string Value1, string Value2) { }
+public class Baz { }
 ````
 
 ## Compliant code
@@ -21,4 +22,5 @@ public class Bar(string Value1, string Value2) { }
 public record Foo(string Value1, string Value2);
 
 public class Bar(string Value1, string Value2);
+public class Baz;
 ````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryBracesInTypeDeclarationFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryBracesInTypeDeclarationFixer.cs
@@ -53,7 +53,7 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationFixer : CodeFixProvi
 
     private static bool CanRemoveBraces(TypeDeclarationSyntax typeDeclaration)
     {
-        if (!HasParameterList(typeDeclaration))
+        if (!CanUseSemicolonTypeDeclaration(typeDeclaration))
             return false;
 
         if (typeDeclaration.Members.Count != 0)
@@ -65,16 +65,16 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationFixer : CodeFixProvi
         return !ContainsCommentOrDirectiveInBraces(typeDeclaration);
     }
 
-    private static bool HasParameterList(TypeDeclarationSyntax typeDeclaration)
+    private static bool CanUseSemicolonTypeDeclaration(TypeDeclarationSyntax typeDeclaration)
     {
-        if (typeDeclaration is RecordDeclarationSyntax { ParameterList: not null })
+        if (typeDeclaration is RecordDeclarationSyntax)
             return true;
 
 #if CSHARP12_OR_GREATER
         if (!typeDeclaration.GetCSharpLanguageVersion().IsCSharp12OrAbove())
             return false;
 
-        if (typeDeclaration is ClassDeclarationSyntax { ParameterList: not null } or StructDeclarationSyntax { ParameterList: not null })
+        if (typeDeclaration is ClassDeclarationSyntax or StructDeclarationSyntax)
             return true;
 #endif
 

--- a/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzer.cs
@@ -46,7 +46,7 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzer : Diagnosti
 
     private static bool CanRemoveBraces(TypeDeclarationSyntax typeDeclaration, LanguageVersion languageVersion)
     {
-        if (!HasParameterList(typeDeclaration, languageVersion))
+        if (!CanUseSemicolonTypeDeclaration(typeDeclaration, languageVersion))
             return false;
 
         if (typeDeclaration.Members.Count != 0)
@@ -58,16 +58,16 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzer : Diagnosti
         return !ContainsCommentOrDirectiveInBraces(typeDeclaration);
     }
 
-    private static bool HasParameterList(TypeDeclarationSyntax typeDeclaration, LanguageVersion languageVersion)
+    private static bool CanUseSemicolonTypeDeclaration(TypeDeclarationSyntax typeDeclaration, LanguageVersion languageVersion)
     {
-        if (typeDeclaration is RecordDeclarationSyntax { ParameterList: not null })
+        if (typeDeclaration is RecordDeclarationSyntax)
             return true;
 
 #if CSHARP12_OR_GREATER
         if (!languageVersion.IsCSharp12OrAbove())
             return false;
 
-        if (typeDeclaration is ClassDeclarationSyntax { ParameterList: not null } or StructDeclarationSyntax { ParameterList: not null })
+        if (typeDeclaration is ClassDeclarationSyntax or StructDeclarationSyntax)
             return true;
 #endif
 

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests.cs
@@ -83,9 +83,10 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
         await CreateProjectBuilder()
             .WithLanguageVersion(LanguageVersion.CSharp9)
             .WithSourceCode("""
-                public record Foo
-                {
-                }
+                public record Foo [|{|]}
+                """)
+            .ShouldFixCodeWith("""
+                public record Foo;
                 """)
             .ValidateAsync();
     }
@@ -126,6 +127,46 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
                 """)
             .ShouldFixCodeWith("""
                 public struct Foo(string Value1, string Value2);
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ClassPrimaryConstructor_WithDocumentation()
+    {
+        await CreateProjectBuilder()
+            .WithLanguageVersion(LanguageVersion.CSharp12)
+            .WithSourceCode("""
+                /// <summary>
+                /// I show up when you hover my constructor invocation too!
+                /// </summary>
+                public sealed class Documented() [|{|]}
+                """)
+            .ShouldFixCodeWith("""
+                /// <summary>
+                /// I show up when you hover my constructor invocation too!
+                /// </summary>
+                public sealed class Documented();
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ClassWithoutPrimaryConstructor_WithDocumentation()
+    {
+        await CreateProjectBuilder()
+            .WithLanguageVersion(LanguageVersion.CSharp12)
+            .WithSourceCode("""
+                /// <summary>
+                /// I don't. :(
+                /// </summary>
+                public sealed class HalfDocumented [|{|]}
+                """)
+            .ShouldFixCodeWith("""
+                /// <summary>
+                /// I don't. :(
+                /// </summary>
+                public sealed class HalfDocumented;
                 """)
             .ValidateAsync();
     }


### PR DESCRIPTION
Fix #1196

MA0206 missed some empty class declarations that are valid semicolon declarations, especially around documented types in C# 12 scenarios. This made the rule inconsistent for equivalent empty type bodies.

### What changed
- Updated MA0206 analyzer logic to check whether a type can use a semicolon declaration by type kind/language version, instead of requiring a parameter list.
- Applied the same condition in the code fix provider so fix availability matches analyzer reporting.
- Added regression tests for documented classes with and without primary constructors, and for records without a parameter list.
- Updated `docs/Rules/MA0206.md` to describe the broader applicability (`record`, `class`, and `struct` when legal).

### Notes for review
- The behavior still preserves existing safety checks: no members, no comments/directives in braces, no existing semicolon token.