### PR TITLE
Skip XML comment langword diagnostics for attributed code tags

### DIFF
--- a/docs/Rules/MA0154.md
+++ b/docs/Rules/MA0154.md
@@ -3,7 +3,7 @@
 Sources: [UseLangwordInXmlCommentAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs), [UseLangwordInXmlCommentFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentFixer.cs)
 <!-- sources -->
 
-Use `<see langword="keyword" />` instead of `<c>keyword</c>` or `<code>keyword</code>` in XML comments.
+Use `<see langword="keyword" />` instead of plain `<c>keyword</c>` or `<code>keyword</code>` in XML comments.
 
 ```c#
 // non-compliant

--- a/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
@@ -154,6 +154,9 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
                         var elementName = elementSyntax.StartTag.Name.LocalName.Text;
                         if (string.Equals(elementName, "c", StringComparison.OrdinalIgnoreCase) || string.Equals(elementName, "code", StringComparison.OrdinalIgnoreCase))
                         {
+                            if (elementSyntax.StartTag.Attributes.Count > 0)
+                                continue;
+
                             var item = elementSyntax.Content.SingleOrDefaultIfMultiple();
                             if (item is XmlTextSyntax { TextTokens: [var codeText] } && CSharpKeywords.Contains(codeText.Text))
                             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseLangwordInXmlCommentAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseLangwordInXmlCommentAnalyzerTests.cs
@@ -35,6 +35,7 @@ class Sample { }
     [InlineData("<i>in</i>")]
     [InlineData("null")]
     [InlineData("this is null")]
+    [InlineData("<c language=\"json\">null</c>")]
     public async Task ValidateSummary_Valid(string comment)
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
## Summary
- Ignore `<c>` and `<code>` XML comment elements when they already carry attributes, since they are not plain keyword markup.
- Update the MA0154 documentation to clarify that the rule targets plain `<c>` and `<code>` usage.
- Add a regression test covering attributed `<c>` content.

## Testing
- Added analyzer test coverage for an attributed XML comment example.
- Documentation and analyzer changes were validated by the existing test suite expectations in the affected rule area.