### PR TITLE
[codex] Fix MA0002 dictionary comparer formatting

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparerFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparerFixer.cs
@@ -4,6 +4,7 @@ using Meziantou.Analyzer.Internals;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 
@@ -61,7 +62,7 @@ public sealed class UseStringComparerFixer : CodeFixProvider
         switch (nodeToFix)
         {
             case ObjectCreationExpressionSyntax creationExpression:
-                editor.ReplaceNode(creationExpression, creationExpression.AddArgumentListArguments(newArgument));
+                editor.ReplaceNode(creationExpression, AddArgument(creationExpression, newArgument));
                 break;
 
             case ImplicitObjectCreationExpressionSyntax implicitCreationExpression:
@@ -77,5 +78,16 @@ public sealed class UseStringComparerFixer : CodeFixProvider
         }
 
         return editor.GetChangedDocument();
+    }
+
+    private static ObjectCreationExpressionSyntax AddArgument(ObjectCreationExpressionSyntax creationExpression, ArgumentSyntax argument)
+    {
+        if (creationExpression.ArgumentList is not null)
+            return creationExpression.AddArgumentListArguments(argument);
+
+        var trailingTrivia = creationExpression.Type.GetTrailingTrivia();
+        return creationExpression
+            .WithType(creationExpression.Type.WithoutTrailingTrivia())
+            .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(argument)).WithTrailingTrivia(trailingTrivia));
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -158,6 +158,39 @@ public sealed class UseStringComparerAnalyzerTests
     }
 
     [Fact]
+    public async Task Dictionary_String_WithoutArgumentListAndWithInitializer_ShouldReportDiagnostic()
+    {
+        const string SourceCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    [|new System.Collections.Generic.Dictionary<string, object?>
+                    {
+                        ["c"] = true,
+                    }|];
+                }
+            }
+            """;
+        const string CodeFix = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    new System.Collections.Generic.Dictionary<string, object?>(System.StringComparer.Ordinal)
+                    {
+                        ["c"] = true,
+                    };
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ShouldFixCodeWith(CodeFix)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task ConcurrentDictionary_String_ShouldReportDiagnostic()
     {
         const string SourceCode = """


### PR DESCRIPTION
## Summary

- Fix MA0002 code fix formatting when adding a comparer to an object creation without `()`
- Add a regression test for a dictionary initializer using collection initializer syntax

## Root Cause

When an object creation omitted the argument list, the newline before the initializer was kept as trailing trivia on the type node. Adding the comparer argument then placed the new argument list after that newline.

## Validation

- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj --filter "FullyQualifiedName~UseStringComparerAnalyzerTests"` passed: 31 tests
- `dotnet run --project src/DocumentationGenerator` passed; no markdown files changed
- `git diff --check` passed

Explicit full and targeted `dotnet build --no-restore` attempts were stopped after hanging silently; the focused test command restored, built the relevant projects, and ran successfully.
