### PR TITLE
Fix MA0002 false positives on IQueryable LINQ operators

### DIFF
--- a/docs/Rules/MA0002.md
+++ b/docs/Rules/MA0002.md
@@ -42,6 +42,8 @@ list.Distinct();
 list.Distinct(StringComparer.Ordinal);
 ````
 
+`IQueryable` query-operator calls are excluded from this recommendation because comparer overloads are often not translatable by query providers.
+
 # Configuration
 
 The rule can be configured using an `.editorconfig` file:

--- a/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
@@ -78,6 +78,7 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
         public INamedTypeSymbol? EqualityComparerStringType { get; } = GetIEqualityComparerString(compilation);
         public INamedTypeSymbol? ComparerStringType { get; } = GetIComparerString(compilation);
         public INamedTypeSymbol? EnumerableType { get; } = compilation.GetBestTypeByMetadataName("System.Linq.Enumerable");
+        public INamedTypeSymbol? QueryableType { get; } = compilation.GetBestTypeByMetadataName("System.Linq.Queryable");
         public INamedTypeSymbol? ISetType { get; } = compilation.GetBestTypeByMetadataName("System.Collections.Generic.ISet`1")?.Construct(compilation.GetSpecialType(SpecialType.System_String));
         public INamedTypeSymbol? IReadOnlySetType { get; } = compilation.GetBestTypeByMetadataName("System.Collections.Generic.IReadOnlySet`1")?.Construct(compilation.GetSpecialType(SpecialType.System_String));
         public INamedTypeSymbol? IImmutableSetType { get; } = compilation.GetBestTypeByMetadataName("System.Collections.Immutable.IImmutableSet`1")?.Construct(compilation.GetSpecialType(SpecialType.System_String));
@@ -128,6 +129,10 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
             }
 
             if (operation.IsImplicit && IsQueryOperator(operation) && ctx.Options.GetConfigurationValue(operation, Rule.Id + ".exclude_query_operator_syntaxes", defaultValue: false))
+                return;
+
+            // Queryable comparer overloads are often not translatable by providers.
+            if (QueryableType is not null && method.ContainingType.IsEqualTo(QueryableType))
                 return;
 
             if ((EqualityComparerStringType is not null && _overloadFinder.HasOverloadWithAdditionalParameterOfType(operation, options: default, [EqualityComparerStringType])) ||

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -361,6 +361,94 @@ class TypeName
     }
 
     [Fact]
+    public async Task EnumerableDistinct_String_ShouldReportDiagnostic()
+    {
+        const string SourceCode = """
+            using System.Linq;
+            class TypeName
+            {
+                public void Test()
+                {
+                    System.Collections.Generic.IEnumerable<string> obj = null;
+                    obj.[|Distinct()|];
+                }
+            }
+            """;
+        const string CodeFix = """
+            using System.Linq;
+            class TypeName
+            {
+                public void Test()
+                {
+                    System.Collections.Generic.IEnumerable<string> obj = null;
+                    obj.Distinct(System.StringComparer.Ordinal);
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ShouldFixCodeWith(CodeFix)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task QueryableDistinct_String_ShouldNotReportDiagnostic()
+    {
+        const string SourceCode = """
+            using System.Linq;
+            class TypeName
+            {
+                public void Test()
+                {
+                    IQueryable<string?> obj = null;
+                    obj.Distinct();
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task QueryableContains_String_ShouldNotReportDiagnostic()
+    {
+        const string SourceCode = """
+            using System.Linq;
+            class TypeName
+            {
+                public void Test()
+                {
+                    IQueryable<string?> obj = null;
+                    obj.Contains("");
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task QueryableOrderBy_String_ShouldNotReportDiagnostic()
+    {
+        const string SourceCode = """
+            using System.Linq;
+            class TypeName
+            {
+                public void Test()
+                {
+                    IQueryable<string?> obj = null;
+                    obj.OrderBy(p => p);
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task EnumerableToDictionary_String_ShouldReportDiagnostic()
     {
         const string SourceCode = @"using System.Linq;


### PR DESCRIPTION
MA0002 was suggesting comparer overloads for `IQueryable<string?>` operators such as `Distinct`. For provider-backed queries, these overloads are often not translatable and can lead to incorrect guidance.

This change skips MA0002 diagnostics for `System.Linq.Queryable` invocations while keeping existing behavior for in-memory `IEnumerable`/`Enumerable` calls.

## What changed
- Added a `Queryable` guard in `UseStringComparerAnalyzer` invocation analysis
- Added regression tests for:
  - `IQueryable<string?>.Distinct()` (no diagnostic)
  - `IQueryable<string?>.Contains(...)` (no diagnostic)
  - `IQueryable<string?>.OrderBy(...)` (no diagnostic)
  - `IEnumerable<string>.Distinct()` (still reports + code fix)
- Updated `docs/Rules/MA0002.md` to document Queryable behavior

Fixes: #1234