### PR TITLE
Fix MA0011 false positives on *OrDefault LINQ methods

### DIFF
--- a/docs/Rules/MA0011.md
+++ b/docs/Rules/MA0011.md
@@ -4,6 +4,7 @@ Sources: [UseIFormatProviderAnalyzer.cs](https://github.com/meziantou/Meziantou.
 <!-- sources -->
 
 This rule warns about the usage of overloads of methods like `Parse`, `TryParse` and `ToString` that do not take a parameter of type `IFormatProvider`.
+Methods ending with `OrDefault` are excluded from this rule as the argument is often not relevant for globalization.
 
 For more information, see [Creating Globally Aware Applications](https://learn.microsoft.com/en-us/previous-versions/windows/silverlight/dotnet-windows-silverlight/cc853414(v=vs.95)?WT.mc_id=DT-MVP-5003978).
 

--- a/src/Meziantou.Analyzer/Rules/UseIFormatProviderAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseIFormatProviderAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
 using Meziantou.Analyzer.Internals;
 using Microsoft.CodeAnalysis;
@@ -111,8 +112,11 @@ public sealed class UseIFormatProviderAnalyzer : DiagnosticAnalyzer
 
         private static bool IsExcludedMethod(OperationAnalysisContext context, IInvocationOperation operation)
         {
+            if (operation.TargetMethod.Name.EndsWith("OrDefault", StringComparison.Ordinal))
+                return true;
+
             // ToString show culture-sensitive data by default
-            if (operation?.GetContainingMethod(context.CancellationToken)?.Name == "ToString")
+            if (operation.GetContainingMethod(context.CancellationToken)?.Name == "ToString")
             {
                 return context.Options.GetConfigurationValue(operation.Syntax.SyntaxTree, "MA0011.exclude_tostring_methods", defaultValue: true);
             }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
@@ -156,6 +156,38 @@ public sealed class UseIFormatProviderAnalyzerTests
     }
 
     [Fact]
+    public async Task ListOfCultureInfo_FirstOrDefault_ShouldNotReportDiagnostic()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            using System.Globalization;
+            using System.Linq;
+
+            List<CultureInfo> values = new();
+            _ = values.FirstOrDefault();
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ListOfCultureInfo_LastOrDefault_ShouldNotReportDiagnostic()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            using System.Globalization;
+            using System.Linq;
+
+            List<CultureInfo> values = new();
+            _ = values.LastOrDefault();
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task EnumToString()
     {
         const string SourceCode = """


### PR DESCRIPTION
MA0011 was incorrectly reporting calls like `List<CultureInfo>.FirstOrDefault()` because `*OrDefault` overloads with `defaultValue` could be interpreted as culture-related overload guidance. This created warnings for cases that are unrelated to `IFormatProvider` usage.

This change excludes methods ending with `OrDefault` from MA0011 analysis.

- Added an early `OrDefault` exclusion in `UseIFormatProviderAnalyzer`.
- Added regression tests for `List<CultureInfo>.FirstOrDefault()` and `List<CultureInfo>.LastOrDefault()`.
- Updated MA0011 documentation to mention the exclusion.

Fixes: #1238