### PR TITLE
MA0099: add opt-in configuration options for report location and zero-member filtering

### DIFF
--- a/docs/Rules/MA0099.md
+++ b/docs/Rules/MA0099.md
@@ -19,3 +19,19 @@ class Test
     }
 }
 ````
+
+## Configuration
+
+```editorconfig
+# Only report the diagnostic when the enum has a named member with value 0.
+# Default: false (report for all implicit 0 → enum conversions)
+[*.cs]
+MA0099.exclude_enum_without_zero_member = true
+```
+
+```editorconfig
+# Restrict reporting to method/constructor arguments only (where accidental
+# overload selection is the primary risk). Values: all (default), argument.
+[*.cs]
+MA0099.report_on = argument
+```

--- a/src/Meziantou.Analyzer/Rules/DoNotUseZeroToInitializeAnEnumValue.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseZeroToInitializeAnEnumValue.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Immutable;
+using System.Linq;
+using Meziantou.Analyzer.Configurations;
 using Meziantou.Analyzer.Internals;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -35,7 +37,7 @@ public class DoNotUseZeroToInitializeAnEnumValue : DiagnosticAnalyzer
         if (!operation.IsImplicit)
             return;
 
-        if (operation.Type is not INamedTypeSymbol { EnumUnderlyingType: not null and var enumType })
+        if (operation.Type is not INamedTypeSymbol { EnumUnderlyingType: not null and var enumType } enumSymbol)
             return;
 
         if (operation.Operand is IDefaultValueOperation)
@@ -49,10 +51,21 @@ public class DoNotUseZeroToInitializeAnEnumValue : DiagnosticAnalyzer
             return;
 #endif
 
-        if (operation.ConstantValue is { HasValue: true, Value: not null and var value } && IsZero(enumType, value))
+        if (operation.ConstantValue is not { HasValue: true, Value: not null and var value } || !IsZero(enumType, value))
+            return;
+
+        var reportOn = context.Options.GetConfigurationValue(operation, RuleIdentifiers.DoNotUseZeroToInitializeAnEnumValue + ".report_on", defaultValue: "all");
+        if (string.Equals(reportOn, "argument", StringComparison.OrdinalIgnoreCase))
         {
-            context.ReportDiagnostic(Rule, operation, operation.Type.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+            if (operation.Parent is not IArgumentOperation)
+                return;
         }
+
+        var excludeEnumWithoutZeroMember = context.Options.GetConfigurationValue(operation, RuleIdentifiers.DoNotUseZeroToInitializeAnEnumValue + ".exclude_enum_without_zero_member", defaultValue: false);
+        if (excludeEnumWithoutZeroMember && !HasZeroMember(enumSymbol, enumType))
+            return;
+
+        context.ReportDiagnostic(Rule, operation, operation.Type.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
 
         static bool IsZero(ITypeSymbol enumType, object value)
         {
@@ -68,6 +81,14 @@ public class DoNotUseZeroToInitializeAnEnumValue : DiagnosticAnalyzer
                 SpecialType.System_UInt64 => value is ulong converted && converted == 0uL,
                 _ => false,
             };
+        }
+
+        static bool HasZeroMember(INamedTypeSymbol enumSymbol, ITypeSymbol enumType)
+        {
+            return enumSymbol.GetMembers()
+                .OfType<IFieldSymbol>()
+                .Where(f => f.HasConstantValue)
+                .Any(f => IsZero(enumType, f.ConstantValue!));
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseZeroToInitializeAnEnumValueTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseZeroToInitializeAnEnumValueTests.cs
@@ -456,4 +456,106 @@ public class MyClass
 """)
               .ValidateAsync();
     }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1210")]
+    public async Task ExcludeEnumWithoutZeroMember_NoZeroMember_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration("MA0099.exclude_enum_without_zero_member", "true")
+              .WithSourceCode("""
+enum MyEnum { A = 1, B = 2 }
+
+class Test
+{
+    void M()
+    {
+        MyEnum a = 0;
+    }
+}
+""")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1210")]
+    public async Task ExcludeEnumWithoutZeroMember_HasZeroMember_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration("MA0099.exclude_enum_without_zero_member", "true")
+              .WithSourceCode("""
+enum MyEnum { A = 0, B = 1 }
+
+class Test
+{
+    void M()
+    {
+        MyEnum a = [|0|];
+    }
+}
+""")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1210")]
+    public async Task ReportOnArgument_ZeroInArgument_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration("MA0099.report_on", "argument")
+              .WithSourceCode("""
+enum MyEnum { A = 0, B = 1 }
+
+class Test
+{
+    void M(MyEnum x) { }
+
+    void A()
+    {
+        M([|0|]);
+    }
+}
+""")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1210")]
+    public async Task ReportOnArgument_ZeroInAssignment_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration("MA0099.report_on", "argument")
+              .WithSourceCode("""
+enum MyEnum { A = 0, B = 1 }
+
+class Test
+{
+    void M()
+    {
+        MyEnum a = 0;
+    }
+}
+""")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1210")]
+    public async Task ReportOnArgument_ZeroInOptionalParameterDefault_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration("MA0099.report_on", "argument")
+              .WithSourceCode("""
+enum MyEnum { A = 0, B = 1 }
+
+class Test
+{
+    void M(MyEnum x = 0)
+    {
+        M();
+    }
+}
+""")
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
Closes #1210

## Changes

Added two opt-in editorconfig options for MA0099 (`DoNotUseZeroToInitializeAnEnumValue`):

### `MA0099.exclude_enum_without_zero_member` (bool, default `false`)
When set to `true`, the diagnostic is suppressed when the target enum has no named member with value `0` — i.e., there is no named value the user could use instead.

```editorconfig
[*.cs]
MA0099.exclude_enum_without_zero_member = true
```

### `MA0099.report_on` (string, default `all`)
When set to `argument`, the diagnostic is only reported when the zero literal appears as a method or constructor argument. This is the location where accidental overload selection is the primary risk.

```editorconfig
[*.cs]
MA0099.report_on = argument
```

Both options can be used independently or together. Default behavior is unchanged.