### PR TITLE
Add global generic constraint support to type relationship helpers

### DIFF
--- a/src/Meziantou.Analyzer/Internals/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/TypeSymbolExtensions.cs
@@ -25,8 +25,21 @@ internal static class TypeSymbolExtensions
 
     public static bool InheritsFrom(this ITypeSymbol classSymbol, [NotNullWhen(true)] ITypeSymbol? baseClassType)
     {
+        return InheritsFrom(classSymbol, baseClassType, visitedTypeParameters: null);
+    }
+
+    private static bool InheritsFrom(this ITypeSymbol classSymbol, [NotNullWhen(true)] ITypeSymbol? baseClassType, HashSet<ITypeParameterSymbol>? visitedTypeParameters)
+    {
         if (baseClassType is null)
             return false;
+
+        if (classSymbol is ITypeParameterSymbol typeParameter)
+        {
+            return AnyConstraintTypeMatches(typeParameter, visitedTypeParameters, (constraintType, visitedTypeParameters) =>
+            {
+                return !constraintType.IsEqualTo(baseClassType) && constraintType.InheritsFrom(baseClassType, visitedTypeParameters);
+            });
+        }
 
         var baseType = classSymbol.BaseType;
         while (baseType is not null)
@@ -42,8 +55,21 @@ internal static class TypeSymbolExtensions
 
     public static bool Implements(this ITypeSymbol classSymbol, [NotNullWhen(true)] ITypeSymbol? interfaceType)
     {
+        return Implements(classSymbol, interfaceType, visitedTypeParameters: null);
+    }
+
+    private static bool Implements(this ITypeSymbol classSymbol, [NotNullWhen(true)] ITypeSymbol? interfaceType, HashSet<ITypeParameterSymbol>? visitedTypeParameters)
+    {
         if (interfaceType is null)
             return false;
+
+        if (classSymbol is ITypeParameterSymbol typeParameter)
+        {
+            return AnyConstraintTypeMatches(typeParameter, visitedTypeParameters, (constraintType, visitedTypeParameters) =>
+            {
+                return constraintType.IsEqualTo(interfaceType) || constraintType.Implements(interfaceType, visitedTypeParameters);
+            });
+        }
 
         foreach (var @interface in classSymbol.AllInterfaces)
         {
@@ -56,8 +82,21 @@ internal static class TypeSymbolExtensions
 
     public static bool ImplementsGenericInterface(this ITypeSymbol classSymbol, [NotNullWhen(true)] ITypeSymbol? interfaceType)
     {
+        return ImplementsGenericInterface(classSymbol, interfaceType, visitedTypeParameters: null);
+    }
+
+    private static bool ImplementsGenericInterface(this ITypeSymbol classSymbol, [NotNullWhen(true)] ITypeSymbol? interfaceType, HashSet<ITypeParameterSymbol>? visitedTypeParameters)
+    {
         if (interfaceType is null)
             return false;
+
+        if (classSymbol is ITypeParameterSymbol typeParameter)
+        {
+            return AnyConstraintTypeMatches(typeParameter, visitedTypeParameters, (constraintType, visitedTypeParameters) =>
+            {
+                return constraintType.OriginalDefinition.IsEqualTo(interfaceType.OriginalDefinition) || constraintType.ImplementsGenericInterface(interfaceType, visitedTypeParameters);
+            });
+        }
 
         foreach (var iface in classSymbol.AllInterfaces)
         {
@@ -73,16 +112,7 @@ internal static class TypeSymbolExtensions
         if (interfaceType is null)
             return false;
 
-        if (symbol is INamedTypeSymbol { TypeKind: TypeKind.Interface } interfaceSymbol && interfaceSymbol.IsEqualTo(interfaceType))
-            return true;
-
-        foreach (var @interface in symbol.AllInterfaces)
-        {
-            if (@interface.IsEqualTo(interfaceType))
-                return true;
-        }
-
-        return false;
+        return symbol.IsEqualTo(interfaceType) || symbol.Implements(interfaceType);
     }
 
     public static IEnumerable<AttributeData> GetAttributes(this ISymbol symbol, ITypeSymbol? attributeType, bool inherits = true)
@@ -149,10 +179,41 @@ internal static class TypeSymbolExtensions
 
     public static bool IsOrInheritFrom(this ITypeSymbol symbol, [NotNullWhen(true)] ITypeSymbol? expectedType)
     {
+        return IsOrInheritFrom(symbol, expectedType, visitedTypeParameters: null);
+    }
+
+    private static bool IsOrInheritFrom(this ITypeSymbol symbol, [NotNullWhen(true)] ITypeSymbol? expectedType, HashSet<ITypeParameterSymbol>? visitedTypeParameters)
+    {
         if (expectedType is null)
             return false;
 
-        return symbol.IsEqualTo(expectedType) || (!expectedType.IsSealed && symbol.InheritsFrom(expectedType));
+        if (symbol.IsEqualTo(expectedType))
+            return true;
+
+        if (symbol is ITypeParameterSymbol typeParameter)
+        {
+            return AnyConstraintTypeMatches(typeParameter, visitedTypeParameters, (constraintType, visitedTypeParameters) =>
+            {
+                return constraintType.IsOrInheritFrom(expectedType, visitedTypeParameters);
+            });
+        }
+
+        return !expectedType.IsSealed && symbol.InheritsFrom(expectedType, visitedTypeParameters);
+    }
+
+    private static bool AnyConstraintTypeMatches(ITypeParameterSymbol typeParameter, HashSet<ITypeParameterSymbol>? visitedTypeParameters, Func<ITypeSymbol, HashSet<ITypeParameterSymbol>, bool> predicate)
+    {
+        visitedTypeParameters ??= [];
+        if (!visitedTypeParameters.Add(typeParameter))
+            return false;
+
+        foreach (var constraintType in typeParameter.ConstraintTypes)
+        {
+            if (predicate(constraintType, visitedTypeParameters))
+                return true;
+        }
+
+        return false;
     }
 
     public static bool IsEqualToAny([NotNullWhen(true)] this ITypeSymbol? symbol, params ReadOnlySpan<ITypeSymbol?> expectedTypes)

--- a/src/Meziantou.Analyzer/Rules/UseEventHandlerOfTAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseEventHandlerOfTAnalyzer.cs
@@ -90,19 +90,7 @@ public sealed class UseEventHandlerOfTAnalyzer : DiagnosticAnalyzer
 
         private bool IsEventArgsType(ITypeSymbol type)
         {
-            if (type.IsOrInheritFrom(EventArgsSymbol))
-                return true;
-
-            if (type is not ITypeParameterSymbol typeParameter)
-                return false;
-
-            foreach (var constraintType in typeParameter.ConstraintTypes)
-            {
-                if (IsEventArgsType(constraintType))
-                    return true;
-            }
-
-            return false;
+            return type.IsOrInheritFrom(EventArgsSymbol);
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/EventsShouldHaveProperArgumentsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EventsShouldHaveProperArgumentsAnalyzerTests.cs
@@ -294,4 +294,25 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzerTests
               .ShouldFixCodeWith(Fix)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task InvalidEventArgs_GenericTypeParameterConstraint()
+    {
+        const string SourceCode = """
+            using System;
+            delegate void CustomEventHandler<TEventArgs>(object sender, TEventArgs e) where TEventArgs : EventArgs;
+            class Test<TEventArgs> where TEventArgs : EventArgs
+            {
+                public event CustomEventHandler<TEventArgs> MyEvent;
+
+                void OnEvent()
+                {
+                    MyEvent?.Invoke(this, [|null|]);
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
## Motivation

MA0046 (Use EventHandler<T> to declare events) recently added support for generic type parameter constraints, but this capability was isolated to a single analyzer. Other relationship-checking helpers like `IsOrInheritFrom`, `Implements`, and `InheritsFrom` lack this awareness, causing them to miss or incorrectly handle cases where a type parameter is constrained to a base type or interface. This creates inconsistency across the codebase and false positives/negatives in analyzers that rely on these helpers.

## Approach

**Centralized generic constraint resolution:** Updated all type relationship helpers in `TypeSymbolExtensions` to recursively resolve generic type parameter constraints:

- `InheritsFrom` – now checks if constraint types inherit from the target
- `Implements` – now checks if constraint types implement the target interface
- `ImplementsGenericInterface` – now checks generic interface constraints
- `IsOrImplements` – simplified by delegating to `Implements`
- `IsOrInheritFrom` – combined type equality check with constraint resolution

**Cycle-safe recursion:** Added `AnyConstraintTypeMatches` helper that tracks visited type parameters using a HashSet to prevent infinite loops in recursive constraint chains.

**Refactored consumers:** Simplified `UseEventHandlerOfTAnalyzer` (`MA0046`) to use `IsOrInheritFrom` directly instead of maintaining its own constraint-traversal logic.

## Changes

- `TypeSymbolExtensions.cs`: Added generic constraint awareness to five core helpers; introduced cycle-safe traversal
- `UseEventHandlerOfTAnalyzer.cs`: Removed local constraint recursion (14 lines → 2 lines)
- `EventsShouldHaveProperArgumentsAnalyzerTests.cs`: Added regression test for constrained generic delegate arguments
- `docs/Rules/MA0046.md` and `docs/Rules/MA0093.md`: Updated to note generic constraint support

## Testing

- All 3289 existing tests pass
- Targeted tests pass on Roslyn 4.2 (earliest supported version)
- New test validates that `EventsShouldHaveProperArgumentsAnalyzer` correctly flags null EventArgs on constrained generic delegates
- Full test suite passes after documentation regeneration