### PR TITLE
Detect ISpanFormattable in culture-sensitive formatting

### DIFF
--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -23,6 +23,7 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
     public INamedTypeSymbol? TimeSpanSymbol { get; } = compilation.GetBestTypeByMetadataName("System.TimeSpan");
     public INamedTypeSymbol? VersionSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Version");
     public INamedTypeSymbol? SystemIFormattableSymbol { get; } = compilation.GetBestTypeByMetadataName("System.IFormattable");
+    public INamedTypeSymbol? SystemISpanFormattableSymbol { get; } = compilation.GetBestTypeByMetadataName("System.ISpanFormattable");
     public INamedTypeSymbol? SystemWindowsFontStretchSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Windows.FontStretch");
     public INamedTypeSymbol? SystemWindowsMediaBrushSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Windows.Media.Brush");
     public INamedTypeSymbol? NuGetVersioningSemanticVersionSymbol { get; } = compilation.GetBestTypeByMetadataName("NuGet.Versioning.SemanticVersion");
@@ -398,7 +399,7 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
 
         bool IsFormattableType(ITypeSymbol type)
         {
-            if (type.Implements(SystemIFormattableSymbol))
+            if (type.Implements(SystemIFormattableSymbol) || type.Implements(SystemISpanFormattableSymbol))
                 return true;
 
             // May have ToString(IFormatProvider) even if IFormattable is not implemented directly
@@ -410,7 +411,7 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
             {
                 foreach (var constraintType in typeParameter.ConstraintTypes)
                 {
-                    if (HasToStringWithFormatProvider(constraintType))
+                    if (constraintType.Implements(SystemIFormattableSymbol) || constraintType.Implements(SystemISpanFormattableSymbol) || HasToStringWithFormatProvider(constraintType))
                         return true;
                 }
             }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -675,6 +675,23 @@ class Test
     }
 
     [Fact]
+    public async Task GenericTypeParameterConstrainedToISpanFormattable()
+    {
+        var sourceCode = """
+class Test
+{
+    void A<T>(T item) where T : System.ISpanFormattable
+    {
+        _ = "abc" + [|item|];
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task GenericTypeParameterConstrainedToTypeThatImplementsIFormattable()
     {
         var sourceCode = """
@@ -689,6 +706,34 @@ class Test
 class Sample : System.IFormattable
 {
     public string ToString(string? format, System.IFormatProvider? formatProvider) => "abc";
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task GenericTypeParameterConstrainedToTypeThatImplementsISpanFormattable()
+    {
+        var sourceCode = """
+class Test
+{
+    void A<T>(T item) where T : Sample
+    {
+        _ = "abc" + [|item|];
+    }
+}
+
+class Sample : System.ISpanFormattable
+{
+    public override string ToString() => "abc";
+    public string ToString(string? format, System.IFormatProvider? formatProvider) => "abc";
+    public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider)
+    {
+        charsWritten = 0;
+        return true;
+    }
 }
 """;
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
@@ -385,6 +385,24 @@ class Sample : System.IFormattable
     }
 
     [Fact]
+    public async Task ToString_ISpanFormattable()
+    {
+        var sourceCode = """
+_ = [|new Sample().ToString()|];
+
+class Sample : System.ISpanFormattable
+{
+    public override string ToString() => throw null;
+    public string ToString(string? format, System.IFormatProvider? formatProvider) => throw null;
+    public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider formatProvider) => throw null;
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task ToString_IFormattable_CodeFix()
     {
         var sourceCode = """


### PR DESCRIPTION
## Why
Some formatting-sensitive checks only recognized `IFormattable`, which could miss types exposed through `ISpanFormattable` paths. This can hide culture-sensitive formatting usage that should be analyzed consistently.

## What changed
- Extended `CultureSensitiveFormattingContext` to resolve and recognize `System.ISpanFormattable`.
- Updated formattable detection logic to treat `ISpanFormattable` like `IFormattable`, including constrained generic type parameters.
- Added test coverage for both analyzers that rely on this context:
  - `UseIFormatProviderAnalyzerTests.ToString_ISpanFormattable`
  - `DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.GenericTypeParameterConstrainedToISpanFormattable`
  - `DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.GenericTypeParameterConstrainedToTypeThatImplementsISpanFormattable`

## Notes for reviewers
- The change is intentionally narrow and does not alter existing `IFormattable` behavior; it only broadens detection to include equivalent span-formattable cases.