### PR TITLE
Update MA0023 guidance for named regex groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0020](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0020.md)|Performance|Use direct methods instead of LINQ methods|ℹ️|✔️|✔️|✔️|
 |[MA0021](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0021.md)|Usage|Use StringComparer.GetHashCode instead of string.GetHashCode|⚠️|✔️|✔️|❌|
 |[MA0022](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0022.md)|Design|Return Task.FromResult instead of returning null|⚠️|✔️|✔️|❌|
-|[MA0023](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0023.md)|Performance|Add RegexOptions.ExplicitCapture|⚠️|✔️|✔️|❌|
+|[MA0023](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0023.md)|Performance|Use RegexOptions.ExplicitCapture or named groups|⚠️|✔️|✔️|❌|
 |[MA0024](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0024.md)|Usage|Use an explicit StringComparer when possible|⚠️|✔️|✔️|❌|
 |[MA0025](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0025.md)|Design|Implement the functionality instead of throwing NotImplementedException|⚠️|✔️|❌|❌|
 |[MA0026](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md)|Design|Fix TODO comment|⚠️|✔️|❌|❌|

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@
 |[MA0020](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0020.md)|Performance|Use direct methods instead of LINQ methods|<span title='Info'>ℹ️</span>|✔️|✔️|<span title='MA0020.report_when_conversion_needed'>✔️</span>|
 |[MA0021](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0021.md)|Usage|Use StringComparer.GetHashCode instead of string.GetHashCode|<span title='Warning'>⚠️</span>|✔️|✔️|❌|
 |[MA0022](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0022.md)|Design|Return Task.FromResult instead of returning null|<span title='Warning'>⚠️</span>|✔️|✔️|❌|
-|[MA0023](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0023.md)|Performance|Add RegexOptions.ExplicitCapture|<span title='Warning'>⚠️</span>|✔️|✔️|❌|
+|[MA0023](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0023.md)|Performance|Use RegexOptions.ExplicitCapture or named groups|<span title='Warning'>⚠️</span>|✔️|✔️|❌|
 |[MA0024](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0024.md)|Usage|Use an explicit StringComparer when possible|<span title='Warning'>⚠️</span>|✔️|✔️|❌|
 |[MA0025](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0025.md)|Design|Implement the functionality instead of throwing NotImplementedException|<span title='Warning'>⚠️</span>|✔️|❌|❌|
 |[MA0026](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md)|Design|Fix TODO comment|<span title='Warning'>⚠️</span>|✔️|❌|❌|

--- a/docs/Rules/MA0023.md
+++ b/docs/Rules/MA0023.md
@@ -1,9 +1,9 @@
-# MA0023 - Add RegexOptions.ExplicitCapture
+# MA0023 - Use RegexOptions.ExplicitCapture or named groups
 <!-- sources -->
 Sources: [GeneratedRegexAttributeUsageAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/GeneratedRegexAttributeUsageAnalyzer.cs), [RegexMethodUsageAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/RegexMethodUsageAnalyzer.cs), [UseRegexExplicitCaptureOptionsFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexExplicitCaptureOptionsFixer.cs)
 <!-- sources -->
 
-Using named groups clarifies what is to be captured. It also makes the regex more performant, as unnamed groups will not be captured needlessly.
+Use named groups for groups that should be captured, or add `RegexOptions.ExplicitCapture` to prevent unnamed groups from being captured needlessly.
 
 ````c#
 new Regex("a(b)"); // non-compliant
@@ -14,5 +14,8 @@ new Regex("a(?<name>b)"); // ok
 private static partial Regex SampleRegex { get; }
 
 [GeneratedRegex("a(b)", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)] // ok
+private static partial Regex SampleRegex { get; }
+
+[GeneratedRegex("a(?<name>b)", RegexOptions.None, matchTimeoutMilliseconds: 1000)] // ok
 private static partial Regex SampleRegex { get; }
 ````

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -68,7 +68,7 @@ dotnet_diagnostic.MA0021.severity = error
 # MA0022: Return Task.FromResult instead of returning null
 dotnet_diagnostic.MA0022.severity = error
 
-# MA0023: Add RegexOptions.ExplicitCapture
+# MA0023: Use RegexOptions.ExplicitCapture or named groups
 dotnet_diagnostic.MA0023.severity = error
 
 # MA0024: Use an explicit StringComparer when possible

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -68,7 +68,7 @@ dotnet_diagnostic.MA0021.severity = suggestion
 # MA0022: Return Task.FromResult instead of returning null
 dotnet_diagnostic.MA0022.severity = suggestion
 
-# MA0023: Add RegexOptions.ExplicitCapture
+# MA0023: Use RegexOptions.ExplicitCapture or named groups
 dotnet_diagnostic.MA0023.severity = suggestion
 
 # MA0024: Use an explicit StringComparer when possible

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -68,7 +68,7 @@ dotnet_diagnostic.MA0021.severity = warning
 # MA0022: Return Task.FromResult instead of returning null
 dotnet_diagnostic.MA0022.severity = warning
 
-# MA0023: Add RegexOptions.ExplicitCapture
+# MA0023: Use RegexOptions.ExplicitCapture or named groups
 dotnet_diagnostic.MA0023.severity = warning
 
 # MA0024: Use an explicit StringComparer when possible

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -68,7 +68,7 @@ dotnet_diagnostic.MA0021.severity = warning
 # MA0022: Return Task.FromResult instead of returning null
 dotnet_diagnostic.MA0022.severity = warning
 
-# MA0023: Add RegexOptions.ExplicitCapture
+# MA0023: Use RegexOptions.ExplicitCapture or named groups
 dotnet_diagnostic.MA0023.severity = warning
 
 # MA0024: Use an explicit StringComparer when possible

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -68,7 +68,7 @@ dotnet_diagnostic.MA0021.severity = none
 # MA0022: Return Task.FromResult instead of returning null
 dotnet_diagnostic.MA0022.severity = none
 
-# MA0023: Add RegexOptions.ExplicitCapture
+# MA0023: Use RegexOptions.ExplicitCapture or named groups
 dotnet_diagnostic.MA0023.severity = none
 
 # MA0024: Use an explicit StringComparer when possible

--- a/src/Meziantou.Analyzer/Rules/RegexUsageAnalyzerBase.cs
+++ b/src/Meziantou.Analyzer/Rules/RegexUsageAnalyzerBase.cs
@@ -23,8 +23,8 @@ public abstract class RegexUsageAnalyzerBase : DiagnosticAnalyzer
 
     private static readonly DiagnosticDescriptor ExplicitCaptureRule = new(
         RuleIdentifiers.UseRegexExplicitCaptureOptions,
-        title: "Add RegexOptions.ExplicitCapture",
-        messageFormat: "Add RegexOptions.ExplicitCapture to prevent capturing unneeded groups",
+        title: "Use RegexOptions.ExplicitCapture or named groups",
+        messageFormat: "Use RegexOptions.ExplicitCapture or named groups to prevent capturing unneeded groups",
         RuleCategories.Performance,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,


### PR DESCRIPTION
## Summary

- Clarify MA0023 to allow named groups as an alternative to `RegexOptions.ExplicitCapture`.
- Update diagnostic text, rule documentation, README rule listings, and editorconfig descriptions.
- Add a compliant named-group example to the MA0023 documentation.

## Testing

Not run (not requested).