### PR TITLE
Fix IsCultureSensitiveType to handle generic type parameters with constraints

### DIFF
--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -402,11 +402,24 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
                 return true;
 
             // May have ToString(IFormatProvider) even if IFormattable is not implemented directly
-            if (type.GetAllMembers().OfType<IMethodSymbol>().Any(m => m is { Name: "ToString", IsStatic: false, ReturnType: { SpecialType: SpecialType.System_String }, Parameters: [var param1] } && param1.Type.IsOrInheritFrom(FormatProviderSymbol) && m.DeclaredAccessibility is Accessibility.Public))
+            if (HasToStringWithFormatProvider(type))
                 return true;
+
+            // For type parameters, also check the constraint types
+            if (type is ITypeParameterSymbol typeParameter)
+            {
+                foreach (var constraintType in typeParameter.ConstraintTypes)
+                {
+                    if (HasToStringWithFormatProvider(constraintType))
+                        return true;
+                }
+            }
 
             return false;
         }
+
+        bool HasToStringWithFormatProvider(ITypeSymbol type)
+            => type.GetAllMembers().OfType<IMethodSymbol>().Any(m => m is { Name: "ToString", IsStatic: false, ReturnType: { SpecialType: SpecialType.System_String }, Parameters: [var param1] } && param1.Type.IsOrInheritFrom(FormatProviderSymbol) && m.DeclaredAccessibility is Accessibility.Public);
     }
 
     private bool IsCultureSensitiveTypeUsingAttribute(ITypeSymbol typeSymbol)
@@ -432,6 +445,15 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
             if (attribute.ConstructorArguments[0].Value is INamedTypeSymbol attributeType && attributeType.IsEqualTo(typeSymbol))
             {
                 if (attribute.ConstructorArguments.Length == 1)
+                    return false;
+            }
+        }
+
+        if (typeSymbol is ITypeParameterSymbol typeParameter)
+        {
+            foreach (var constraintType in typeParameter.ConstraintTypes)
+            {
+                if (!IsCultureSensitiveTypeUsingAttribute(constraintType))
                     return false;
             }
         }
@@ -489,6 +511,15 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
                 var attrFormat = attrValue as string;
                 if (attrFormat == format)
                     return false; // no format is set, so the type is culture insensitive
+            }
+        }
+
+        if (typeSymbol is ITypeParameterSymbol typeParameter)
+        {
+            foreach (var constraintType in typeParameter.ConstraintTypes)
+            {
+                if (!IsCultureSensitiveTypeUsingAttribute(constraintType, hasFormat, format))
+                    return false;
             }
         }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -656,4 +656,88 @@ class Sample : System.IFormattable
               .WithSourceCode(sourceCode)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task GenericTypeParameterConstrainedToIFormattable()
+    {
+        var sourceCode = """
+class Test
+{
+    void A<T>(T item) where T : System.IFormattable
+    {
+        _ = "abc" + [|item|];
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericTypeParameterConstrainedToTypeThatImplementsIFormattable()
+    {
+        var sourceCode = """
+class Test
+{
+    void A<T>(T item) where T : Sample
+    {
+        _ = "abc" + [|item|];
+    }
+}
+
+class Sample : System.IFormattable
+{
+    public string ToString(string? format, System.IFormatProvider? formatProvider) => "abc";
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericTypeParameterConstrainedToTypeThatHasToStringWithIFormatProvider()
+    {
+        var sourceCode = """
+class Test
+{
+    void A<T>(T item) where T : Sample
+    {
+        _ = "abc" + [|item|];
+    }
+}
+
+class Sample
+{
+    public string ToString(System.IFormatProvider? formatProvider) => "abc";
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericTypeParameterConstrainedToTypeWithCultureInsensitiveAttribute()
+    {
+        var sourceCode = """
+class Test
+{
+    void A<T>(T item) where T : Sample
+    {
+        _ = "abc" + item;
+    }
+}
+
+[Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute]
+class Sample : System.IFormattable
+{
+    public string ToString(string? format, System.IFormatProvider? formatProvider) => "abc";
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
@@ -482,18 +482,9 @@ ILogger logger = null;
 logger.LogInformation("{Prop}", [|2|]);
 logger.LogInformation("{Prop}", 2L);
 logger.LogInformation("{Prop}", "");
-
-namespace Meziantou.Analyzer.Annotations
-{
-    [System.Diagnostics.ConditionalAttribute("MEZIANTOU_ANALYZER_ATTRIBUTES")]
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
-    internal sealed class StructuredLogFieldAttribute : System.Attribute
-    {
-        public StructuredLogFieldAttribute(string parameterName, params System.Type[] allowedTypes) { }
-    }
-}
 """;
         await CreateProjectBuilder()
+              .AddMeziantouAttributes()
               .WithSourceCode(SourceCode)
               .AddAdditionalFile("LoggerParameterTypes.txt", """
 Prop;System.Int32

--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -1104,6 +1104,7 @@ public sealed class NamedParameterAnalyzerTests
     public async Task CallerMustUseNamedArgument()
     {
         await CreateProjectBuilder()
+              .AddMeziantouAttributes()
               .WithSourceCode("""
                 class Test
                 {
@@ -1114,12 +1115,6 @@ public sealed class NamedParameterAnalyzerTests
                         _ = new Test([|new object()|]);
                     }
                 }
-
-                namespace Meziantou.Analyzer.Annotations
-                {
-                    [System.AttributeUsage(System.AttributeTargets.Parameter)]
-                    internal class RequireNamedArgumentAttribute : System.Attribute {}
-                }
                 """)
               .ValidateAsync();
     }
@@ -1128,6 +1123,7 @@ public sealed class NamedParameterAnalyzerTests
     public async Task CallerMustUseNamedArgument_False()
     {
         await CreateProjectBuilder()
+              .AddMeziantouAttributes()
               .WithSourceCode("""
                 class Test
                 {
@@ -1138,16 +1134,6 @@ public sealed class NamedParameterAnalyzerTests
                         _ = new Test(new object());
                     }
                 }
-
-                namespace Meziantou.Analyzer.Annotations
-                {
-                    [System.AttributeUsage(System.AttributeTargets.Parameter)]
-                    internal class RequireNamedArgumentAttribute : System.Attribute
-                    {
-                        public RequireNamedArgumentAttribute() {}
-                        public RequireNamedArgumentAttribute(bool value) {}
-                    }
-                }
                 """)
               .ValidateAsync();
     }
@@ -1156,6 +1142,7 @@ public sealed class NamedParameterAnalyzerTests
     public async Task CallerMustUseNamedArgument_True()
     {
         await CreateProjectBuilder()
+              .AddMeziantouAttributes()
               .WithSourceCode("""
                 class Test
                 {
@@ -1164,16 +1151,6 @@ public sealed class NamedParameterAnalyzerTests
                     void A()
                     {
                         _ = new Test([|new object()|]);
-                    }
-                }
-
-                namespace Meziantou.Analyzer.Annotations
-                {
-                    [System.AttributeUsage(System.AttributeTargets.Parameter)]
-                    internal class RequireNamedArgumentAttribute : System.Attribute
-                    {
-                        public RequireNamedArgumentAttribute() {}
-                        public RequireNamedArgumentAttribute(bool value) {}
                     }
                 }
                 """)
@@ -1184,6 +1161,7 @@ public sealed class NamedParameterAnalyzerTests
     public async Task MinimumNumberOfParameters_2_RequireNamedArgumentAttribute()
     {
         await CreateProjectBuilder()
+              .AddMeziantouAttributes()
               .AddAnalyzerConfiguration("MA0003.minimum_method_parameters", "2")
               .WithSourceCode("""
                 class Test
@@ -1193,16 +1171,6 @@ public sealed class NamedParameterAnalyzerTests
                     void A()
                     {
                         _ = new Test([|new object()|]);
-                    }
-                }
-
-                namespace Meziantou.Analyzer.Annotations
-                {
-                    [System.AttributeUsage(System.AttributeTargets.Parameter)]
-                    internal class RequireNamedArgumentAttribute : System.Attribute
-                    {
-                        public RequireNamedArgumentAttribute() {}
-                        public RequireNamedArgumentAttribute(bool value) {}
                     }
                 }
                 """)


### PR DESCRIPTION
## Why

When a method has a generic type parameter constrained to a class that implements `IFormattable` (or has `ToString(IFormatProvider)`), the analyzer was not reporting diagnostics for implicit culture-sensitive `ToString` calls. For example:

```csharp
void Foo<T>(T item) where T : Bar;  // Bar : IFormattable
_ = "abc" + item;  // no diagnostic was reported -- bug
```

## What changed

Two gaps in `IsCultureSensitiveType` / `CultureSensitiveFormattingContext` were addressed:

1. **`IsFormattableType` local function** -- the fallback check for `ToString(IFormatProvider)` used `GetAllMembers()`, which walks `BaseType`. For a type parameter, `BaseType` is `object`, so members of the constraint class were never found. The fix extracts a `HasToStringWithFormatProvider` helper and explicitly iterates `ConstraintTypes` when the symbol is an `ITypeParameterSymbol`.

2. **`IsCultureSensitiveTypeUsingAttribute`** -- if a constraint type carries `[CultureInsensitiveType]`, that should suppress the diagnostic for the type parameter too. Both overloads now walk `ConstraintTypes` for type parameters and propagate the insensitive marking.

Note: the case `where T : IFormattable` and `where T : SomeClass` (where `SomeClass : IFormattable`) were already handled correctly by the existing `Implements()` helper, which traverses constraints. The bug only affected the `ToString(IFormatProvider)`-without-`IFormattable` path and the attribute suppression path.

## Tests added

- `GenericTypeParameterConstrainedToIFormattable` -- direct interface constraint (was already working, regression guard)
- `GenericTypeParameterConstrainedToTypeThatImplementsIFormattable` -- class constraint where the class implements `IFormattable` (was already working, regression guard)
- `GenericTypeParameterConstrainedToTypeThatHasToStringWithIFormatProvider` -- class constraint with `ToString(IFormatProvider)` but no `IFormattable` (was the bug)
- `GenericTypeParameterConstrainedToTypeWithCultureInsensitiveAttribute` -- constraint type marked `[CultureInsensitiveType]`, no diagnostic expected