### PR TITLE
Fix MA0002 false positive on `[with(StringComparer.Ordinal)]` collection expression

### DIFF
--- a/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
@@ -184,6 +184,14 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
             if (operation is not { Elements.Length: 0, Type: INamedTypeSymbol targetType })
                 return;
 
+#if ROSLYN_5_6_OR_GREATER
+            // [with(StringComparer.Ordinal)] already provides a comparer — no diagnostic needed.
+#pragma warning disable RSEXPERIMENTAL006
+            if (HasEqualityComparerConstructArgument(operation.ConstructArguments))
+                return;
+#pragma warning restore RSEXPERIMENTAL006
+#endif
+
             if (DictionaryType is null || !targetType.ConstructedFrom.IsEqualTo(DictionaryType))
                 return;
 
@@ -246,6 +254,25 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
 
             return false;
         }
+
+#if ROSLYN_5_6_OR_GREATER
+#pragma warning disable RSEXPERIMENTAL006
+        private bool HasEqualityComparerConstructArgument(ImmutableArray<IOperation> constructArguments)
+        {
+            foreach (var arg in constructArguments)
+            {
+                var argumentType = arg is IArgumentOperation argOp ? argOp.Value.Type : arg.Type;
+                if (argumentType is null)
+                    continue;
+
+                if (argumentType.GetAllInterfacesIncludingThis().Any(i => EqualityComparerStringType.IsEqualTo(i) || ComparerStringType.IsEqualTo(i)))
+                    return true;
+            }
+
+            return false;
+        }
+#pragma warning restore RSEXPERIMENTAL006
+#endif
 
         private static INamedTypeSymbol? GetIEqualityComparerString(Compilation compilation)
         {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -266,6 +266,38 @@ public sealed class UseStringComparerAnalyzerTests
               .ShouldFixCodeWith(CodeFix)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task Dictionary_String_CollectionExpression_WithStringComparer_ShouldNotReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.Dictionary<string, int> a = [with(System.StringComparer.Ordinal)];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Dictionary_String_CollectionExpression_WithCapacityNoComparer_ShouldReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.Dictionary<string, int> a = [|[with(10)]|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
 #endif
 
     [Fact]


### PR DESCRIPTION
Fixes #1235

## Problem

`Dictionary<string, List<string>> duplicates = [with(StringComparer.Ordinal)];` was incorrectly flagged by MA0002 ("IEqualityComparer<string> or IComparer<string> is missing").

## Root Cause

`AnalyzeCollectionExpression` checked `Elements.Length == 0` but did not check `ConstructArguments` (C# 15's `with(...)` arguments).

In Roslyn's IOperation model for `[with(StringComparer.Ordinal)]`:
- `Elements.Length == 0` (no key-value entries) → check passes
- `ConstructArguments.Length == 1` (the `StringComparer.Ordinal`) → **was not checked**

So the analyzer continued and incorrectly reported MA0002.

## Fix

Under `#if ROSLYN_5_6_OR_GREATER` (when C# 15's `with(...)` syntax is available), check `ConstructArguments` for an existing `IEqualityComparer<string>` or `IComparer<string>`. If already present, skip reporting.

## Tests added

- `[with(StringComparer.Ordinal)]` → no diagnostic ✓
- `[with(10)]` (capacity only, no comparer) → still reports MA0002 ✓