### PR TITLE
Fix MA0202 false positive for comment-only branches

### DIFF
--- a/docs/Rules/MA0202.md
+++ b/docs/Rules/MA0202.md
@@ -7,7 +7,9 @@ This rule reports duplicate code in a single `#if` / `#elif` / `#else` block.
 
 If a branch has the same code as any previous branch in the same conditional compilation block, the directive is redundant and should be simplified.
 
-The comparison ignores trivia (such as comments and whitespace), so only the actual code structure is considered.
+The comparison ignores trivia (such as comments and whitespace) when branches contain code, so only the actual code structure is considered.
+
+For comment-only branches, comments are compared textually to avoid false positives when comment content differs.
 
 ## Non-compliant code
 

--- a/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalCommon.cs
@@ -89,6 +89,9 @@ internal static class ConditionalCompilationBranchesAreIdenticalCommon
             builder.Append(';');
         }
 
+        if (builder.Length == 0)
+            return text.Trim();
+
         return builder.ToString();
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
@@ -63,6 +63,40 @@ public sealed class ConditionalCompilationBranchesAreIdenticalAnalyzerTests
         .ValidateAsync();
 
     [Fact]
+    public Task DifferentXmlCommentsOnly() => CreateProjectBuilder()
+        .WithSourceCode("""
+            class C
+            {
+            #if A
+                /// <summary>net8</summary>
+            #else
+                /// <summary>net9</summary>
+            #endif
+                void M() { }
+            }
+
+            static class Program { static void Main() { } }
+            """)
+        .ValidateAsync();
+
+    [Fact]
+    public Task SameXmlCommentsOnly() => CreateProjectBuilder()
+        .WithSourceCode("""
+            class C
+            {
+            #if A
+                /// <summary>text</summary>
+            {|MA0202:#else|}
+                /// <summary>text</summary>
+            #endif
+                void M() { }
+            }
+
+            static class Program { static void Main() { } }
+            """)
+        .ValidateAsync();
+
+    [Fact]
     public Task DifferentBranches() => CreateProjectBuilder()
         .WithSourceCode("""
             #if A

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -534,7 +534,7 @@ public sealed class UseStringComparerAnalyzerTests
     }
 
     [Fact]
-    public async Task HashSet_String_CollectionExpression_WithElements_ShouldReportDiagnostic()
+    public async Task HashSet_String_CollectionExpression_WithElements_Spread_ShouldReportDiagnostic()
     {
         await CreatePreviewProjectBuilder()
               .WithSourceCode("""

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -534,7 +534,7 @@ public sealed class UseStringComparerAnalyzerTests
     }
 
     [Fact]
-    public async Task Dictionary_String_CollectionExpression_WithElements_ShouldReportDiagnostic()
+    public async Task HashSet_String_CollectionExpression_WithElements_ShouldReportDiagnostic()
     {
         await CreatePreviewProjectBuilder()
               .WithSourceCode("""


### PR DESCRIPTION
MA0202 could report a false positive when conditional compilation branches only contained comments (including XML documentation comments). In that case, tokenization produced an empty signature for each branch, so different comment-only branches were treated as identical.

This change updates branch signature computation to fall back to trimmed raw text when a branch has no tokens, while keeping the existing token-based comparison for branches that contain code. It also adds regression tests for both different and identical XML-comment-only branches, and updates MA0202 documentation to reflect the behavior.

Fixes: #1255
Fixes: #1256