### PR TITLE
Fix MA0194 invalid pattern merges

### DIFF
--- a/src/Meziantou.Analyzer/Rules/MergeIsPatternChecksAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MergeIsPatternChecksAnalyzer.cs
@@ -74,7 +74,7 @@ public sealed class MergeIsPatternChecksAnalyzer : DiagnosticAnalyzer
                 }
                 else
                 {
-                    if (currentGroup.Count > 1)
+                    if (CanMergeCandidates(rootExpression.Kind(), currentGroup))
                         return true;
 
                     currentGroup.Clear();
@@ -83,14 +83,14 @@ public sealed class MergeIsPatternChecksAnalyzer : DiagnosticAnalyzer
             }
             else
             {
-                if (currentGroup.Count > 1)
+                if (CanMergeCandidates(rootExpression.Kind(), currentGroup))
                     return true;
 
                 currentGroup.Clear();
             }
         }
 
-        return currentGroup.Count > 1;
+        return CanMergeCandidates(rootExpression.Kind(), currentGroup);
     }
 
     private static void FlattenLogicalTerms(ExpressionSyntax expression, SyntaxKind operatorKind, List<ExpressionSyntax> terms)
@@ -120,7 +120,8 @@ public sealed class MergeIsPatternChecksAnalyzer : DiagnosticAnalyzer
         if (!MergeIsPatternChecksCommon.TryGetMergeTarget(isPatternOperation.Value, out var mergeTarget))
             return false;
 
-        candidate = new(mergeTarget);
+        var patternSyntax = isPatternOperation.Pattern.Syntax as PatternSyntax;
+        candidate = new(mergeTarget, patternSyntax);
         return true;
     }
 
@@ -135,5 +136,56 @@ public sealed class MergeIsPatternChecksAnalyzer : DiagnosticAnalyzer
         return operation;
     }
 
-    private readonly record struct MergeCandidate(MergeIsPatternChecksCommon.MergeTarget Target);
+    private static bool CanMergeCandidates(SyntaxKind logicalExpressionKind, List<MergeCandidate> mergeCandidates)
+    {
+        if (mergeCandidates.Count <= 1)
+            return false;
+
+        foreach (var candidate in mergeCandidates)
+        {
+            if (candidate.Pattern is not null && ContainsNotPatternWithVariableDesignation(candidate.Pattern))
+                return false;
+        }
+
+        if (logicalExpressionKind is SyntaxKind.LogicalOrExpression)
+        {
+            foreach (var candidate in mergeCandidates)
+            {
+                if (candidate.Pattern is not null && ContainsVariableDesignation(candidate.Pattern))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ContainsNotPatternWithVariableDesignation(PatternSyntax pattern)
+    {
+        if (pattern is UnaryPatternSyntax unaryPattern && ContainsVariableDesignation(unaryPattern.Pattern))
+            return true;
+
+        foreach (var child in pattern.ChildNodes())
+        {
+            if (child is PatternSyntax childPattern && ContainsNotPatternWithVariableDesignation(childPattern))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsVariableDesignation(SyntaxNode node)
+    {
+        if (node is SingleVariableDesignationSyntax)
+            return true;
+
+        foreach (var child in node.ChildNodes())
+        {
+            if (ContainsVariableDesignation(child))
+                return true;
+        }
+
+        return false;
+    }
+
+    private readonly record struct MergeCandidate(MergeIsPatternChecksCommon.MergeTarget Target, PatternSyntax? Pattern);
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/MergeIsPatternChecksAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MergeIsPatternChecksAnalyzerTests.cs
@@ -119,6 +119,28 @@ public sealed class MergeIsPatternChecksAnalyzerTests
     }
 
     [Fact]
+    public async Task Indexer_SameArgument_NotPatternWithDeclaration_DoNotReport()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  var cList = new System.Collections.Generic.List<object?> { "" };
+                  _ = cList[0] is not null || cList[0] is not string cy;
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LogicalOr_DeclarationPattern_DoNotReport()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  object? value = "";
+                  _ = value is string text || value is null;
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task AlreadyMerged_DoNotReport()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
## Summary

Fix MA0194 so it does not report or offer a merge when the resulting pattern would be invalid because a variable designation would be placed inside a not or or pattern.

The analyzer now carries pattern syntax with merge candidates and validates the merged pattern shape before reporting. The fixer uses the same guard before creating a merged pattern.

## Validation

- dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj --filter FullyQualifiedName~MergeIsPatternChecksAnalyzerTests
- dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj /p:RoslynVersion=roslyn4.2 --filter FullyQualifiedName~MergeIsPatternChecksAnalyzerTests
- dotnet run --project src/DocumentationGenerator
- dotnet build Meziantou.Analyzer.slnx /p:TreatWarningsAsErrors=true /p:TreatsWarningsAsErrors=true