### PR TITLE
Add MA0212: Use MemoryMarshal.GetReference instead of ref span[0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0209](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0209.md)|Performance|Use in keyword for in parameter|ℹ️|❌|✔️|
 |[MA0210](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0210.md)|Performance|Use in keyword to call the in overload|ℹ️|❌|✔️|
 |[MA0211](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0211.md)|Style|Use multi-line syntax for XML summary comments|ℹ️|❌|✔️|
-|[MA0212](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0212.md)|Usage|Use MemoryMarshal.GetReference instead of indexing at 0|⚠️|✔️|✔️|
+|[MA0212](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0212.md)|Usage|Use MemoryMarshal.GetReference instead of indexing at 0|⚠️|❌|✔️|
 
 <!-- rules -->
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0209](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0209.md)|Performance|Use in keyword for in parameter|ℹ️|❌|✔️|
 |[MA0210](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0210.md)|Performance|Use in keyword to call the in overload|ℹ️|❌|✔️|
 |[MA0211](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0211.md)|Style|Use multi-line syntax for XML summary comments|ℹ️|❌|✔️|
+|[MA0212](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0212.md)|Usage|Use MemoryMarshal.GetReference instead of indexing at 0|⚠️|✔️|✔️|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -210,7 +210,7 @@
 |[MA0209](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0209.md)|Performance|Use in keyword for in parameter|<span title='Info'>ℹ️</span>|❌|✔️|
 |[MA0210](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0210.md)|Performance|Use in keyword to call the in overload|<span title='Info'>ℹ️</span>|❌|✔️|
 |[MA0211](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0211.md)|Style|Use multi-line syntax for XML summary comments|<span title='Info'>ℹ️</span>|❌|✔️|
-|[MA0212](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0212.md)|Usage|Use MemoryMarshal.GetReference instead of indexing at 0|<span title='Warning'>⚠️</span>|✔️|✔️|
+|[MA0212](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0212.md)|Usage|Use MemoryMarshal.GetReference instead of indexing at 0|<span title='Warning'>⚠️</span>|❌|✔️|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/README.md
+++ b/docs/README.md
@@ -210,6 +210,7 @@
 |[MA0209](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0209.md)|Performance|Use in keyword for in parameter|<span title='Info'>ℹ️</span>|❌|✔️|
 |[MA0210](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0210.md)|Performance|Use in keyword to call the in overload|<span title='Info'>ℹ️</span>|❌|✔️|
 |[MA0211](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0211.md)|Style|Use multi-line syntax for XML summary comments|<span title='Info'>ℹ️</span>|❌|✔️|
+|[MA0212](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0212.md)|Usage|Use MemoryMarshal.GetReference instead of indexing at 0|<span title='Warning'>⚠️</span>|✔️|✔️|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0212.md
+++ b/docs/Rules/MA0212.md
@@ -1,0 +1,24 @@
+# MA0212 - Use MemoryMarshal.GetReference instead of indexing at 0
+<!-- sources -->
+Sources: [UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs), [UseMemoryMarshalGetReferenceForEmptyBuffersFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersFixer.cs)
+<!-- sources -->
+
+This rule reports by-reference access to the first element (`[0]`) of a `Span<T>`, `ReadOnlySpan<T>`, or array. Indexing into `[0]` throws when the buffer is empty; using `MemoryMarshal.GetReference` or `MemoryMarshal.GetArrayDataReference` returns a reference without bounds-checking, which is the correct pattern when working with potentially-empty buffers.
+
+````csharp
+void Process(Span<byte> span)
+{
+    ref byte first = ref span[0];   // throws IndexOutOfRangeException when span is empty
+}
+
+// Should be
+void Process(Span<byte> span)
+{
+    ref byte first = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span);
+}
+````
+
+## Additional resources
+
+- [MemoryMarshal.GetReference](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.memorymarshal.getreference)
+- [MemoryMarshal.GetArrayDataReference](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.memorymarshal.getarraydatareference) (.NET 6+)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersFixer.cs
@@ -1,0 +1,94 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class UseMemoryMarshalGetReferenceForEmptyBuffersFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.UseMemoryMarshalGetReferenceForEmptyBuffers);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
+        if (nodeToFix is not ElementAccessExpressionSyntax elementAccess)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var receiverType = semanticModel.GetTypeInfo(elementAccess.Expression, context.CancellationToken).Type;
+        if (receiverType is null)
+            return;
+
+        var memoryMarshalType = semanticModel.Compilation.GetBestTypeByMetadataName("System.Runtime.InteropServices.MemoryMarshal");
+        if (memoryMarshalType is null)
+            return;
+
+        string methodName;
+        if (receiverType.TypeKind is TypeKind.Array)
+        {
+            // GetArrayDataReference is available since .NET 6; verify it exists before offering the fix
+            if (!HasGetArrayDataReference(memoryMarshalType))
+                return;
+
+            methodName = "GetArrayDataReference";
+        }
+        else
+        {
+            methodName = "GetReference";
+        }
+
+        var title = $"Use MemoryMarshal.{methodName}";
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title,
+                ct => FixAsync(context.Document, elementAccess, memoryMarshalType, methodName, ct),
+                equivalenceKey: title),
+            context.Diagnostics);
+    }
+
+    private static bool HasGetArrayDataReference(INamedTypeSymbol memoryMarshalType)
+    {
+        foreach (var member in memoryMarshalType.GetMembers("GetArrayDataReference"))
+        {
+            if (member is IMethodSymbol)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static async Task<Document> FixAsync(
+        Document document,
+        ElementAccessExpressionSyntax elementAccess,
+        INamedTypeSymbol memoryMarshalType,
+        string methodName,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var generator = editor.Generator;
+
+        var receiverExpression = elementAccess.Expression;
+
+        var replacement = generator.InvocationExpression(
+            generator.MemberAccessExpression(
+                generator.TypeExpression(memoryMarshalType),
+                methodName),
+            receiverExpression.WithoutTrivia())
+            .WithTriviaFrom(elementAccess);
+
+        editor.ReplaceNode(elementAccess, replacement);
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -628,3 +628,6 @@ dotnet_diagnostic.MA0210.severity = error
 
 # MA0211: Use multi-line syntax for XML summary comments
 dotnet_diagnostic.MA0211.severity = error
+
+# MA0212: Use MemoryMarshal.GetReference instead of indexing at 0
+dotnet_diagnostic.MA0212.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -628,3 +628,6 @@ dotnet_diagnostic.MA0210.severity = suggestion
 
 # MA0211: Use multi-line syntax for XML summary comments
 dotnet_diagnostic.MA0211.severity = suggestion
+
+# MA0212: Use MemoryMarshal.GetReference instead of indexing at 0
+dotnet_diagnostic.MA0212.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -628,3 +628,6 @@ dotnet_diagnostic.MA0210.severity = warning
 
 # MA0211: Use multi-line syntax for XML summary comments
 dotnet_diagnostic.MA0211.severity = warning
+
+# MA0212: Use MemoryMarshal.GetReference instead of indexing at 0
+dotnet_diagnostic.MA0212.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -630,4 +630,4 @@ dotnet_diagnostic.MA0210.severity = none
 dotnet_diagnostic.MA0211.severity = none
 
 # MA0212: Use MemoryMarshal.GetReference instead of indexing at 0
-dotnet_diagnostic.MA0212.severity = warning
+dotnet_diagnostic.MA0212.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -628,3 +628,6 @@ dotnet_diagnostic.MA0210.severity = none
 
 # MA0211: Use multi-line syntax for XML summary comments
 dotnet_diagnostic.MA0211.severity = none
+
+# MA0212: Use MemoryMarshal.GetReference instead of indexing at 0
+dotnet_diagnostic.MA0212.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -628,3 +628,6 @@ dotnet_diagnostic.MA0210.severity = none
 
 # MA0211: Use multi-line syntax for XML summary comments
 dotnet_diagnostic.MA0211.severity = none
+
+# MA0212: Use MemoryMarshal.GetReference instead of indexing at 0
+dotnet_diagnostic.MA0212.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -211,6 +211,7 @@ internal static class RuleIdentifiers
     public const string UseInKeywordForInParameter = "MA0209";
     public const string UseInKeywordToSelectInOverload = "MA0210";
     public const string UseMultiLineXmlCommentSyntax = "MA0211";
+    public const string UseMemoryMarshalGetReferenceForEmptyBuffers = "MA0212";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs
@@ -1,0 +1,147 @@
+using System.Collections.Immutable;
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.UseMemoryMarshalGetReferenceForEmptyBuffers,
+        title: "Use MemoryMarshal.GetReference instead of indexing at 0",
+        messageFormat: "Use MemoryMarshal.GetReference instead of indexing at 0, which throws on empty buffers",
+        RuleCategories.Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Indexing a Span<T>, ReadOnlySpan<T>, or array at index 0 to obtain a by-reference value throws IndexOutOfRangeException on empty buffers. Use MemoryMarshal.GetReference (for spans) or MemoryMarshal.GetArrayDataReference (for arrays) instead, which safely returns a reference to the start even for empty collections.",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseMemoryMarshalGetReferenceForEmptyBuffers));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var analyzerContext = new AnalyzerContext(compilationContext.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            // Handles: ref span[0], ref array[0] used in ref-return, ref-local, etc.
+            compilationContext.RegisterSyntaxNodeAction(analyzerContext.AnalyzeRefExpression, SyntaxKind.RefExpression);
+
+            // Handles: Method(ref span[0]), Method(in span[0]), Method(ref readonly span[0])
+            compilationContext.RegisterOperationAction(analyzerContext.AnalyzeArgument, OperationKind.Argument);
+        });
+    }
+
+    private sealed class AnalyzerContext
+    {
+        private readonly INamedTypeSymbol? _spanType;
+        private readonly INamedTypeSymbol? _readOnlySpanType;
+
+        public AnalyzerContext(Compilation compilation)
+        {
+            _spanType = compilation.GetBestTypeByMetadataName("System.Span`1");
+            _readOnlySpanType = compilation.GetBestTypeByMetadataName("System.ReadOnlySpan`1");
+        }
+
+        public bool IsValid => _spanType is not null || _readOnlySpanType is not null;
+
+        public void AnalyzeRefExpression(SyntaxNodeAnalysisContext context)
+        {
+            var refExpression = (RefExpressionSyntax)context.Node;
+
+            if (refExpression.Expression is not ElementAccessExpressionSyntax elementAccess)
+                return;
+
+            if (!IsIndexZero(context, elementAccess.ArgumentList))
+                return;
+
+            var receiverTypeInfo = context.SemanticModel.GetTypeInfo(elementAccess.Expression, context.CancellationToken);
+            if (!IsSpanOrArray(receiverTypeInfo.Type))
+                return;
+
+            context.ReportDiagnostic(Rule, elementAccess);
+        }
+
+        public void AnalyzeArgument(OperationAnalysisContext context)
+        {
+            var argument = (IArgumentOperation)context.Operation;
+
+            if (argument.Syntax is not ArgumentSyntax { RefKindKeyword: var refKindToken })
+                return;
+
+            // Only care about by-reference arguments (ref, in, ref readonly)
+            if (refKindToken.IsKind(SyntaxKind.None))
+                return;
+
+            var value = argument.Value.UnwrapConversionOperations();
+
+            IOperation? receiverOp;
+            IOperation? indexOp;
+
+            if (value is IArrayElementReferenceOperation { Indices: [var arrayIdx], ArrayReference: var arrayRef })
+            {
+                // True array: T[]
+                receiverOp = arrayRef;
+                indexOp = arrayIdx;
+            }
+            else if (value is IPropertyReferenceOperation { Property.IsIndexer: true, Arguments: [{ Value: var propIdx }], Instance: var instance })
+            {
+                // Span<T> / ReadOnlySpan<T> indexer
+                receiverOp = instance;
+                indexOp = propIdx;
+            }
+            else
+            {
+                return;
+            }
+
+            if (!indexOp.IsConstantZero())
+                return;
+
+            if (!IsSpanOrArray(receiverOp?.Type))
+                return;
+
+            if (value.Syntax is not ElementAccessExpressionSyntax elementAccessSyntax)
+                return;
+
+            context.ReportDiagnostic(Rule, elementAccessSyntax);
+        }
+
+        private bool IsSpanOrArray(ITypeSymbol? type)
+        {
+            if (type is null)
+                return false;
+
+            if (type.TypeKind is TypeKind.Array)
+                return true;
+
+            if (type.OriginalDefinition.IsEqualToAny(_spanType, _readOnlySpanType))
+                return true;
+
+            return false;
+        }
+
+        private static bool IsIndexZero(SyntaxNodeAnalysisContext context, BracketedArgumentListSyntax argumentList)
+        {
+            if (argumentList.Arguments.Count != 1)
+                return false;
+
+            var argument = argumentList.Arguments[0];
+            if (!argument.RefKindKeyword.IsKind(SyntaxKind.None))
+                return false;
+
+            var constantValue = context.SemanticModel.GetConstantValue(argument.Expression, context.CancellationToken);
+            return constantValue.HasValue && constantValue.Value is 0;
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using Meziantou.Analyzer.Internals;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -34,10 +33,13 @@ public sealed class UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer : Diagno
             if (!analyzerContext.IsValid)
                 return;
 
-            // Handles: ref span[0], ref array[0] used in ref-return, ref-local, etc.
-            compilationContext.RegisterSyntaxNodeAction(analyzerContext.AnalyzeRefExpression, SyntaxKind.RefExpression);
+            // Handles: ref T local = ref span[0]
+            compilationContext.RegisterOperationAction(analyzerContext.AnalyzeVariableDeclarator, OperationKind.VariableDeclarator);
 
-            // Handles: Method(ref span[0]), Method(in span[0]), Method(ref readonly span[0])
+            // Handles: return ref span[0]
+            compilationContext.RegisterOperationAction(analyzerContext.AnalyzeReturn, OperationKind.Return);
+
+            // Handles: Method(ref span[0]), Method(in span[0])
             compilationContext.RegisterOperationAction(analyzerContext.AnalyzeArgument, OperationKind.Argument);
         });
     }
@@ -55,48 +57,60 @@ public sealed class UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer : Diagno
 
         public bool IsValid => _spanType is not null || _readOnlySpanType is not null;
 
-        public void AnalyzeRefExpression(SyntaxNodeAnalysisContext context)
+        public void AnalyzeVariableDeclarator(OperationAnalysisContext context)
         {
-            var refExpression = (RefExpressionSyntax)context.Node;
-
-            if (refExpression.Expression is not ElementAccessExpressionSyntax elementAccess)
+            var declarator = (IVariableDeclaratorOperation)context.Operation;
+            if (!declarator.Symbol.IsRef)
                 return;
 
-            if (!IsIndexZero(context, elementAccess.ArgumentList))
+            var initValue = declarator.Initializer?.Value.UnwrapConversionOperations();
+            if (initValue is null)
                 return;
 
-            var receiverTypeInfo = context.SemanticModel.GetTypeInfo(elementAccess.Expression, context.CancellationToken);
-            if (!IsSpanOrArray(receiverTypeInfo.Type))
+            ReportIfMatch(context, initValue);
+        }
+
+        public void AnalyzeReturn(OperationAnalysisContext context)
+        {
+            var returnsByRef = context.ContainingSymbol switch
+            {
+                IMethodSymbol method => method.ReturnsByRef || method.ReturnsByRefReadonly,
+                IPropertySymbol property => property.ReturnsByRef || property.ReturnsByRefReadonly,
+                _ => false,
+            };
+            if (!returnsByRef)
                 return;
 
-            context.ReportDiagnostic(Rule, elementAccess);
+            var returnedValue = ((IReturnOperation)context.Operation).ReturnedValue?.UnwrapConversionOperations();
+            if (returnedValue is null)
+                return;
+
+            ReportIfMatch(context, returnedValue);
         }
 
         public void AnalyzeArgument(OperationAnalysisContext context)
         {
             var argument = (IArgumentOperation)context.Operation;
 
-            if (argument.Syntax is not ArgumentSyntax { RefKindKeyword: var refKindToken })
+            var refKind = argument.Parameter?.RefKind ?? RefKind.None;
+            if (refKind is RefKind.None or RefKind.Out)
                 return;
 
-            // Only care about by-reference arguments (ref, in, ref readonly)
-            if (refKindToken.IsKind(SyntaxKind.None))
-                return;
+            ReportIfMatch(context, argument.Value.UnwrapConversionOperations());
+        }
 
-            var value = argument.Value.UnwrapConversionOperations();
-
+        private void ReportIfMatch(OperationAnalysisContext context, IOperation value)
+        {
             IOperation? receiverOp;
             IOperation? indexOp;
 
             if (value is IArrayElementReferenceOperation { Indices: [var arrayIdx], ArrayReference: var arrayRef })
             {
-                // True array: T[]
                 receiverOp = arrayRef;
                 indexOp = arrayIdx;
             }
             else if (value is IPropertyReferenceOperation { Property.IsIndexer: true, Arguments: [{ Value: var propIdx }], Instance: var instance })
             {
-                // Span<T> / ReadOnlySpan<T> indexer
                 receiverOp = instance;
                 indexOp = propIdx;
             }
@@ -125,23 +139,7 @@ public sealed class UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer : Diagno
             if (type.TypeKind is TypeKind.Array)
                 return true;
 
-            if (type.OriginalDefinition.IsEqualToAny(_spanType, _readOnlySpanType))
-                return true;
-
-            return false;
-        }
-
-        private static bool IsIndexZero(SyntaxNodeAnalysisContext context, BracketedArgumentListSyntax argumentList)
-        {
-            if (argumentList.Arguments.Count != 1)
-                return false;
-
-            var argument = argumentList.Arguments[0];
-            if (!argument.RefKindKeyword.IsKind(SyntaxKind.None))
-                return false;
-
-            var constantValue = context.SemanticModel.GetConstantValue(argument.Expression, context.CancellationToken);
-            return constantValue.HasValue && constantValue.Value is 0;
+            return type.OriginalDefinition.IsEqualToAny(_spanType, _readOnlySpanType);
         }
     }
 }

--- a/src/Meziantou.Analyzer/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs
@@ -17,7 +17,7 @@ public sealed class UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer : Diagno
         messageFormat: "Use MemoryMarshal.GetReference instead of indexing at 0, which throws on empty buffers",
         RuleCategories.Usage,
         DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
+        isEnabledByDefault: false,
         description: "Indexing a Span<T>, ReadOnlySpan<T>, or array at index 0 to obtain a by-reference value throws IndexOutOfRangeException on empty buffers. Use MemoryMarshal.GetReference (for spans) or MemoryMarshal.GetArrayDataReference (for arrays) instead, which safely returns a reference to the start even for empty collections.",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseMemoryMarshalGetReferenceForEmptyBuffers));
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzerTests.cs
@@ -1,0 +1,327 @@
+using Meziantou.Analyzer.Rules;
+using Meziantou.Analyzer.Test.Helpers;
+using TestHelper;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer>()
+            .WithCodeFixProvider<UseMemoryMarshalGetReferenceForEmptyBuffersFixer>()
+            .WithTargetFramework(TargetFramework.Net6_0);
+    }
+
+    [Fact]
+    public async Task RefSpanArgument_ReportsDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(Span<byte> span)
+                      {
+                          M(ref [|span[0]|]);
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(Span<byte> span)
+                      {
+                          M(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span));
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InSpanArgument_ReportsDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      static void M(in byte b) { }
+                      void Test(Span<byte> span)
+                      {
+                          M(in [|span[0]|]);
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      static void M(in byte b) { }
+                      void Test(Span<byte> span)
+                      {
+                          M(in System.Runtime.InteropServices.MemoryMarshal.GetReference(span));
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InReadOnlySpanArgument_ReportsDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      static void M(in byte b) { }
+                      void Test(ReadOnlySpan<byte> span)
+                      {
+                          M(in [|span[0]|]);
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      static void M(in byte b) { }
+                      void Test(ReadOnlySpan<byte> span)
+                      {
+                          M(in System.Runtime.InteropServices.MemoryMarshal.GetReference(span));
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RefArrayArgument_ReportsDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(byte[] array)
+                      {
+                          M(ref [|array[0]|]);
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(byte[] array)
+                      {
+                          M(ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(array));
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RefSpanReturn_ReportsDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      ref byte Test(Span<byte> span)
+                      {
+                          return ref [|span[0]|];
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      ref byte Test(Span<byte> span)
+                      {
+                          return ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RefLocalAssignment_ReportsDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void Test(Span<byte> span)
+                      {
+                          ref byte r = ref [|span[0]|];
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void Test(Span<byte> span)
+                      {
+                          ref byte r = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RefSpanConstantZero_ReportsDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(Span<byte> span)
+                      {
+                          const int zero = 0;
+                          M(ref [|span[zero]|]);
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(Span<byte> span)
+                      {
+                          const int zero = 0;
+                          M(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span));
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ValueAccessSpanNotByRef_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void Test(Span<byte> span)
+                      {
+                          _ = span[0];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RefSpanNonZeroIndex_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(Span<byte> span)
+                      {
+                          M(ref span[1]);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RefArrayNonZeroIndex_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(byte[] array)
+                      {
+                          M(ref array[1]);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RefNonConstantIndex_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(Span<byte> span, int index)
+                      {
+                          M(ref span[index]);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task RefCustomRefReturningIndexer_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class C
+                  {
+                      static void M(ref int v) { }
+                      void Test(MyCollection col)
+                      {
+                          M(ref col[0]);
+                      }
+                  }
+                  struct MyCollection
+                  {
+                      private int[] _items;
+                      public ref int this[int index] => ref _items[index];
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ArrayOnNet5_DiagnosticFiresButNoCodeFix()
+    {
+        await new ProjectBuilder()
+              .WithAnalyzer<UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer>()
+              .WithCodeFixProvider<UseMemoryMarshalGetReferenceForEmptyBuffersFixer>()
+              .WithTargetFramework(TargetFramework.Net5_0)
+              .WithSourceCode("""
+                  class C
+                  {
+                      static void M(ref byte b) { }
+                      void Test(byte[] array)
+                      {
+                          M(ref [|array[0]|]);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+}


### PR DESCRIPTION
## Summary

Adds rule **MA0212** that flags by-reference access to the first element (`[0]`) of `Span<T>`, `ReadOnlySpan<T>`, or arrays, and suggests safer `MemoryMarshal` APIs instead.

## Motivation

Using `ref span[0]` or `ref array[0]` to obtain a starting reference performs a bounds check and throws `IndexOutOfRangeException` when the buffer is empty. The correct pattern for performance-sensitive code is:

- `MemoryMarshal.GetReference(span)` — for `Span<T>` / `ReadOnlySpan<T>`
- `MemoryMarshal.GetArrayDataReference(array)` — for arrays (.NET 6+)

These APIs return a managed reference without bounds-checking, remaining safe even for empty buffers.

## What's detected

All by-reference forms are flagged:

| Form | Example |
|------|---------|
| `ref` local | `ref byte first = ref span[0];` |
| `ref` return | `return ref span[0];` |
| `ref` argument | `M(ref span[0]);` |
| `in` argument | `M(in span[0]);` |

Non-by-reference access (`span[0]` as a value) is **not** flagged.

## Code fix

The fixer rewrites the indexed expression to the appropriate `MemoryMarshal` call, preserving the surrounding `ref`/`in` keyword:

```csharp
// Before
M(ref span[0]);

// After
M(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span));
```

For arrays, the fix is only offered on .NET 6+ (where `GetArrayDataReference` is available); the diagnostic still fires on older targets.

## Tests

13 test cases: ref/in span and array arguments, ref-local and ref-return, ReadOnlySpan with in, constant-zero detection, no-diagnostic for non-zero/non-constant/value-access/custom-indexer, and array on .NET 5.