### PR TITLE
Fix MA0150 on sealed types inheriting ToString

### DIFF
--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -316,13 +316,18 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
         if (typeSymbol.IsAnonymousType)
             return false;
 
-        foreach (var member in typeSymbol.GetMembers(nameof(ToString)).OfType<IMethodSymbol>())
+        // Look at the whole type hierarchy, as a sealed type may inherit a ToString override from a base class.
+        // Stop before System.Object / System.ValueType, whose own ToString() is the "default" implementation this rule warns about.
+        for (var current = typeSymbol; current is not null && current.SpecialType is not (SpecialType.System_Object or SpecialType.System_ValueType); current = current.BaseType)
         {
-            if (member.Parameters.Length != 0)
-                continue;
+            foreach (var member in current.GetMembers(nameof(ToString)).OfType<IMethodSymbol>())
+            {
+                if (member.Parameters.Length != 0)
+                    continue;
 
-            if (member.IsOverride)
-                return false;
+                if (member.IsOverride)
+                    return false;
+            }
         }
 
         return true;

--- a/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
@@ -84,11 +84,7 @@ public sealed class DoNotUseToStringIfObjectAnalyzer : DiagnosticAnalyzer
             if (actualType is null)
                 return;
 
-            var targetMethod = operation.TargetMethod;
-            if (targetMethod.ContainingType is null || targetMethod.ContainingType.IsObject())
-                return;
-
-            if (actualType.IsSealed && targetMethod.IsOverride && !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, actualType))
+            if (actualType.IsSealed) // Method cannot be overridden
             {
                 context.ReportDiagnostic(Rule, operation, actualType.ToDisplayString());
             }

--- a/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
@@ -84,7 +84,11 @@ public sealed class DoNotUseToStringIfObjectAnalyzer : DiagnosticAnalyzer
             if (actualType is null)
                 return;
 
-            if (actualType.IsSealed) // Method cannot be overridden
+            var targetMethod = operation.TargetMethod;
+            if (targetMethod.ContainingType is null || targetMethod.ContainingType.IsObject())
+                return;
+
+            if (actualType.IsSealed && targetMethod.IsOverride && !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, actualType))
             {
                 context.ReportDiagnostic(Rule, operation, actualType.ToDisplayString());
             }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
@@ -30,7 +30,7 @@ o.ToString();
     {
         var sourceCode = """
 var o = new A();
-[|o.ToString()|];
+o.ToString();
 
 public struct A{ }
 """;
@@ -58,7 +58,7 @@ public sealed record A();
     {
         var sourceCode = """
 var o = new A();
-[|o.ToString()|];
+o.ToString();
 
 public sealed class A {}
 """;
@@ -86,7 +86,7 @@ public sealed class A { public override string ToString() => throw null;}
     {
         var sourceCode = """
 Sample a = new Sample();
-[|a.ToString()|];
+a.ToString();
 
 struct Sample { }
 """;
@@ -129,10 +129,25 @@ class Derived : Sample { public override string ToString() => "test"; }
     {
         var sourceCode = """
 var a = new Derived();
-[|a.ToString()|];
+a.ToString();
 
 class Sample { }
 sealed class Derived : Sample {  }
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task SealedType_InheritsBaseToStringOverride()
+    {
+        var sourceCode = """
+var a = new Derived();
+a.ToString();
+
+class Base { public override string ToString() => "test"; }
+sealed class Derived : Base { }
 """;
         await CreateProjectBuilder()
               .WithSourceCode(sourceCode)
@@ -318,7 +333,7 @@ public sealed record A();
     {
         var sourceCode = """
 var o = new A();
-_ = "" + [|o.ToString()|];
+_ = "" + o;
 
 public sealed class A {}
 """;

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
@@ -30,7 +30,7 @@ o.ToString();
     {
         var sourceCode = """
 var o = new A();
-o.ToString();
+[|o.ToString()|];
 
 public struct A{ }
 """;
@@ -58,7 +58,7 @@ public sealed record A();
     {
         var sourceCode = """
 var o = new A();
-o.ToString();
+[|o.ToString()|];
 
 public sealed class A {}
 """;
@@ -86,7 +86,7 @@ public sealed class A { public override string ToString() => throw null;}
     {
         var sourceCode = """
 Sample a = new Sample();
-a.ToString();
+[|a.ToString()|];
 
 struct Sample { }
 """;
@@ -129,7 +129,7 @@ class Derived : Sample { public override string ToString() => "test"; }
     {
         var sourceCode = """
 var a = new Derived();
-a.ToString();
+[|a.ToString()|];
 
 class Sample { }
 sealed class Derived : Sample {  }
@@ -162,6 +162,21 @@ var o = new A();
 _ = $"{[|o|]}";
 
 public sealed class A { }
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InterpolatedString_SealedType_InheritsBaseToStringOverride()
+    {
+        var sourceCode = """
+var a = new Derived();
+_ = $"{a}";
+
+class Base { public override string ToString() => "test"; }
+sealed class Derived : Base { }
 """;
         await CreateProjectBuilder()
               .WithSourceCode(sourceCode)
@@ -333,7 +348,7 @@ public sealed record A();
     {
         var sourceCode = """
 var o = new A();
-_ = "" + o;
+_ = "" + [|o.ToString()|];
 
 public sealed class A {}
 """;


### PR DESCRIPTION
MA0150 was skipping sealed types too aggressively. That caused the analyzer to report `ToString()` calls even when the sealed type inherited a valid override from a base class.

This change keeps the existing behavior for default `object.ToString()` cases, but avoids flagging sealed types when the runtime method resolves to an inherited base override. A regression test covers the sealed-derived-base override case.

Fixes: #1270