### PR TITLE
Add opt-in analyzers for explicit in call-site usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0206](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0206.md)|Style|Remove unnecessary braces in type declaration|ℹ️|✔️|✔️|
 |[MA0207](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0207.md)|Usage|\[FixedAddressValueType\] fields must be static|⚠️|✔️|❌|
 |[MA0208](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0208.md)|Usage|\[FixedAddressValueType\] fields must be value types|⚠️|✔️|❌|
+|[MA0209](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0209.md)|Performance|Use in keyword for in parameter|ℹ️|❌|✔️|
+|[MA0210](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0210.md)|Performance|Use in keyword to call the in overload|ℹ️|❌|✔️|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -207,6 +207,8 @@
 |[MA0206](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0206.md)|Style|Remove unnecessary braces in type declaration|<span title='Info'>ℹ️</span>|✔️|✔️|
 |[MA0207](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0207.md)|Usage|\[FixedAddressValueType\] fields must be static|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0208](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0208.md)|Usage|\[FixedAddressValueType\] fields must be value types|<span title='Warning'>⚠️</span>|✔️|❌|
+|[MA0209](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0209.md)|Performance|Use in keyword for in parameter|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0210](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0210.md)|Performance|Use in keyword to call the in overload|<span title='Info'>ℹ️</span>|❌|✔️|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0209.md
+++ b/docs/Rules/MA0209.md
@@ -1,0 +1,18 @@
+# MA0209 - Use in keyword for in parameter
+<!-- sources -->
+Sources: [UseInKeywordForInParameterAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseInKeywordForInParameterAnalyzer.cs), [UseInKeywordForInParameterFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseInKeywordForInParameterFixer.cs)
+<!-- sources -->
+
+When a method parameter is declared as `in`, you can add `in` at the call site to make by-reference intent explicit.
+
+````csharp
+var value = new LargeStruct();
+Process(value);
+
+// Prefer
+Process(in value);
+
+static void Process(in LargeStruct value) { }
+````
+
+This rule is disabled by default.

--- a/docs/Rules/MA0210.md
+++ b/docs/Rules/MA0210.md
@@ -1,0 +1,20 @@
+# MA0210 - Use in keyword to call the in overload
+<!-- sources -->
+Sources: [UseInKeywordForInParameterAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseInKeywordForInParameterAnalyzer.cs), [UseInKeywordForInParameterFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseInKeywordForInParameterFixer.cs)
+<!-- sources -->
+
+If a type exposes both by-value and `in` overloads, omitting `in` selects the by-value overload.
+Use `in` at the call site to select the `in` overload.
+
+````csharp
+var value = new LargeStruct();
+Process(value); // Calls Process(LargeStruct)
+
+// Prefer
+Process(in value); // Calls Process(in LargeStruct)
+
+void Process(LargeStruct value) { }
+void Process(in LargeStruct value) { }
+````
+
+This rule is disabled by default.

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseInKeywordForInParameterFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseInKeywordForInParameterFixer.cs
@@ -35,9 +35,6 @@ public sealed class UseInKeywordForInParameterFixer : CodeFixProvider
         if (semanticModel?.GetOperation(argument, context.CancellationToken) is not IArgumentOperation operation)
             return;
 
-        if (HasNonIdentityConversion(operation.Value))
-            return;
-
         if (!IsVariableReference(operation.Value))
             return;
 
@@ -48,19 +45,6 @@ public sealed class UseInKeywordForInParameterFixer : CodeFixProvider
                 cancellationToken => AddInKeywordAsync(context.Document, diagnostic.Location.SourceSpan, cancellationToken),
                 equivalenceKey: title),
             context.Diagnostics);
-    }
-
-    private static bool HasNonIdentityConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversion)
-        {
-            if (!conversion.Conversion.IsIdentity)
-                return true;
-
-            operation = conversion.Operand;
-        }
-
-        return false;
     }
 
     private static bool IsVariableReference(IOperation operation)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseInKeywordForInParameterFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseInKeywordForInParameterFixer.cs
@@ -1,0 +1,106 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class UseInKeywordForInParameterFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.UseInKeywordForInParameter, RuleIdentifiers.UseInKeywordToSelectInOverload);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics.FirstOrDefault();
+        if (root is null || diagnostic is null)
+            return;
+
+        if (root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<ArgumentSyntax>() is not { } argument)
+            return;
+
+        if (!argument.RefKindKeyword.IsKind(SyntaxKind.None))
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel?.GetOperation(argument, context.CancellationToken) is not IArgumentOperation operation)
+            return;
+
+        if (HasNonIdentityConversion(operation.Value))
+            return;
+
+        if (!IsVariableReference(operation.Value))
+            return;
+
+        var title = "Add in keyword";
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title,
+                cancellationToken => AddInKeywordAsync(context.Document, diagnostic.Location.SourceSpan, cancellationToken),
+                equivalenceKey: title),
+            context.Diagnostics);
+    }
+
+    private static bool HasNonIdentityConversion(IOperation operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            if (!conversion.Conversion.IsIdentity)
+                return true;
+
+            operation = conversion.Operand;
+        }
+
+        return false;
+    }
+
+    private static bool IsVariableReference(IOperation operation)
+    {
+        while (true)
+        {
+            switch (operation)
+            {
+                case IConversionOperation conversionOperation:
+                    if (!conversionOperation.Conversion.IsIdentity)
+                        return false;
+
+                    operation = conversionOperation.Operand;
+                    continue;
+                case ILocalReferenceOperation:
+                case IParameterReferenceOperation:
+                case IFieldReferenceOperation:
+                case IArrayElementReferenceOperation:
+                case IInstanceReferenceOperation:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    private static async Task<Document> AddInKeywordAsync(Document document, TextSpan argumentSpan, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        if (root.FindNode(argumentSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<ArgumentSyntax>() is not { } argument)
+            return document;
+
+        if (!argument.RefKindKeyword.IsKind(SyntaxKind.None))
+            return document;
+
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        editor.ReplaceNode(argument, argument.WithRefKindKeyword(SyntaxFactory.Token(SyntaxKind.InKeyword).WithTrailingTrivia(SyntaxFactory.Space)));
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -619,3 +619,9 @@ dotnet_diagnostic.MA0207.severity = error
 
 # MA0208: [FixedAddressValueType] fields must be value types
 dotnet_diagnostic.MA0208.severity = error
+
+# MA0209: Use in keyword for in parameter
+dotnet_diagnostic.MA0209.severity = error
+
+# MA0210: Use in keyword to call the in overload
+dotnet_diagnostic.MA0210.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -619,3 +619,9 @@ dotnet_diagnostic.MA0207.severity = suggestion
 
 # MA0208: [FixedAddressValueType] fields must be value types
 dotnet_diagnostic.MA0208.severity = suggestion
+
+# MA0209: Use in keyword for in parameter
+dotnet_diagnostic.MA0209.severity = suggestion
+
+# MA0210: Use in keyword to call the in overload
+dotnet_diagnostic.MA0210.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -619,3 +619,9 @@ dotnet_diagnostic.MA0207.severity = warning
 
 # MA0208: [FixedAddressValueType] fields must be value types
 dotnet_diagnostic.MA0208.severity = warning
+
+# MA0209: Use in keyword for in parameter
+dotnet_diagnostic.MA0209.severity = warning
+
+# MA0210: Use in keyword to call the in overload
+dotnet_diagnostic.MA0210.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -619,3 +619,9 @@ dotnet_diagnostic.MA0207.severity = warning
 
 # MA0208: [FixedAddressValueType] fields must be value types
 dotnet_diagnostic.MA0208.severity = warning
+
+# MA0209: Use in keyword for in parameter
+dotnet_diagnostic.MA0209.severity = none
+
+# MA0210: Use in keyword to call the in overload
+dotnet_diagnostic.MA0210.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -619,3 +619,9 @@ dotnet_diagnostic.MA0207.severity = none
 
 # MA0208: [FixedAddressValueType] fields must be value types
 dotnet_diagnostic.MA0208.severity = none
+
+# MA0209: Use in keyword for in parameter
+dotnet_diagnostic.MA0209.severity = none
+
+# MA0210: Use in keyword to call the in overload
+dotnet_diagnostic.MA0210.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -208,6 +208,8 @@ internal static class RuleIdentifiers
     public const string RemoveUnnecessaryBracesInTypeDeclaration = "MA0206";
     public const string FixedAddressValueTypeAttribute_FieldMustBeStatic = "MA0207";
     public const string FixedAddressValueTypeAttribute_FieldTypeMustBeValueType = "MA0208";
+    public const string UseInKeywordForInParameter = "MA0209";
+    public const string UseInKeywordToSelectInOverload = "MA0210";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/UseInKeywordForInParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseInKeywordForInParameterAnalyzer.cs
@@ -1,0 +1,209 @@
+using System.Collections.Immutable;
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseInKeywordForInParameterAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor RuleUseInForInParameter = new(
+        RuleIdentifiers.UseInKeywordForInParameter,
+        title: "Use in keyword for in parameter",
+        messageFormat: "Use in keyword for in parameter",
+        RuleCategories.Performance,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseInKeywordForInParameter));
+
+    private static readonly DiagnosticDescriptor RuleUseInToSelectInOverload = new(
+        RuleIdentifiers.UseInKeywordToSelectInOverload,
+        title: "Use in keyword to call the in overload",
+        messageFormat: "Use in keyword to call the in overload",
+        RuleCategories.Performance,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseInKeywordToSelectInOverload));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RuleUseInForInParameter, RuleUseInToSelectInOverload);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            var overloadFinder = new OverloadFinder(context.Compilation);
+            context.RegisterOperationAction(context => AnalyzeArgument(context, overloadFinder), OperationKind.Argument);
+        });
+    }
+
+    private static void AnalyzeArgument(OperationAnalysisContext context, OverloadFinder overloadFinder)
+    {
+        var operation = (IArgumentOperation)context.Operation;
+        if (operation.Parameter is null)
+            return;
+
+        if (operation.Syntax is not ArgumentSyntax argumentSyntax)
+            return;
+
+        if (!argumentSyntax.RefKindKeyword.IsKind(SyntaxKind.None))
+            return;
+
+        if (!CanUseInAtCallSite(operation))
+            return;
+
+        if (operation.Parameter.RefKind is RefKind.In)
+        {
+            context.ReportDiagnostic(RuleUseInForInParameter, argumentSyntax);
+            return;
+        }
+
+        if (operation.Parameter.RefKind is not RefKind.None)
+            return;
+
+        if (!TryGetInvocationAndArgumentIndex(operation, out var invocationOperation, out var argumentIndex))
+            return;
+
+        if (HasInOverloadWithEquivalentParameters(invocationOperation, argumentIndex, overloadFinder))
+        {
+            context.ReportDiagnostic(RuleUseInToSelectInOverload, argumentSyntax);
+        }
+    }
+
+    private static bool CanUseInAtCallSite(IArgumentOperation operation)
+    {
+        if (operation.ArgumentKind is ArgumentKind.ParamArray)
+            return false;
+
+        if (HasNonIdentityConversion(operation.Value))
+            return false;
+
+        return IsVariableReference(operation.Value);
+    }
+
+    private static bool HasNonIdentityConversion(IOperation operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            if (!conversion.Conversion.IsIdentity)
+                return true;
+
+            operation = conversion.Operand;
+        }
+
+        return false;
+    }
+
+    private static bool IsVariableReference(IOperation operation)
+    {
+        operation = operation.UnwrapConversionOperations();
+
+        return operation.Kind switch
+        {
+            OperationKind.LocalReference => true,
+            OperationKind.ParameterReference => true,
+            OperationKind.FieldReference => true,
+            OperationKind.ArrayElementReference => true,
+            OperationKind.InstanceReference => true,
+            _ => false,
+        };
+    }
+
+    private static bool TryGetInvocationAndArgumentIndex(IArgumentOperation operation, out IInvocationOperation invocationOperation, out int argumentIndex)
+    {
+        invocationOperation = null!;
+        argumentIndex = -1;
+
+        if (operation.Parent is not IInvocationOperation invocation)
+            return false;
+
+        for (var i = 0; i < invocation.Arguments.Length; i++)
+        {
+            if (invocation.Arguments[i] == operation)
+            {
+                invocationOperation = invocation;
+                argumentIndex = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasInOverloadWithEquivalentParameters(IInvocationOperation invocationOperation, int argumentIndex, OverloadFinder overloadFinder)
+    {
+        var targetMethod = invocationOperation.TargetMethod;
+        if (targetMethod.ContainingType is null)
+            return false;
+
+        var currentParameter = targetMethod.Parameters[argumentIndex];
+        if (currentParameter.RefKind is not RefKind.None)
+            return false;
+
+        var options = new OverloadOptions(
+            IncludeObsoleteMembers: false,
+            IncludeExperimentalMembers: false,
+            AllowOptionalParameters: false,
+            SyntaxNode: invocationOperation.Syntax,
+            AllowNumericConversion: false,
+            AllowParamsToNonParamsCompatibility: false,
+            AllowInModifierCompatibility: true,
+            AllowInterfaceConversions: false,
+            ShouldCheckMethod: method =>
+            {
+                if (method.Parameters.Length != targetMethod.Parameters.Length)
+                    return false;
+
+                if (method.Parameters[argumentIndex].RefKind is not RefKind.In)
+                    return false;
+
+                return HasEquivalentParameterList(targetMethod.Parameters, method.Parameters, argumentIndex);
+            });
+
+        return !overloadFinder.FindSimilarMethods(targetMethod, options, targetMethod.Name, additionalParameterTypes: default).IsEmpty;
+    }
+
+    private static bool HasEquivalentParameterList(ImmutableArray<IParameterSymbol> currentParameters, ImmutableArray<IParameterSymbol> candidateParameters, int argumentIndex)
+    {
+        if (currentParameters.Length != candidateParameters.Length)
+            return false;
+
+        for (var i = 0; i < currentParameters.Length; i++)
+        {
+            var current = currentParameters[i];
+            var candidate = candidateParameters[i];
+            if (i == argumentIndex)
+            {
+                if (current.RefKind is not (RefKind.None or RefKind.In))
+                    return false;
+
+                if (!SymbolEqualityComparer.Default.Equals(current.Type, candidate.Type))
+                    return false;
+
+                if (current.IsParams != candidate.IsParams)
+                    return false;
+            }
+            else
+            {
+                if (current.RefKind != candidate.RefKind)
+                    return false;
+
+                if (!SymbolEqualityComparer.Default.Equals(current.Type, candidate.Type))
+                    return false;
+
+                if (current.IsParams != candidate.IsParams)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/UseInKeywordForInParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseInKeywordForInParameterAnalyzerTests.cs
@@ -1,0 +1,268 @@
+using Meziantou.Analyzer.Rules;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class UseInKeywordForInParameterAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<UseInKeywordForInParameterAnalyzer>()
+            .WithCodeFixProvider<UseInKeywordForInParameterFixer>();
+    }
+
+    [Fact]
+    public async Task StyleRule_Variable_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          var value = new S();
+                          M({|MA0209:value|});
+                      }
+
+                      private static void M(in S value) { }
+                  }
+
+                  struct S { }
+                  """)
+              .ShouldFixCodeWith("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          var value = new S();
+                          M(in value);
+                      }
+
+                      private static void M(in S value) { }
+                  }
+
+                  struct S { }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StyleRule_AlreadyIn_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          var value = new S();
+                          M(in value);
+                      }
+
+                      private static void M(in S value) { }
+                  }
+
+                  struct S { }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StyleRule_Literal_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          M(42);
+                      }
+
+                      private static void M(in int value) { }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StyleRule_Property_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  struct S { }
+
+                  class C
+                  {
+                      public S Property => default;
+
+                      public void Test()
+                      {
+                          M(Property);
+                      }
+
+                      private static void M(in S value) { }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StyleRule_MethodReturnValue_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          M(GetValue());
+                      }
+
+                      private static S GetValue() => default;
+                      private static void M(in S value) { }
+                  }
+
+                  struct S { }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StyleRule_ImplicitConversion_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          short value = 0;
+                          M(value);
+                      }
+
+                      private static void M(in int value) { }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StyleRule_Expression_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          var a = 1;
+                          var b = 2;
+                          M(a + b);
+                      }
+
+                      private static void M(in int value) { }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StyleRule_ObjectCreation_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          M(new S());
+                      }
+
+                      private static void M(in S value) { }
+                  }
+
+                  struct S { }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task OverloadRule_Variable_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          var value = new S();
+                          M({|MA0210:value|});
+                      }
+
+                      private static void M(S value) { }
+                      private static void M(in S value) { }
+                  }
+
+                  struct S { }
+                  """)
+              .ShouldFixCodeWith("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          var value = new S();
+                          M(in value);
+                      }
+
+                      private static void M(S value) { }
+                      private static void M(in S value) { }
+                  }
+
+                  struct S { }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task OverloadRule_Expression_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          M(new S());
+                      }
+
+                      private static void M(S value) { }
+                      private static void M(in S value) { }
+                  }
+
+                  struct S { }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task OverloadRule_ImplicitConversion_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      public void Test()
+                      {
+                          short value = 0;
+                          M(value);
+                      }
+
+                      private static void M(int value) { }
+                      private static void M(in int value) { }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+}


### PR DESCRIPTION
This adds analyzer support for issue #1200 so callers can opt in to explicit `in` usage at call sites. The goal is to make by-ref intent explicit and to detect cases where omitting `in` selects a by-value overload.

## What changed
- Added two new opt-in rules:
  - `MA0209`: suggest adding `in` when calling an `in` parameter.
  - `MA0210`: suggest adding `in` to select the `in` overload when both by-value and `in` overloads exist.
- Added a shared code fix that inserts `in` only when the call-site is valid.
- Implemented overload matching using `Internals/OverloadFinder` for overload-switch detection instead of custom method enumeration.
- Added focused tests for both rules, including documented invalid explicit-`in` scenarios (literal/constant, property, method return, conversion-required argument, and non-variable expressions).
- Added rule docs for `MA0209` and `MA0210`, and regenerated generated documentation/configuration artifacts.

## Notes
- Both rules are disabled by default.

## Validation
- `dotnet test --filter "FullyQualifiedName~UseInKeywordForInParameterAnalyzerTests"`
- `dotnet test /p:RoslynVersion=roslyn4.2 --filter "FullyQualifiedName~UseInKeywordForInParameterAnalyzerTests"`
- `dotnet run --project src/DocumentationGenerator`

Fixes: #1200