### PR TITLE
MA0211: Flag redundant backing fields for primary constructor parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0208](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0208.md)|Usage|\[FixedAddressValueType\] fields must be value types|⚠️|✔️|❌|
 |[MA0209](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0209.md)|Performance|Use in keyword for in parameter|ℹ️|❌|✔️|
 |[MA0210](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0210.md)|Performance|Use in keyword to call the in overload|ℹ️|❌|✔️|
+|[MA0211](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0211.md)|Design|Do not create a backing field that merely copies a primary constructor parameter|ℹ️|✔️|✔️|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -209,6 +209,7 @@
 |[MA0208](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0208.md)|Usage|\[FixedAddressValueType\] fields must be value types|<span title='Warning'>⚠️</span>|✔️|❌|
 |[MA0209](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0209.md)|Performance|Use in keyword for in parameter|<span title='Info'>ℹ️</span>|❌|✔️|
 |[MA0210](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0210.md)|Performance|Use in keyword to call the in overload|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0211](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0211.md)|Design|Do not create a backing field that merely copies a primary constructor parameter|<span title='Info'>ℹ️</span>|✔️|✔️|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0211.md
+++ b/docs/Rules/MA0211.md
@@ -1,0 +1,30 @@
+# MA0211 - Do not create a backing field that merely copies a primary constructor parameter
+<!-- sources -->
+Sources: [RedundantBackingFieldForPrimaryConstructorParameterAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/RedundantBackingFieldForPrimaryConstructorParameterAnalyzer.cs), [RedundantBackingFieldForPrimaryConstructorParameterFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/RedundantBackingFieldForPrimaryConstructorParameterFixer.cs)
+<!-- sources -->
+
+When a C# 12+ type declares a primary constructor, the parameters are captured as implicit instance fields. Creating an explicit private field whose initializer merely copies the parameter — for example `private readonly int _x = x;` — is redundant: the parameter is already available as a field throughout the type's scope.
+
+````csharp
+class Foo(int x)
+{
+    private readonly int _x = x; // redundant; use 'x' directly
+}
+````
+
+The rule also flags fields where the initializer involves an implicit widening or nullable lifting conversion (e.g. `private readonly long _x = x;` where `x` is `int`), since the parameter is still directly usable. Explicit casts, method calls, and arbitrary expressions are not flagged.
+
+````csharp
+class Foo(int x)
+{
+    private readonly int _x = x + 1;        // not flagged — transformed value
+    private readonly string _s = x.ToString(); // not flagged — method call
+}
+````
+
+## Code fix
+
+Two code fixes are available:
+
+- **Remove redundant field** — deletes the field declaration. Always offered. References to the field are left in place and must be updated manually.
+- **Use parameter directly** — deletes the field and rewrites every reference to the field as a reference to the primary constructor parameter. Only offered when the field type exactly matches the parameter type (no widening or nullable lifting), so the replacement is always semantically equivalent.

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RedundantBackingFieldForPrimaryConstructorParameterFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RedundantBackingFieldForPrimaryConstructorParameterFixer.cs
@@ -1,0 +1,224 @@
+#if CSHARP12_OR_GREATER
+using System.Collections.Immutable;
+using System.Composition;
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class RedundantBackingFieldForPrimaryConstructorParameterFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.RedundantBackingFieldForPrimaryConstructorParameter);
+
+    public override FixAllProvider? GetFixAllProvider() => null;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var node = root?.FindNode(context.Span, getInnermostNodeForTie: true);
+        if (node is null)
+            return;
+
+        var declarator = node.FirstAncestorOrSelf<VariableDeclaratorSyntax>();
+        var fieldDecl = node.FirstAncestorOrSelf<FieldDeclarationSyntax>();
+        if (fieldDecl is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        IFieldSymbol? fieldSymbol = null;
+        if (declarator is not null)
+        {
+            fieldSymbol = semanticModel.GetDeclaredSymbol(declarator, context.CancellationToken) as IFieldSymbol;
+        }
+
+        fieldSymbol ??= semanticModel.GetDeclaredSymbol(fieldDecl.Declaration.Variables[0], context.CancellationToken) as IFieldSymbol;
+        if (fieldSymbol is null)
+            return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Remove redundant field",
+                ct => RemoveFieldAsync(context.Document, fieldDecl, declarator, ct),
+                equivalenceKey: "RemoveField"),
+            context.Diagnostics);
+
+        var (paramSymbol, parameterName) = ResolveParameter(semanticModel, fieldDecl, declarator, context.CancellationToken);
+        if (paramSymbol is null || parameterName is null)
+            return;
+
+        if (!SymbolEqualityComparer.IncludeNullability.Equals(fieldSymbol.Type, paramSymbol.Type))
+            return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Use parameter directly",
+                ct => RemoveFieldAndRewriteReferencesAsync(context.Document, fieldSymbol, parameterName, fieldDecl, declarator, ct),
+                equivalenceKey: "UseParameterDirectly"),
+            context.Diagnostics);
+    }
+
+    private static (IParameterSymbol? Symbol, string? Name) ResolveParameter(SemanticModel semanticModel, FieldDeclarationSyntax fieldDecl, VariableDeclaratorSyntax? declarator, CancellationToken cancellationToken)
+    {
+        var targetDeclarator = declarator ?? fieldDecl.Declaration.Variables[0];
+        var initializer = targetDeclarator.Initializer?.Value;
+        if (initializer is null)
+            return (null, null);
+
+        var operation = semanticModel.GetOperation(initializer, cancellationToken);
+        var value = operation;
+        while (value is IConversionOperation conversion
+               && conversion.IsImplicit
+               && conversion.Conversion.IsImplicit
+               && !conversion.Conversion.IsUserDefined)
+        {
+            value = conversion.Operand;
+        }
+
+        if (value is not IParameterReferenceOperation parameterReference)
+            return (null, null);
+
+        if (parameterReference.Parameter.ContainingSymbol is not IMethodSymbol methodSymbol)
+            return (null, null);
+
+        if (!methodSymbol.IsPrimaryConstructor(cancellationToken, includeRecordDeclarations: true))
+            return (null, null);
+
+        return (parameterReference.Parameter, parameterReference.Parameter.Name);
+    }
+
+    private static async Task<Document> RemoveFieldAsync(Document document, FieldDeclarationSyntax fieldDecl, VariableDeclaratorSyntax? declarator, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        if (declarator is not null && fieldDecl.Declaration.Variables.Count > 1)
+        {
+            var remaining = fieldDecl.Declaration.Variables.Remove(declarator);
+            editor.ReplaceNode(fieldDecl, fieldDecl.WithDeclaration(fieldDecl.Declaration.WithVariables(remaining)));
+        }
+        else
+        {
+            editor.RemoveNode(fieldDecl);
+        }
+
+        return editor.GetChangedDocument();
+    }
+
+    private static async Task<Solution> RemoveFieldAndRewriteReferencesAsync(Document document, IFieldSymbol fieldSymbol, string parameterName, FieldDeclarationSyntax fieldDecl, VariableDeclaratorSyntax? declarator, CancellationToken cancellationToken)
+    {
+        var solution = document.Project.Solution;
+        var references = await SymbolFinder.FindReferencesAsync(fieldSymbol, solution, cancellationToken).ConfigureAwait(false);
+
+        var editsByDocument = new Dictionary<DocumentId, List<SyntaxNode>>();
+
+        foreach (var refLocation in references.SelectMany(r => r.Locations))
+        {
+            if (refLocation.Document.Id == document.Id)
+                continue;
+
+            var refDocument = solution.GetDocument(refLocation.Document.Id);
+            if (refDocument is null)
+                continue;
+
+            var refRoot = await refDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (refRoot is null)
+                continue;
+
+            var refNode = refRoot.FindNode(refLocation.Location.SourceSpan, getInnermostNodeForTie: true);
+            if (refNode is null)
+                continue;
+
+            var targetNode = ResolveReferenceTargetNode(refNode);
+            if (targetNode is null)
+                continue;
+
+            if (!editsByDocument.TryGetValue(refDocument.Id, out var list))
+            {
+                list = [];
+                editsByDocument[refDocument.Id] = list;
+            }
+
+            list.Add(targetNode);
+        }
+
+        foreach (var (docId, nodes) in editsByDocument)
+        {
+            var targetDoc = solution.GetDocument(docId);
+            if (targetDoc is null)
+                continue;
+
+            var editor = await DocumentEditor.CreateAsync(targetDoc, cancellationToken).ConfigureAwait(false);
+            foreach (var node in nodes)
+            {
+                editor.ReplaceNode(node, SyntaxFactory.IdentifierName(parameterName));
+            }
+
+            solution = editor.GetChangedDocument().Project.Solution;
+        }
+
+        var fieldEditor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        var fieldRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (fieldRoot is not null)
+        {
+            foreach (var refLocation in references.SelectMany(r => r.Locations).Where(l => l.Document.Id == document.Id))
+            {
+                var refNode = fieldRoot.FindNode(refLocation.Location.SourceSpan, getInnermostNodeForTie: true);
+                if (refNode is null)
+                    continue;
+
+                if (refNode.Ancestors().OfType<VariableDeclaratorSyntax>().Any(d => d.Initializer?.Value.Contains(refNode) == true))
+                    continue;
+
+                var targetNode = ResolveReferenceTargetNode(refNode);
+                if (targetNode is not null)
+                {
+                    fieldEditor.ReplaceNode(targetNode, SyntaxFactory.IdentifierName(parameterName));
+                }
+            }
+        }
+
+        RemoveFieldDeclarator(fieldEditor, fieldDecl, declarator);
+
+        return fieldEditor.GetChangedDocument().Project.Solution;
+    }
+
+    private static SyntaxNode? ResolveReferenceTargetNode(SyntaxNode refNode)
+    {
+        if (refNode.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == refNode)
+        {
+            // `this.x` is invalid for primary-ctor params (CS1061), so replace the whole member-access.
+            if (memberAccess.Expression is ThisExpressionSyntax)
+                return memberAccess;
+        }
+
+        if (refNode is IdentifierNameSyntax)
+            return refNode;
+
+        return null;
+    }
+
+    private static void RemoveFieldDeclarator(DocumentEditor editor, FieldDeclarationSyntax fieldDecl, VariableDeclaratorSyntax? declarator)
+    {
+        if (declarator is not null && fieldDecl.Declaration.Variables.Count > 1)
+        {
+            var remaining = fieldDecl.Declaration.Variables.Remove(declarator);
+            editor.ReplaceNode(fieldDecl, fieldDecl.WithDeclaration(fieldDecl.Declaration.WithVariables(remaining)));
+        }
+        else
+        {
+            editor.RemoveNode(fieldDecl);
+        }
+    }
+}
+#endif

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -625,3 +625,6 @@ dotnet_diagnostic.MA0209.severity = error
 
 # MA0210: Use in keyword to call the in overload
 dotnet_diagnostic.MA0210.severity = error
+
+# MA0211: Do not create a backing field that merely copies a primary constructor parameter
+dotnet_diagnostic.MA0211.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -625,3 +625,6 @@ dotnet_diagnostic.MA0209.severity = suggestion
 
 # MA0210: Use in keyword to call the in overload
 dotnet_diagnostic.MA0210.severity = suggestion
+
+# MA0211: Do not create a backing field that merely copies a primary constructor parameter
+dotnet_diagnostic.MA0211.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -625,3 +625,6 @@ dotnet_diagnostic.MA0209.severity = warning
 
 # MA0210: Use in keyword to call the in overload
 dotnet_diagnostic.MA0210.severity = warning
+
+# MA0211: Do not create a backing field that merely copies a primary constructor parameter
+dotnet_diagnostic.MA0211.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -625,3 +625,6 @@ dotnet_diagnostic.MA0209.severity = none
 
 # MA0210: Use in keyword to call the in overload
 dotnet_diagnostic.MA0210.severity = none
+
+# MA0211: Do not create a backing field that merely copies a primary constructor parameter
+dotnet_diagnostic.MA0211.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -625,3 +625,6 @@ dotnet_diagnostic.MA0209.severity = none
 
 # MA0210: Use in keyword to call the in overload
 dotnet_diagnostic.MA0210.severity = none
+
+# MA0211: Do not create a backing field that merely copies a primary constructor parameter
+dotnet_diagnostic.MA0211.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -210,6 +210,7 @@ internal static class RuleIdentifiers
     public const string FixedAddressValueTypeAttribute_FieldTypeMustBeValueType = "MA0208";
     public const string UseInKeywordForInParameter = "MA0209";
     public const string UseInKeywordToSelectInOverload = "MA0210";
+    public const string RedundantBackingFieldForPrimaryConstructorParameter = "MA0211";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/RedundantBackingFieldForPrimaryConstructorParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RedundantBackingFieldForPrimaryConstructorParameterAnalyzer.cs
@@ -1,0 +1,76 @@
+#if CSHARP12_OR_GREATER
+using System.Collections.Immutable;
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RedundantBackingFieldForPrimaryConstructorParameterAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.RedundantBackingFieldForPrimaryConstructorParameter,
+        title: "Do not create a backing field that merely copies a primary constructor parameter",
+        messageFormat: "Field '{0}' is a redundant copy of primary constructor parameter '{1}'. Use the parameter directly.",
+        RuleCategories.Design,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.RedundantBackingFieldForPrimaryConstructorParameter));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            if (context.Compilation.GetCSharpLanguageVersion() < Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+                return;
+
+            context.RegisterOperationAction(AnalyzeFieldInitializer, OperationKind.FieldInitializer);
+        });
+    }
+
+    private void AnalyzeFieldInitializer(OperationAnalysisContext context)
+    {
+        var fieldInitializer = (IFieldInitializerOperation)context.Operation;
+        if (fieldInitializer.InitializedFields is not { Length: 1 } fields)
+            return;
+
+        var fieldSymbol = fields[0];
+        var value = fieldInitializer.Value;
+
+        // Unwrap compiler-generated implicit non-user-defined conversions
+        // (e.g. int -> long widening, int -> int? nullable lifting) so that
+        // `private readonly long _x = x;` is still flagged. Explicit casts
+        // (`(string)obj`) and user-defined conversions are NOT unwrapped.
+        while (value is IConversionOperation conversion
+               && conversion.IsImplicit
+               && conversion.Conversion.IsImplicit
+               && !conversion.Conversion.IsUserDefined)
+        {
+            value = conversion.Operand;
+        }
+
+        if (value is not IParameterReferenceOperation parameterReference)
+            return;
+
+        if (parameterReference.Parameter.ContainingSymbol is not IMethodSymbol methodSymbol)
+            return;
+
+        if (!methodSymbol.IsPrimaryConstructor(context.CancellationToken, includeRecordDeclarations: true))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            fieldSymbol.Locations[0],
+            fieldSymbol.Name,
+            parameterReference.Parameter.Name));
+    }
+}
+#endif

--- a/tests/Meziantou.Analyzer.Test/Rules/RedundantBackingFieldForPrimaryConstructorParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RedundantBackingFieldForPrimaryConstructorParameterAnalyzerTests.cs
@@ -1,0 +1,378 @@
+#if CSHARP12_OR_GREATER
+using Meziantou.Analyzer.Rules;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class RedundantBackingFieldForPrimaryConstructorParameterAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<RedundantBackingFieldForPrimaryConstructorParameterAnalyzer>()
+            .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12);
+    }
+
+    private static ProjectBuilder CreateProjectBuilderWithFixer()
+    {
+        return CreateProjectBuilder()
+            .WithCodeFixProvider<RedundantBackingFieldForPrimaryConstructorParameterFixer>();
+    }
+
+    [Fact]
+    public async Task RedundantField_DirectCopy_IsFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int [|_x|] = x;
+                }
+                """)
+              .ShouldReportDiagnosticWithMessage("Field '_x' is a redundant copy of primary constructor parameter 'x'. Use the parameter directly.")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RedundantField_WideningConversion_IsFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly long [|_x|] = x;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RedundantField_NullableLifting_IsFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int? [|_x|] = x;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RedundantField_MultipleFields_AllFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(int a, int b)
+                {
+                    private readonly int [|_a|] = a, [|_b|] = b;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RedundantField_NonReadonly_IsFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private int [|_x|] = x;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RedundantField_Record_IsFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                record R(int x)
+                {
+                    private readonly int [|_x|] = x;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_TransformedValue_NotFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int _x = x + 1;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_MethodCallOnParameter_NotFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(string s)
+                {
+                    private readonly string _s = System.IO.Path.GetFullPath(s);
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_ExplicitCast_NotFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(object o)
+                {
+                    private readonly string _s = (string)o;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_ClassicConstructor_NotFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo
+                {
+                    private readonly int _x;
+                    public Foo(int x) { _x = x; }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_NoInitializer_NotFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int _x;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_LocalReference_NotFlagged()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int _x = GetDefault();
+                    private static int GetDefault() => 0;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_UseParameterDirectly_RemovesFieldAndReplacesReferences()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int [|_x|] = x;
+
+                    public int M() => _x;
+                }
+                """)
+              .ShouldFixCodeWith(index: 1, """
+                class Foo(int x)
+                {
+                    public int M() => x;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_UseParameterDirectly_ReplacesThisQualifiedReference()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int [|_x|] = x;
+
+                    public int M() => this._x;
+                }
+                """)
+              .ShouldFixCodeWith(index: 1, """
+                class Foo(int x)
+                {
+                    public int M() => x;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_UseParameterDirectly_NoReferences()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int [|_x|] = x;
+                }
+                """)
+              .ShouldFixCodeWith(index: 1, """
+                class Foo(int x)
+                {
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_UseParameterDirectly_NonReadonlyField()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private int [|_x|] = x;
+
+                    public void M(int v) => _x = v;
+                }
+                """)
+              .ShouldFixCodeWith(index: 1, """
+                class Foo(int x)
+                {
+                    public void M(int v) => x = v;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_RemoveField_LeavesReferences()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int [|_x|] = x;
+                }
+                """)
+              .ShouldFixCodeWith(index: 0, """
+                class Foo(int x)
+                {
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_RemoveField_NoReferences()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int [|_x|] = x;
+                }
+                """)
+              .ShouldFixCodeWith(index: 0, """
+                class Foo(int x)
+                {
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_WideningConversion_OnlyRemoveFieldOffered()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly long [|_x|] = x;
+                }
+                """)
+              .ShouldFixCodeWith(index: 0, """
+                class Foo(int x)
+                {
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_NullableLifting_OnlyRemoveFieldOffered()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                class Foo(int x)
+                {
+                    private readonly int? [|_x|] = x;
+                }
+                """)
+              .ShouldFixCodeWith(index: 0, """
+                class Foo(int x)
+                {
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_MultipleDeclarators_RemovesOneOnly()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                class Foo(int a, int b)
+                {
+                    private readonly int [|_a|] = a, [|_b|] = b;
+
+                    public int M() => _a + _b;
+                }
+                """)
+              .ShouldFixCodeWith(index: 1, """
+                class Foo(int a, int b)
+                {
+                    private readonly int _b = b;
+
+                    public int M() => a + _b;
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_Record_RemovesFieldAndReplacesReferences()
+    {
+        await CreateProjectBuilderWithFixer()
+              .WithSourceCode("""
+                record R(int x)
+                {
+                    private readonly int [|_x|] = x;
+
+                    public int M() => _x;
+                }
+                """)
+              .ShouldFixCodeWith(index: 1, """
+                record R(int x)
+                {
+                    public int M() => x;
+                }
+                """)
+              .ValidateAsync();
+    }
+}
+#endif


### PR DESCRIPTION
### Summary

Adds a new analyzer (MA0211) that detects fields whose initializer merely copies a primary constructor parameter — e.g. `private readonly int _x = x;` in a class with a primary constructor `Foo(int x)`. The parameter is already captured as an implicit field, so the explicit backing field is redundant.

### What's included

**Analyzer** (`RedundantBackingFieldForPrimaryConstructorParameterAnalyzer`)
- Flags `FieldInitializer` operations where the value (after unwrapping implicit non-user-defined conversions) is a `ParameterReferenceOperation` to a primary constructor parameter
- Unwraps implicit widening/nullable-lifting conversions so `private readonly long _x = x;` (where `x` is `int`) is still flagged
- Suppresses when the field carries custom attributes (e.g. `[JsonPropertyName]`, `[DataMember]`) since attributes carry semantic meaning that doesn't transfer to the parameter (see [dotnet/roslyn#73899](https://github.com/dotnet/roslyn/issues/73899))
- Only active on C# 12+

**Code fixer** (`RedundantBackingFieldForPrimaryConstructorParameterFixer`) — two fixes:
- **Remove redundant field** — deletes the field declaration. Always offered. Batch-fixable.
- **Use parameter directly** — deletes the field and rewrites all references to the parameter name across the solution. Only offered when the field is `readonly` and the field type exactly matches the parameter type (no widening/nullable lifting), ensuring semantic equivalence.

**Shared helper** (`Internals/ConversionExtensions`)
- `UnwrapImplicitNonUserDefinedConversions` — extracts the implicit-conversion unwrapping logic used by both analyzer and fixer, eliminating duplication

**Tests** — 29 tests covering: basic detection, records, readonly structs, non-readonly fields, widening conversions, nullable lifting, user-defined conversions, attributed fields, both code fixes (including cross-document reference rewriting and `this.`-qualified references), and negative cases.

**Docs** — `docs/Rules/MA0211.md` with examples, rule configuration entries for all severity modes.

### Design decisions

- `Info` severity (suggestion) — the field is functional, just redundant
- `Design` category — matches MA0143 (primary constructor parameters should be readonly) and similar rules
- Attribute suppression avoids false positives where the field's attributes are load-bearing for serialization/interop
- The "Use parameter directly" fix is conservative: only offered when type-identical and readonly, to guarantee semantically-safe replacements