### PR TITLE
Treat Meziantou.Framework.Assertions.Assert as non-culture sensitive

### DIFF
--- a/src/Meziantou.Analyzer/Rules/UseStringComparisonAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringComparisonAnalyzer.cs
@@ -53,6 +53,7 @@ public sealed class UseStringComparisonAnalyzer : DiagnosticAnalyzer
         private readonly INamedTypeSymbol _stringComparisonSymbol = compilation.GetBestTypeByMetadataName("System.StringComparison")!;
         private readonly INamedTypeSymbol? _jobjectSymbol = compilation.GetBestTypeByMetadataName("Newtonsoft.Json.Linq.JObject");
         private readonly INamedTypeSymbol? _xunitAssertSymbol = compilation.GetBestTypeByMetadataName("XUnit.Assert");
+        private readonly INamedTypeSymbol? _meziantouFrameworkAssertSymbol = compilation.GetBestTypeByMetadataName("Meziantou.Framework.Assertions.Assert");
         private readonly HashSet<ISymbol> _nonCultureSensitiveSymbols = CreateNonCultureSensitiveSymbols(compilation);
 
         public bool IsValid => _stringComparisonSymbol is not null;
@@ -144,6 +145,10 @@ public sealed class UseStringComparisonAnalyzer : DiagnosticAnalyzer
 
             // Xunit.Assert.Contains/NotContains
             if (method.ContainingType.IsEqualTo(_xunitAssertSymbol))
+                return true;
+
+            // Meziantou.Framework.Assertions.Assert
+            if (method.ContainingType.IsEqualTo(_meziantouFrameworkAssertSymbol))
                 return true;
 
             return false;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerNonCultureSensitiveTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerNonCultureSensitiveTests.cs
@@ -329,4 +329,31 @@ public sealed class UseStringComparisonAnalyzerNonCultureSensitiveTests
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task MeziantouFrameworkAssertions_Assert_ShouldReportDiagnosticMA0001()
+    {
+        const string SourceCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    [|Meziantou.Framework.Assertions.Assert.Contains("abc", "abcdef")|];
+                }
+            }
+
+            namespace Meziantou.Framework.Assertions
+            {
+                public static class Assert
+                {
+                    public static void Contains(string expected, string actual) => throw null;
+                    public static void Contains(string expected, string actual, System.StringComparison comparison) => throw null;
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ShouldReportDiagnosticWithMessage("Use an overload of 'Contains' that has a StringComparison parameter")
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
## Motivation

`UseStringComparisonAnalyzer` (MA0001/MA0002) already treats `Xunit.Assert` methods as non-culture sensitive -- meaning when a `StringComparison` overload exists it reports MA0001 ("use an overload with StringComparison") rather than MA0002 ("avoid culture-sensitive method"). This PR extends the same treatment to `Meziantou.Framework.Assertions.Assert`.

## Changes

- **`UseStringComparisonAnalyzer.cs`**: Added a `_meziantouFrameworkAssertSymbol` field and a check for it in `IsNonCultureSensitiveMethod`, mirroring the existing `Xunit.Assert` handling.
- **`UseStringComparisonAnalyzerNonCultureSensitiveTests.cs`**: Added a test verifying MA0001 is reported (not MA0002) for `Meziantou.Framework.Assertions.Assert` methods that have a `StringComparison` overload. The type is defined inline in the test source, following the same pattern used for `Newtonsoft.Json.Linq.JObject` tests.