### PR TITLE
MA0002: report collection expressions with elements, not just empty ones

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparerFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparerFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Simplification;
 
 namespace Meziantou.Analyzer.Rules;
 
@@ -116,11 +117,7 @@ public sealed class UseStringComparerFixer : CodeFixProvider
     {
         var comparerType = stringComparer.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         var parsed = (CollectionExpressionSyntax)SyntaxFactory.ParseExpression($"[with({comparerType}.{comparerName})]");
-
-        if (collectionExpression.Elements.Count == 0)
-            return parsed.WithTriviaFrom(collectionExpression);
-
-        var withElement = parsed.Elements[0];
+        var withElement = parsed.Elements[0].WithAdditionalAnnotations(Simplifier.Annotation);
         var newElements = collectionExpression.Elements.Insert(0, withElement);
         return collectionExpression.WithElements(newElements);
     }

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparerFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparerFixer.cs
@@ -37,11 +37,6 @@ public sealed class UseStringComparerFixer : CodeFixProvider
         if (stringComparerSymbol is null)
             return;
 
-#if CSHARP15_OR_GREATER
-        if (nodeToFix is CollectionExpressionSyntax collectionExpression && !CanFixCollectionExpression(collectionExpression))
-            return;
-#endif
-
         RegisterCodeFix(nameof(StringComparer.Ordinal));
         RegisterCodeFix(nameof(StringComparer.OrdinalIgnoreCase));
 
@@ -117,16 +112,17 @@ public sealed class UseStringComparerFixer : CodeFixProvider
     }
 
 #if CSHARP15_OR_GREATER
-    private static bool CanFixCollectionExpression(CollectionExpressionSyntax collectionExpression)
-    {
-        return collectionExpression.Elements.Count == 0;
-    }
-
     private static CollectionExpressionSyntax AddCollectionArgument(CollectionExpressionSyntax collectionExpression, INamedTypeSymbol stringComparer, string comparerName)
     {
         var comparerType = stringComparer.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        var replacement = SyntaxFactory.ParseExpression($"[with({comparerType}.{comparerName})]");
-        return replacement.WithTriviaFrom(collectionExpression) as CollectionExpressionSyntax ?? collectionExpression;
+        var parsed = (CollectionExpressionSyntax)SyntaxFactory.ParseExpression($"[with({comparerType}.{comparerName})]");
+
+        if (collectionExpression.Elements.Count == 0)
+            return parsed.WithTriviaFrom(collectionExpression);
+
+        var withElement = parsed.Elements[0];
+        var newElements = collectionExpression.Elements.Insert(0, withElement);
+        return collectionExpression.WithElements(newElements);
     }
 #endif
 }

--- a/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
@@ -182,9 +182,7 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
             if (!ShouldReportCollectionExpression(ctx, operation))
                 return;
 
-            // Without collection arguments (`with(...)`), empty collection expressions pick the parameterless constructor.
-            // So report only when a comparer-aware constructor exists and the key type is string.
-            if (operation is not { Elements.Length: 0, Type: INamedTypeSymbol targetType })
+            if (operation.Type is not INamedTypeSymbol targetType)
                 return;
 
 #if ROSLYN_5_6_OR_GREATER

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -272,6 +272,24 @@ public sealed class UseStringComparerAnalyzerTests
                   """)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task HashSet_String_CollectionExpression_WithElements_CSharp12_OptionEnabled_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+              .AddAnalyzerConfiguration(ReportCollectionExpressionsConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.HashSet<string> a = [|["a", "b"]|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
 #endif
 
 #if CSHARP15_OR_GREATER
@@ -371,6 +389,101 @@ public sealed class UseStringComparerAnalyzerTests
                       public void Test()
                       {
                           System.Collections.Generic.Dictionary<string, int> a = [|[with(10)]|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task HashSet_String_CollectionExpression_WithElements_ShouldReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.HashSet<string> a = [|["a", "b"]|];
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.HashSet<string> a = [with(global::System.StringComparer.Ordinal), "a", "b"];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task HashSet_String_CollectionExpression_WithSpread_ShouldReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          var other = new string[] { "a", "b" };
+                          System.Collections.Generic.HashSet<string> a = [|[.. other]|];
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          var other = new string[] { "a", "b" };
+                          System.Collections.Generic.HashSet<string> a = [with(global::System.StringComparer.Ordinal), .. other];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task HashSet_String_CollectionExpression_WithComparerAndElements_ShouldNotReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.HashSet<string> a = [with(System.StringComparer.Ordinal), "a", "b"];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Dictionary_String_CollectionExpression_WithElements_ShouldReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          var other = new string[] { "a", "b" };
+                          System.Collections.Generic.HashSet<string> a = [|[.. other, "c"]|];
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          var other = new string[] { "a", "b" };
+                          System.Collections.Generic.HashSet<string> a = [with(global::System.StringComparer.Ordinal), .. other, "c"];
                       }
                   }
                   """)


### PR DESCRIPTION
## Motivation

MA0002 was only reporting a diagnostic for empty collection expressions (`[]`). A non-empty collection expression like `["a", "b"]` or `[.. other]` assigned to a `HashSet<string>` or `Dictionary<string, int>` was silently accepted even though no comparer was specified. This is just as unsafe as an empty one -- the resulting collection still uses ordinal case-sensitive comparison by default.

## Changes

**Analyzer** (`UseStringComparerAnalyzer.cs`): Removed the `Elements.Length: 0` guard so the diagnostic is now raised for any collection expression whose target type has a comparer-aware constructor and no `with(comparer)` argument is present.

**Code fixer** (`UseStringComparerFixer.cs`): Updated `AddCollectionArgument` to handle non-empty collections. Instead of replacing the whole expression with `[with(...)]`, it now inserts the `with(...)` element at position 0 of the existing element list, producing e.g.:

```csharp
// Before
HashSet<string> set = ["a", "b"];

// After (fix applied)
HashSet<string> set = [with(StringComparer.Ordinal), "a", "b"];
```

The `CanFixCollectionExpression` helper that previously blocked the fix for non-empty collections has been removed.

**Tests**: Added cases covering elements-only, spread-only, and mixed collections, including a no-diagnostic case for `[with(comparer), ...]`.

Fix https://github.com/meziantou/Meziantou.Analyzer/issues/1242