### PR TITLE
Fix MA0011 false positive on Equals(object?)

### DIFF
--- a/src/Meziantou.Analyzer/Internals/OverloadFinder.cs
+++ b/src/Meziantou.Analyzer/Internals/OverloadFinder.cs
@@ -293,7 +293,7 @@ internal sealed class OverloadFinder(Compilation compilation)
                 left,
                 method,
                 otherMethod,
-                options,
+                options with { AllowNumericConversion = false, AllowInterfaceConversions = false, AllowBaseTypeConversions = false },
                 _ienumerableOfTSymbol,
                 _halfSymbol,
                 new Dictionary<ITypeParameterSymbol, ITypeSymbol>(SymbolEqualityComparer.Default));
@@ -438,7 +438,8 @@ internal sealed class OverloadFinder(Compilation compilation)
                 }
             }
 
-            if (methodNamedType is INamedTypeSymbol directCandidate &&
+            if (options.AllowBaseTypeConversions &&
+                methodNamedType is INamedTypeSymbol directCandidate &&
                 directCandidate.BaseType is INamedTypeSymbol baseTypeCandidate &&
                 baseTypeCandidate.OriginalDefinition.IsEqualTo(otherMethodNamedType.OriginalDefinition) &&
                 baseTypeCandidate.TypeArguments.Length == otherMethodNamedType.TypeArguments.Length)

--- a/src/Meziantou.Analyzer/Internals/OverloadOptions.cs
+++ b/src/Meziantou.Analyzer/Internals/OverloadOptions.cs
@@ -13,4 +13,5 @@ internal record struct OverloadOptions(
     bool AllowParamsToNonParamsCompatibility = true,
     bool AllowInModifierCompatibility = true,
     bool AllowInterfaceConversions = true,
+    bool AllowBaseTypeConversions = true,
     Func<IMethodSymbol, bool>? ShouldCheckMethod = null);

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
@@ -168,6 +168,32 @@ public sealed class UseIFormatProviderAnalyzerTests
     }
 
     [Fact]
+    public async Task ObjectEquals_ShouldNotReportDiagnostic()
+    {
+        const string SourceCode = """
+            public static class Program { public static void Main() { } }
+
+            public abstract class ValueObject
+            {
+                public override bool Equals(object? obj)
+                {
+                    if (obj is null || obj.GetType() != GetType())
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                public override int GetHashCode() => 0;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task StringBuilder_AppendLine_AllStringParams()
     {
         const string SourceCode = """


### PR DESCRIPTION
## Why
PR #1227 improved generic overload matching, but it also made MA0011 treat `object` parameters as valid matches for a missing `CultureInfo` argument. This caused false positives on common `Equals(object?)` overrides where no culture-aware overload exists.

## What changed
- Added `AllowBaseTypeConversions` to `OverloadOptions`.
- Updated `OverloadFinder` additional-parameter matching to disable broad conversions (numeric, interface, base-type) for the extra parameter check while preserving generic method type-argument substitution support.
- Added a regression test (`ObjectEquals_ShouldNotReportDiagnostic`) to ensure MA0011 does not report on `Equals(object?)` overrides.

## Notes
This keeps the #1227 behavior for generic comparer overload detection while restoring MA0011 expected behavior for `Equals(object?)`.

Fix https://github.com/meziantou/Meziantou.Analyzer/issues/1229