### PR TITLE
fix(MA0002): detect missing comparer for FrozenSet and ImmutableHashSet collection expressions

### DIFF
--- a/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
@@ -182,9 +182,6 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
             if (!ShouldReportCollectionExpression(ctx, operation))
                 return;
 
-            if (operation.Type is not INamedTypeSymbol targetType)
-                return;
-
 #if ROSLYN_5_6_OR_GREATER
             // [with(StringComparer.Ordinal)] already provides a comparer — no diagnostic needed.
 #pragma warning disable RSEXPERIMENTAL006
@@ -193,7 +190,16 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
 #pragma warning restore RSEXPERIMENTAL006
 #endif
 
-            if (HasConstructorWithStringComparer(targetType))
+            // ConstructMethod is the constructor (for types without [CollectionBuilder]) or the
+            // factory method (for types with [CollectionBuilder], e.g. FrozenSet, ImmutableHashSet).
+            // Either way, checking for an overload with an additional comparer parameter is the
+            // correct way to decide whether the user should be prompted to specify a comparer.
+            var constructMethod = operation.ConstructMethod;
+            if (constructMethod is null)
+                return;
+
+            if ((EqualityComparerStringType is not null && _overloadFinder.HasOverloadWithAdditionalParameterOfType(constructMethod, options: default, [EqualityComparerStringType])) ||
+                (ComparerStringType is not null && _overloadFinder.HasOverloadWithAdditionalParameterOfType(constructMethod, options: default, [ComparerStringType])))
             {
                 ctx.ReportDiagnostic(Rule, operation);
             }
@@ -202,23 +208,6 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
             {
                 var defaultValue = operation.GetCSharpLanguageVersion().IsCSharp15OrAbove();
                 return context.Options.GetConfigurationValue(operation, Rule.Id + ".report_collection_expressions", defaultValue);
-            }
-
-            bool HasConstructorWithStringComparer(INamedTypeSymbol targetType)
-            {
-                foreach (var constructor in targetType.Constructors)
-                {
-                    if (constructor.Parameters.Any(parameter =>
-                    {
-                        var parameterType = parameter.Type;
-                        return parameterType.GetAllInterfacesIncludingThis().Any(i => EqualityComparerStringType.IsEqualTo(i) || ComparerStringType.IsEqualTo(i));
-                    }))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
             }
         }
 #endif

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -290,6 +290,76 @@ public sealed class UseStringComparerAnalyzerTests
                   """)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task FrozenSet_String_CollectionExpression_DefaultOnCSharp12_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Frozen.FrozenSet<string> a = [];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task FrozenSet_String_CollectionExpression_CSharp12_OptionEnabled_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+              .AddAnalyzerConfiguration(ReportCollectionExpressionsConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Frozen.FrozenSet<string> a = [|[]|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ImmutableHashSet_String_CollectionExpression_DefaultOnCSharp12_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Immutable.ImmutableHashSet<string> a = [];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ImmutableHashSet_String_CollectionExpression_CSharp12_OptionEnabled_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+              .AddAnalyzerConfiguration(ReportCollectionExpressionsConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Immutable.ImmutableHashSet<string> a = [|[]|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
 #endif
 
 #if CSHARP15_OR_GREATER
@@ -484,6 +554,88 @@ public sealed class UseStringComparerAnalyzerTests
                       {
                           var other = new string[] { "a", "b" };
                           System.Collections.Generic.HashSet<string> a = [with(global::System.StringComparer.Ordinal), .. other, "c"];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task FrozenSet_String_CollectionExpression_Preview_ShouldReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Frozen.FrozenSet<string> a = [|[]|];
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Frozen.FrozenSet<string> a = [with(global::System.StringComparer.Ordinal)];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task FrozenSet_String_CollectionExpression_WithStringComparer_ShouldNotReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Frozen.FrozenSet<string> a = [with(System.StringComparer.Ordinal)];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ImmutableHashSet_String_CollectionExpression_Preview_ShouldReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Immutable.ImmutableHashSet<string> a = [|[]|];
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Immutable.ImmutableHashSet<string> a = [with(global::System.StringComparer.Ordinal)];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ImmutableHashSet_String_CollectionExpression_WithStringComparer_ShouldNotReportDiagnostic()
+    {
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Immutable.ImmutableHashSet<string> a = [with(System.StringComparer.Ordinal)];
                       }
                   }
                   """)


### PR DESCRIPTION
Fixes #1245

## Problem

MA0002 did not raise a diagnostic for:
```csharp
FrozenSet<string> a = [];
ImmutableHashSet<string> a = [];
```

These types have no public constructors with an `IEqualityComparer<string>` parameter — they use static factory methods via the `[CollectionBuilder]` attribute. The previous `HasConstructorWithStringComparer` helper only checked constructors and missed these types.

## Solution

Replace the manual constructor check with `ICollectionExpressionOperation.ConstructMethod` (available since Roslyn 4.14), which Roslyn already resolves to:
- The **constructor** for types without `[CollectionBuilder]` (e.g. `HashSet<T>`, `Dictionary<TK,TV>`)
- The **factory method** for types with `[CollectionBuilder]` (e.g. `FrozenSet<T>`, `ImmutableHashSet<T>`)

Passing `ConstructMethod` to the existing `HasOverloadWithAdditionalParameterOfType` correctly detects overloads that accept an `IEqualityComparer<string>` parameter regardless of whether the overload is a constructor or a static factory.

The code fix (adding `[with(StringComparer.Ordinal)]`) already worked — no changes to the fixer were needed.