### PR TITLE
Add a type helper to local data-flow analysis

### DIFF
--- a/src/Meziantou.Analyzer/Internals/LocalDataFlowAnalysis.cs
+++ b/src/Meziantou.Analyzer/Internals/LocalDataFlowAnalysis.cs
@@ -1,0 +1,315 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Analyzer.Internals;
+
+internal static class LocalDataFlowAnalysis
+{
+    public static ITypeSymbol? GetActualType(this IOperation operation, CancellationToken cancellationToken)
+    {
+        operation = operation.UnwrapImplicitConversionOperations();
+
+        var value = GetFlowValue(operation, cancellationToken);
+        if (value is not null && value != operation)
+            return GetActualType(value, cancellationToken);
+
+        return operation.Type;
+    }
+
+    public static bool TryGetConstantValue(this IOperation operation, out object? value, CancellationToken cancellationToken)
+    {
+        operation = operation.UnwrapImplicitConversionOperations();
+        if (operation.ConstantValue.HasValue)
+        {
+            value = operation.ConstantValue.Value;
+            return true;
+        }
+
+        var flowValue = GetFlowValue(operation, cancellationToken);
+        if (flowValue is not null && flowValue != operation)
+            return TryGetConstantValue(flowValue, out value, cancellationToken);
+
+        value = null;
+        return false;
+    }
+
+    private static IOperation? GetFlowValue(IOperation operation, CancellationToken cancellationToken)
+    {
+        return operation switch
+        {
+            ILocalReferenceOperation localReference => GetLocalValue(localReference, cancellationToken),
+            IFieldReferenceOperation fieldReference => GetFieldValue(fieldReference, cancellationToken),
+            IPropertyReferenceOperation propertyReference => GetPropertyValue(propertyReference, cancellationToken),
+            _ => null,
+        };
+    }
+
+    private static IOperation? GetLocalValue(ILocalReferenceOperation operation, CancellationToken cancellationToken)
+    {
+        if (operation.SemanticModel is null)
+            return null;
+
+        var local = operation.Local;
+        if (IsCaptured(operation.SemanticModel, local, operation.Syntax))
+            return null;
+
+        var value = GetLastLocalAssignment(operation, local, cancellationToken);
+        if (value is not null)
+            return value;
+
+        if (GetLocalInitializer(operation.SemanticModel, local, cancellationToken) is not { } initializer)
+            return null;
+
+        return HasWriteBetween(operation.SemanticModel, local, initializer.Syntax, operation.Syntax, cancellationToken) ? null : initializer;
+    }
+
+    private static IOperation? GetLastLocalAssignment(IOperation operation, ILocalSymbol local, CancellationToken cancellationToken)
+    {
+        var semanticModel = operation.SemanticModel;
+        if (semanticModel is null)
+            return null;
+
+        IOperation? result = null;
+        foreach (var assignmentSyntax in operation.Syntax.SyntaxTree.GetRoot(cancellationToken).DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignmentSyntax.Span.End > operation.Syntax.SpanStart)
+                continue;
+
+            if (IsInNestedFunction(assignmentSyntax))
+                continue;
+
+            if (semanticModel.GetOperation(assignmentSyntax, cancellationToken) is not ISimpleAssignmentOperation assignment)
+                continue;
+
+            if (assignment.Target.UnwrapImplicitConversionOperations() is not ILocalReferenceOperation localReference || !localReference.Local.IsEqualTo(local))
+                continue;
+
+            if (result is null || assignment.Syntax.SpanStart > result.Syntax.SpanStart)
+            {
+                result = assignment.Value;
+            }
+        }
+
+        if (result is null)
+            return null;
+
+        return HasWriteBetween(semanticModel, local, result.Syntax, operation.Syntax, cancellationToken) ? null : result;
+    }
+
+    private static IOperation? GetLocalInitializer(SemanticModel semanticModel, ILocalSymbol local, CancellationToken cancellationToken)
+    {
+        foreach (var syntaxReference in local.DeclaringSyntaxReferences)
+        {
+            if (syntaxReference.GetSyntax(cancellationToken) is VariableDeclaratorSyntax { Initializer.Value: { } value })
+                return semanticModel.GetOperation(value, cancellationToken);
+        }
+
+        return null;
+    }
+
+    private static IOperation? GetFieldValue(IFieldReferenceOperation operation, CancellationToken cancellationToken)
+    {
+        var semanticModel = operation.SemanticModel;
+        if (semanticModel is null)
+            return null;
+
+        var field = operation.Field;
+        if (!field.IsReadOnly || field.DeclaredAccessibility is not Accessibility.Private)
+            return null;
+
+        foreach (var syntaxReference in field.DeclaringSyntaxReferences)
+        {
+            if (syntaxReference.GetSyntax(cancellationToken) is not VariableDeclaratorSyntax { Initializer.Value: { } value })
+                continue;
+
+            if (HasAssignmentOutsideInitializer(semanticModel, field, value, cancellationToken))
+                return null;
+
+            return semanticModel.GetOperation(value, cancellationToken);
+        }
+
+        return null;
+    }
+
+    private static IOperation? GetPropertyValue(IPropertyReferenceOperation operation, CancellationToken cancellationToken)
+    {
+        var semanticModel = operation.SemanticModel;
+        if (semanticModel is null)
+            return null;
+
+        var property = operation.Property;
+        if (property.SetMethod is not null || property.DeclaredAccessibility is not Accessibility.Private)
+            return null;
+
+        foreach (var syntaxReference in property.DeclaringSyntaxReferences)
+        {
+            if (syntaxReference.GetSyntax(cancellationToken) is not PropertyDeclarationSyntax { Initializer.Value: { } value })
+                continue;
+
+            if (HasAssignmentOutsideInitializer(semanticModel, property, value, cancellationToken))
+                return null;
+
+            return semanticModel.GetOperation(value, cancellationToken);
+        }
+
+        return null;
+    }
+
+    private static bool HasAssignmentOutsideInitializer(SemanticModel semanticModel, ISymbol symbol, ExpressionSyntax initializer, CancellationToken cancellationToken)
+    {
+        foreach (var syntaxReference in symbol.ContainingType.DeclaringSyntaxReferences)
+        {
+            if (syntaxReference.GetSyntax(cancellationToken) is not TypeDeclarationSyntax typeDeclaration)
+                continue;
+
+            foreach (var assignment in typeDeclaration.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+            {
+                if (initializer.Span.Contains(assignment.Span))
+                    continue;
+
+                var targetSymbol = semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol;
+                if (targetSymbol.IsEqualTo(symbol))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCaptured(SemanticModel semanticModel, ISymbol local, SyntaxNode syntax)
+    {
+        var statement = syntax.FirstAncestorOrSelf<StatementSyntax>();
+        if (statement is null)
+            return false;
+
+        var dataFlow = semanticModel.AnalyzeDataFlow(statement);
+        return dataFlow?.Succeeded == true && ContainsSymbol(dataFlow.Captured, local);
+    }
+
+    private static bool HasWriteBetween(SemanticModel semanticModel, ISymbol symbol, SyntaxNode source, SyntaxNode destination, CancellationToken cancellationToken)
+    {
+        if (!TryGetStatementRange(source, destination, out var firstStatement, out var lastStatement))
+            return true;
+
+        if (firstStatement is null || lastStatement is null)
+            return false;
+
+        if (firstStatement is not StatementSyntax || lastStatement is not StatementSyntax)
+            return HasWriteBetweenBySyntax(semanticModel, symbol, source, destination, cancellationToken);
+
+        var dataFlow = semanticModel.AnalyzeDataFlow(firstStatement, lastStatement);
+        if (dataFlow?.Succeeded != true)
+            return true;
+
+        return ContainsSymbol(dataFlow.WrittenInside, symbol) ||
+            ContainsSymbol(dataFlow.UnsafeAddressTaken, symbol) ||
+            ContainsSymbol(dataFlow.Captured, symbol);
+    }
+
+    private static bool HasWriteBetweenBySyntax(SemanticModel semanticModel, ISymbol symbol, SyntaxNode source, SyntaxNode destination, CancellationToken cancellationToken)
+    {
+        var sourceEnd = source.Span.End;
+        var destinationStart = destination.SpanStart;
+        foreach (var assignment in destination.SyntaxTree.GetRoot(cancellationToken).DescendantNodes())
+        {
+            if (assignment.SpanStart < sourceEnd || assignment.Span.End > destinationStart)
+                continue;
+
+            SyntaxNode? target = assignment switch
+            {
+                AssignmentExpressionSyntax assignmentExpression => assignmentExpression.Left,
+                PrefixUnaryExpressionSyntax prefixUnaryExpression
+                    when prefixUnaryExpression.IsKind(SyntaxKind.PreIncrementExpression) || prefixUnaryExpression.IsKind(SyntaxKind.PreDecrementExpression) => prefixUnaryExpression.Operand,
+                PostfixUnaryExpressionSyntax postfixUnaryExpression
+                    when postfixUnaryExpression.IsKind(SyntaxKind.PostIncrementExpression) || postfixUnaryExpression.IsKind(SyntaxKind.PostDecrementExpression) => postfixUnaryExpression.Operand,
+                _ => null,
+            };
+
+            if (target is null)
+                continue;
+
+            var targetSymbol = semanticModel.GetSymbolInfo(target, cancellationToken).Symbol;
+            if (targetSymbol.IsEqualTo(symbol))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetStatementRange(SyntaxNode source, SyntaxNode destination, out SyntaxNode? firstStatement, out SyntaxNode? lastStatement)
+    {
+        firstStatement = null;
+        lastStatement = null;
+
+        var sourceStatement = source.FirstAncestorOrSelf<StatementSyntax>();
+        var destinationStatement = destination.FirstAncestorOrSelf<StatementSyntax>();
+        if (sourceStatement is null || destinationStatement is null)
+            return false;
+
+        if (sourceStatement == destinationStatement)
+            return true;
+
+        if (sourceStatement.Parent is not BlockSyntax sourceBlock || destinationStatement.Parent is not BlockSyntax destinationBlock || sourceBlock != destinationBlock)
+        {
+            return TryGetGlobalStatementRange(sourceStatement, destinationStatement, out firstStatement, out lastStatement);
+        }
+
+        var sourceIndex = sourceBlock.Statements.IndexOf(sourceStatement);
+        var destinationIndex = sourceBlock.Statements.IndexOf(destinationStatement);
+        if (sourceIndex < 0 || destinationIndex < 0 || sourceIndex > destinationIndex)
+            return false;
+
+        if (sourceIndex + 1 >= destinationIndex)
+            return true;
+
+        firstStatement = sourceBlock.Statements[sourceIndex + 1];
+        lastStatement = sourceBlock.Statements[destinationIndex - 1];
+        return true;
+    }
+
+    private static bool TryGetGlobalStatementRange(StatementSyntax sourceStatement, StatementSyntax destinationStatement, out SyntaxNode? firstStatement, out SyntaxNode? lastStatement)
+    {
+        firstStatement = null;
+        lastStatement = null;
+
+        if (sourceStatement.Parent is not GlobalStatementSyntax sourceGlobalStatement ||
+            destinationStatement.Parent is not GlobalStatementSyntax destinationGlobalStatement ||
+            sourceGlobalStatement.Parent is not CompilationUnitSyntax sourceCompilationUnit ||
+            destinationGlobalStatement.Parent is not CompilationUnitSyntax destinationCompilationUnit ||
+            sourceCompilationUnit != destinationCompilationUnit)
+        {
+            return false;
+        }
+
+        var sourceIndex = sourceCompilationUnit.Members.IndexOf(sourceGlobalStatement);
+        var destinationIndex = sourceCompilationUnit.Members.IndexOf(destinationGlobalStatement);
+        if (sourceIndex < 0 || destinationIndex < 0 || sourceIndex > destinationIndex)
+            return false;
+
+        if (sourceIndex + 1 >= destinationIndex)
+            return true;
+
+        firstStatement = sourceCompilationUnit.Members[sourceIndex + 1];
+        lastStatement = sourceCompilationUnit.Members[destinationIndex - 1];
+        return true;
+    }
+
+    private static bool IsInNestedFunction(SyntaxNode syntax)
+    {
+        return syntax.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>() is not null ||
+            syntax.FirstAncestorOrSelf<LocalFunctionStatementSyntax>() is not null;
+    }
+
+    private static bool ContainsSymbol(IEnumerable<ISymbol> symbols, ISymbol symbol)
+    {
+        foreach (var candidate in symbols)
+        {
+            if (candidate.IsEqualTo(symbol))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/DoNotRaiseApplicationExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotRaiseApplicationExceptionAnalyzer.cs
@@ -42,7 +42,7 @@ public sealed class DoNotRaiseApplicationExceptionAnalyzer : DiagnosticAnalyzer
         if (operation is null || operation.Exception is null)
             return;
 
-        var exceptionType = operation.Exception.GetActualType();
+        var exceptionType = operation.Exception.GetActualType(context.CancellationToken);
         if (exceptionType.IsEqualTo(reservedExceptionType))
         {
             context.ReportDiagnostic(Rule, operation);

--- a/src/Meziantou.Analyzer/Rules/DoNotRaiseNotImplementedExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotRaiseNotImplementedExceptionAnalyzer.cs
@@ -44,7 +44,7 @@ public sealed class DoNotRaiseNotImplementedExceptionAnalyzer : DiagnosticAnalyz
         if (operation is null || operation.Exception is null)
             return;
 
-        var exceptionType = operation.Exception.GetActualType();
+        var exceptionType = operation.Exception.GetActualType(context.CancellationToken);
         if (exceptionType.IsEqualTo(reservedExceptionType))
         {
             context.ReportDiagnostic(Rule, operation);

--- a/src/Meziantou.Analyzer/Rules/DoNotRaiseReservedExceptionTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotRaiseReservedExceptionTypeAnalyzer.cs
@@ -54,7 +54,7 @@ public sealed class DoNotRaiseReservedExceptionTypeAnalyzer : DiagnosticAnalyzer
         if (operation is null || operation.Exception is null)
             return;
 
-        var exceptionType = operation.Exception.GetActualType();
+        var exceptionType = operation.Exception.GetActualType(context.CancellationToken);
         if (exceptionType is null)
             return;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -192,14 +192,14 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
                 return;
 
             var sqliteSpecialCasesEnabled = IsSqliteSpecialCasesEnabled(context, operation);
-            var isSqliteSpecialCaseMethod = IsSqliteSpecialCaseMethod(operation);
+            var isSqliteSpecialCaseMethod = IsSqliteSpecialCaseMethod(operation, context.CancellationToken);
 
             // The cache only contains methods with no async equivalent methods.
             // This optimizes the best-case scenario where code is correctly written according to this analyzer.
             if (!isSqliteSpecialCaseMethod && _symbolsWithNoAsyncOverloads.Contains(targetMethod))
                 return;
 
-            if (HasAsyncEquivalent(operation, sqliteSpecialCasesEnabled, out var diagnosticMessage))
+            if (HasAsyncEquivalent(operation, sqliteSpecialCasesEnabled, context.CancellationToken, out var diagnosticMessage))
             {
                 ReportDiagnosticIfNeeded(context, diagnosticMessage.CreateProperties(), operation, diagnosticMessage.DiagnosticMessage);
             }
@@ -209,7 +209,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             }
         }
 
-        private bool HasAsyncEquivalent(IInvocationOperation operation, bool sqliteSpecialCasesEnabled, [NotNullWhen(true)] out DiagnosticData? data)
+        private bool HasAsyncEquivalent(IInvocationOperation operation, bool sqliteSpecialCasesEnabled, CancellationToken cancellationToken, [NotNullWhen(true)] out DiagnosticData? data)
         {
             data = null;
             var targetMethod = operation.TargetMethod;
@@ -295,7 +295,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             // Async APIs in Microsoft.Data.Sqlite have documented limitations.
             // Ignore any invocation on SqliteConnection, SqliteCommand, or SqliteDataReader by default.
             // https://learn.microsoft.com/en-us/dotnet/standard/data/sqlite/async
-            else if (sqliteSpecialCasesEnabled && IsSqliteSpecialCaseMethod(operation))
+            else if (sqliteSpecialCasesEnabled && IsSqliteSpecialCaseMethod(operation, cancellationToken))
             {
                 return false;
             }
@@ -306,7 +306,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             }
 
             // SemaphoreSlim.Wait(0) is a non-blocking try-acquire pattern, skip it
-            else if (SemaphoreSlimSymbol is not null && targetMethod.Name == "Wait" && targetMethod.ContainingType.IsEqualTo(SemaphoreSlimSymbol) && IsSemaphoreSlimWaitWithZeroTimeout(operation))
+            else if (SemaphoreSlimSymbol is not null && targetMethod.Name == "Wait" && targetMethod.ContainingType.IsEqualTo(SemaphoreSlimSymbol) && IsSemaphoreSlimWaitWithZeroTimeout(operation, cancellationToken))
             {
                 return false;
             }
@@ -484,7 +484,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             return type.IsEqualToAny(SqliteConnectionSymbol, SqliteCommandSymbol, SqliteDataReaderSymbol);
         }
 
-        private bool IsSqliteSpecialCaseMethod(IInvocationOperation operation)
+        private bool IsSqliteSpecialCaseMethod(IInvocationOperation operation, CancellationToken cancellationToken)
         {
             if (IsSqliteSpecialCaseType(operation.TargetMethod.ContainingType))
                 return true;
@@ -495,7 +495,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             if (operation.TargetMethod.IsStatic)
                 return false;
 
-            if (operation.Instance?.GetActualType() is not INamedTypeSymbol type)
+            if (operation.Instance?.GetActualType(cancellationToken) is not INamedTypeSymbol type)
                 return false;
 
             return IsSqliteSpecialCaseType(type);
@@ -550,16 +550,14 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             return true;
         }
 
-        private bool IsSemaphoreSlimWaitWithZeroTimeout(IInvocationOperation operation)
+        private bool IsSemaphoreSlimWaitWithZeroTimeout(IInvocationOperation operation, CancellationToken cancellationToken)
         {
             if (operation.Arguments.Length == 0)
                 return false;
 
             var firstArgument = operation.Arguments[0];
-            var constantValue = firstArgument.Value.ConstantValue;
-
             // Check for Wait(0) - integer literal 0
-            if (constantValue.HasValue && constantValue.Value is int intValue && intValue == 0)
+            if (firstArgument.Value.TryGetConstantValue(out var constantValue, cancellationToken) && constantValue is int intValue && intValue == 0)
                 return true;
 
             // Check for Wait(TimeSpan.Zero)
@@ -698,16 +696,16 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             return false;
         }
 
-        private bool CanBeAwaitUsing(IOperation operation, bool sqliteSpecialCasesEnabled, bool dbSpecialCasesEnabled)
+        private bool CanBeAwaitUsing(IOperation operation, bool sqliteSpecialCasesEnabled, bool dbSpecialCasesEnabled, CancellationToken cancellationToken)
         {
             var unwrappedOperation = operation.UnwrapImplicitConversionOperations();
             if (unwrappedOperation is IInvocationOperation invocationOperation)
             {
-                if (sqliteSpecialCasesEnabled && IsSqliteSpecialCaseMethod(invocationOperation))
+                if (sqliteSpecialCasesEnabled && IsSqliteSpecialCaseMethod(invocationOperation, cancellationToken))
                     return false;
             }
 
-            if (operation.GetActualType() is not INamedTypeSymbol type)
+            if (operation.GetActualType(cancellationToken) is not INamedTypeSymbol type)
                 return false;
 
             if (IsNonAsyncDisposableType(type))
@@ -794,7 +792,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             {
                 if ((declaration.Initializer?.Value) is not null)
                 {
-                    if (CanBeAwaitUsing(declaration.Initializer.Value, sqliteSpecialCasesEnabled, dbSpecialCasesEnabled))
+                    if (CanBeAwaitUsing(declaration.Initializer.Value, sqliteSpecialCasesEnabled, dbSpecialCasesEnabled, context.CancellationToken))
                     {
                         var data = new DiagnosticData("Prefer using 'await using'", DoNotUseBlockingCallInAsyncContextData.Using);
                         ReportDiagnosticIfNeeded(context, data.CreateProperties(), usingOperation, data.DiagnosticMessage);
@@ -804,7 +802,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
 
                 foreach (var declarator in declaration.Declarators)
                 {
-                    if (declarator.Initializer is not null && CanBeAwaitUsing(declarator.Initializer.Value, sqliteSpecialCasesEnabled, dbSpecialCasesEnabled))
+                    if (declarator.Initializer is not null && CanBeAwaitUsing(declarator.Initializer.Value, sqliteSpecialCasesEnabled, dbSpecialCasesEnabled, context.CancellationToken))
                     {
                         var data = new DiagnosticData("Prefer using 'await using'", DoNotUseBlockingCallInAsyncContextData.UsingDeclarator);
                         ReportDiagnosticIfNeeded(context, data.CreateProperties(), usingOperation, data.DiagnosticMessage);
@@ -830,7 +828,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
                     return;
             }
 
-            if (CanBeAwaitUsing(operation.Resources, sqliteSpecialCasesEnabled, dbSpecialCasesEnabled))
+            if (CanBeAwaitUsing(operation.Resources, sqliteSpecialCasesEnabled, dbSpecialCasesEnabled, context.CancellationToken))
             {
                 var data = new DiagnosticData("Prefer using 'await using'", DoNotUseBlockingCallInAsyncContextData.Using);
                 ReportDiagnosticIfNeeded(context, data.CreateProperties(), operation, data.DiagnosticMessage);

--- a/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
@@ -90,7 +90,7 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
 
             if (operation.TargetMethod.Name == nameof(ValueType.GetHashCode))
             {
-                var actualType = operation.GetChildOperations().FirstOrDefault()?.GetActualType();
+                var actualType = operation.GetChildOperations().FirstOrDefault()?.GetActualType(context.CancellationToken);
                 if (actualType is null)
                     return;
 
@@ -101,7 +101,7 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
             }
             else if (operation.TargetMethod.Name == nameof(ValueType.Equals))
             {
-                var actualType = operation.GetChildOperations().FirstOrDefault()?.GetActualType();
+                var actualType = operation.GetChildOperations().FirstOrDefault()?.GetActualType(context.CancellationToken);
                 if (actualType is null)
                     return;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
@@ -53,7 +53,7 @@ public sealed class DoNotUseToStringIfObjectAnalyzer : DiagnosticAnalyzer
             {
                 if (part is IInterpolationOperation content)
                 {
-                    AnalyzeExpression(context, content.Expression);
+                    AnalyzeExpression(context, content.Expression, context.CancellationToken);
                 }
                 else if (part is IInterpolatedStringAppendOperation { AppendCall: IInvocationOperation appendCall })
                 {
@@ -63,7 +63,7 @@ public sealed class DoNotUseToStringIfObjectAnalyzer : DiagnosticAnalyzer
                     if (appendCall.Arguments is not [{ Value: var content2 }])
                         continue;
 
-                    AnalyzeExpression(context, content2);
+                    AnalyzeExpression(context, content2, context.CancellationToken);
                 }
             }
         }
@@ -80,7 +80,7 @@ public sealed class DoNotUseToStringIfObjectAnalyzer : DiagnosticAnalyzer
             if (operation.Instance is null)
                 return;
 
-            var actualType = operation.Instance.GetActualType();
+            var actualType = operation.Instance.GetActualType(context.CancellationToken);
             if (actualType is null)
                 return;
 
@@ -96,13 +96,13 @@ public sealed class DoNotUseToStringIfObjectAnalyzer : DiagnosticAnalyzer
             if (!operation.Type.IsString())
                 return;
 
-            AnalyzeExpression(context, operation.LeftOperand);
-            AnalyzeExpression(context, operation.RightOperand);
+            AnalyzeExpression(context, operation.LeftOperand, context.CancellationToken);
+            AnalyzeExpression(context, operation.RightOperand, context.CancellationToken);
         }
 
-        private static void AnalyzeExpression(DiagnosticReporter reporter, IOperation operation)
+        private static void AnalyzeExpression(DiagnosticReporter reporter, IOperation operation, CancellationToken cancellationToken)
         {
-            var actualType = operation.UnwrapImplicitConversionOperations().Type;
+            var actualType = operation.GetActualType(cancellationToken);
             if (actualType is null)
                 return;
 

--- a/src/Meziantou.Analyzer/Rules/JSInteropMustNotBeUsedInOnInitializedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/JSInteropMustNotBeUsedInOnInitializedAnalyzer.cs
@@ -100,7 +100,7 @@ public sealed class JSInteropMustNotBeUsedInOnInitializedAnalyzer : DiagnosticAn
                     return;
             }
 
-            var type = instance.GetActualType();
+            var type = instance.GetActualType(context.CancellationToken);
             if (type is null)
                 return;
 

--- a/src/Meziantou.Analyzer/Rules/ObjectGetTypeOnTypeInstanceAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ObjectGetTypeOnTypeInstanceAnalyzer.cs
@@ -37,7 +37,7 @@ public sealed class ObjectGetTypeOnTypeInstanceAnalyzer : DiagnosticAnalyzer
                 var operation = (IInvocationOperation)context.Operation;
                 if (operation.Instance is not null && operation.TargetMethod.Name == "GetType" && operation.TargetMethod.ContainingType.IsObject())
                 {
-                    var instanceType = operation.Instance.GetActualType();
+                    var instanceType = operation.Instance.GetActualType(context.CancellationToken);
                     if (instanceType is null)
                         return;
 

--- a/src/Meziantou.Analyzer/Rules/OptimizeGuidCreationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeGuidCreationAnalyzer.cs
@@ -46,9 +46,7 @@ public sealed class OptimizeGuidCreationAnalyzer : DiagnosticAnalyzer
         if (!creation.Constructor.ContainingType.IsEqualTo(type))
             return;
 
-        if (creation.Arguments is [{ Value: { Type.SpecialType: SpecialType.System_String } argumentValue }] &&
-            argumentValue.TryGetConstantValue(out var constantValue, symbolContext.CancellationToken) &&
-            constantValue is string value)
+        if (creation.Arguments is [{ Value.Type.SpecialType: SpecialType.System_String, Value.ConstantValue: { HasValue: true, Value: string value } }])
         {
             if (Guid.TryParse(value, out _))
             {
@@ -63,9 +61,7 @@ public sealed class OptimizeGuidCreationAnalyzer : DiagnosticAnalyzer
         if (!invocation.TargetMethod.ContainingType.IsEqualTo(guidType))
             return;
 
-        if (invocation is { TargetMethod.Name: "Parse", Arguments: [{ Value: { Type.SpecialType: SpecialType.System_String } argumentValue }] } &&
-            argumentValue.TryGetConstantValue(out var constantValue, context.CancellationToken) &&
-            constantValue is string value)
+        if (invocation is { TargetMethod.Name: "Parse", Arguments: [{ Value.Type.SpecialType: SpecialType.System_String, Value.ConstantValue: { HasValue: true, Value: string value } }] })
         {
             if (Guid.TryParse(value, out _))
             {

--- a/src/Meziantou.Analyzer/Rules/OptimizeGuidCreationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeGuidCreationAnalyzer.cs
@@ -46,7 +46,9 @@ public sealed class OptimizeGuidCreationAnalyzer : DiagnosticAnalyzer
         if (!creation.Constructor.ContainingType.IsEqualTo(type))
             return;
 
-        if (creation is { Arguments: [{ Value.Type.SpecialType: SpecialType.System_String, Value.ConstantValue: { HasValue: true, Value: string value } }] })
+        if (creation.Arguments is [{ Value: { Type.SpecialType: SpecialType.System_String } argumentValue }] &&
+            argumentValue.TryGetConstantValue(out var constantValue, symbolContext.CancellationToken) &&
+            constantValue is string value)
         {
             if (Guid.TryParse(value, out _))
             {
@@ -61,7 +63,9 @@ public sealed class OptimizeGuidCreationAnalyzer : DiagnosticAnalyzer
         if (!invocation.TargetMethod.ContainingType.IsEqualTo(guidType))
             return;
 
-        if (invocation is { TargetMethod.Name: "Parse", Arguments: [{ Value.Type.SpecialType: SpecialType.System_String, Value.ConstantValue: { HasValue: true, Value: string value } }] })
+        if (invocation is { TargetMethod.Name: "Parse", Arguments: [{ Value: { Type.SpecialType: SpecialType.System_String } argumentValue }] } &&
+            argumentValue.TryGetConstantValue(out var constantValue, context.CancellationToken) &&
+            constantValue is string value)
         {
             if (Guid.TryParse(value, out _))
             {

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -257,7 +257,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 if (ICollectionOfTSymbol is null && IReadOnlyCollectionOfTSymbol is null)
                     return;
 
-                var actualType = operation.Arguments[0].Value.GetActualType();
+                var actualType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
                 if (actualType is null)
                     return;
 
@@ -295,7 +295,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             }
             else if (operation.TargetMethod.Name == nameof(Enumerable.LongCount))
             {
-                var actualType = operation.Arguments[0].Value.GetActualType();
+                var actualType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
                 if (actualType is not null && actualType.TypeKind == TypeKind.Array)
                 {
                     var properties = CreateProperties(OptimizeLinqUsageData.UseLongLengthProperty);
@@ -312,7 +312,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (operation.Arguments.Length != 2)
                 return;
 
-            var firstArgumentType = operation.Arguments[0].Value.GetActualType();
+            var firstArgumentType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
             if (firstArgumentType is null)
                 return;
 
@@ -348,7 +348,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (operation.Arguments.Length != 2)
                 return;
 
-            var firstArgumentType = operation.Arguments[0].Value.GetActualType();
+            var firstArgumentType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
             if (firstArgumentType is null)
                 return;
 
@@ -380,7 +380,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (operation.Arguments.Length != 2)
                 return;
 
-            var firstArgumentType = operation.Arguments[0].Value.GetActualType();
+            var firstArgumentType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
             if (firstArgumentType is null)
                 return;
 
@@ -434,7 +434,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (IListOfTSymbol is null && IReadOnlyListOfTSymbol is null)
                 return;
 
-            var actualType = operation.Arguments[0].Value.GetActualType();
+            var actualType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
             if (actualType is null)
                 return;
 
@@ -869,14 +869,14 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             var castType = castOp.Type.ToMinimalDisplayString(semanticModel, nullableFlowState, operation.Syntax.SpanStart);
             context.ReportDiagnostic(OptimizeLinqUsageAnalyzer.UseCastInsteadOfSelect, properties, operation, DiagnosticInvocationReportOptions.ReportOnMember, castType);
 
-            static bool CanReplaceByCast(IConversionOperation op)
+            bool CanReplaceByCast(IConversionOperation op)
             {
                 if (op.Conversion.IsUserDefined || op.Conversion.IsNumeric)
                     return false;
 
                 // Handle enums: source.Select<MyEnum, byte>(item => (byte)item);
                 // Using Cast<T> is only possible when the enum underlying type is the same as the conversion type
-                var operandActualType = op.Operand.GetActualType();
+                var operandActualType = op.Operand.GetActualType(context.CancellationToken);
                 var enumerationType = operandActualType.GetEnumType();
                 if (enumerationType is not null)
                 {
@@ -896,7 +896,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 if (operation.Arguments.Length >= 2)
                     return;
 
-                var operandType = operation.Arguments[0].Value.GetActualType();
+                var operandType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
                 if (operandType is null)
                     return;
 

--- a/src/Meziantou.Analyzer/Rules/RegexUsageAnalyzerBase.cs
+++ b/src/Meziantou.Analyzer/Rules/RegexUsageAnalyzerBase.cs
@@ -150,7 +150,7 @@ public abstract class RegexUsageAnalyzerBase : DiagnosticAnalyzer
                 if (patternArgumentIndex < arguments.Length)
                 {
                     var argument = arguments[patternArgumentIndex];
-                    if (argument.Value is not null && argument.Value.ConstantValue.HasValue && argument.Value.ConstantValue.Value is string pattern)
+                    if (argument.Value is not null && argument.Value.TryGetConstantValue(out var value, context.CancellationToken) && value is string pattern)
                         return pattern;
                 }
 
@@ -163,10 +163,10 @@ public abstract class RegexUsageAnalyzerBase : DiagnosticAnalyzer
                     return (null, null);
 
                 var arg = arguments.FirstOrDefault(a => a.Parameter is not null && a.Parameter.Type.IsEqualTo(regexOptionsSymbol));
-                if (arg is null || arg.Value is null || !arg.Value.ConstantValue.HasValue)
+                if (arg is null || arg.Value is null || !arg.Value.TryGetConstantValue(out var value, context.CancellationToken))
                     return (null, arg);
 
-                return ((RegexOptions)arg.Value.ConstantValue.Value!, arg);
+                return ((RegexOptions)value!, arg);
             }
         }
 

--- a/src/Meziantou.Analyzer/Rules/StringFormatShouldBeConstantAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/StringFormatShouldBeConstantAnalyzer.cs
@@ -99,7 +99,7 @@ public sealed class StringFormatShouldBeConstantAnalyzer : DiagnosticAnalyzer
         }
 
         // Case 2: Has formatting arguments but constant format string has no placeholders
-        if (formatArgument.Value.ConstantValue.HasValue && formatArgument.Value.ConstantValue.Value is string formatString)
+        if (formatArgument.Value.TryGetConstantValue(out var constantValue, context.CancellationToken) && constantValue is string formatString)
         {
             if (!HasPlaceholders(formatString))
             {

--- a/src/Meziantou.Analyzer/Rules/ThrowIfNullWithNonNullableInstanceAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ThrowIfNullWithNonNullableInstanceAnalyzer.cs
@@ -49,7 +49,7 @@ public sealed class ThrowIfNullWithNonNullableInstanceAnalyzer : DiagnosticAnaly
                     return;
 
                 var instance = operation.Arguments[0].Value;
-                var type = instance.GetActualType();
+                var type = instance.GetActualType(context.CancellationToken);
                 if (type is null)
                     return;
 

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
@@ -186,7 +186,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
             if (!op.IsAsynchronous)
                 return;
 
-            var collectionType = op.Collection.GetActualType();
+            var collectionType = op.Collection.GetActualType(context.CancellationToken);
             if (collectionType.IsEqualTo(ConfiguredCancelableAsyncEnumerableSymbol))
                 return;
 

--- a/src/Meziantou.Analyzer/Rules/UseArrayEmptyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseArrayEmptyAnalyzer.cs
@@ -45,7 +45,7 @@ public sealed class UseArrayEmptyAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeArrayCreationOperation(OperationAnalysisContext context)
     {
         var operation = (IArrayCreationOperation)context.Operation;
-        if (IsZeroLengthArrayCreation(operation))
+        if (IsZeroLengthArrayCreation(operation, context.CancellationToken))
         {
             // Cannot use Array.Empty<T>() as an attribute parameter
             if (IsInAttribute(operation))
@@ -58,13 +58,12 @@ public sealed class UseArrayEmptyAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool IsZeroLengthArrayCreation(IArrayCreationOperation operation)
+    private static bool IsZeroLengthArrayCreation(IArrayCreationOperation operation, CancellationToken cancellationToken)
     {
         if (operation.DimensionSizes.Length != 1)
             return false;
 
-        var dimensionSize = operation.DimensionSizes[0].ConstantValue;
-        return dimensionSize.HasValue && IsZero(dimensionSize.Value);
+        return operation.DimensionSizes[0].TryGetConstantValue(out var dimensionSize, cancellationToken) && IsZero(dimensionSize);
 
         static bool IsZero(object? value)
         {

--- a/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
@@ -90,7 +90,7 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
                 return;
 
             // ConfiguredCancelableAsyncEnumerable
-            var collectionType = operation.Collection.GetActualType();
+            var collectionType = operation.Collection.GetActualType(context.CancellationToken);
             if (collectionType is null)
                 return;
 
@@ -196,7 +196,7 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
                         continue;
 
                     // ConfiguredCancelableAsyncEnumerable
-                    var variableType = declarator.Initializer.Value.GetActualType();
+                    var variableType = declarator.Initializer.Value.GetActualType(context.CancellationToken);
                     if (variableType is null || variableType.IsEqualTo(ConfiguredAsyncDisposableSymbol))
                         return;
 

--- a/src/Meziantou.Analyzer/Rules/UseDateTimeUnixEpochAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseDateTimeUnixEpochAnalyzer.cs
@@ -65,7 +65,7 @@ public sealed class UseDateTimeUnixEpochAnalyzer : DiagnosticAnalyzer
         public void AnalyzeDateTimeObjectCreation(OperationAnalysisContext context)
         {
             var operation = (IObjectCreationOperation)context.Operation;
-            if (IsDateTimeUnixEpoch(operation))
+            if (IsDateTimeUnixEpoch(operation, context.CancellationToken))
             {
                 context.ReportDiagnostic(DateTimeRule, operation);
             }
@@ -86,7 +86,7 @@ public sealed class UseDateTimeUnixEpochAnalyzer : DiagnosticAnalyzer
 
                 if (operation.Arguments.Length == 1)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(), [621355968000000000L]))
+                    if (ArgumentsEquals(operation.Arguments.AsSpan(), [621355968000000000L], context.CancellationToken))
                         return true;
 
                     if (IsUnixEpochProperty(operation.Arguments[0]))
@@ -94,7 +94,7 @@ public sealed class UseDateTimeUnixEpochAnalyzer : DiagnosticAnalyzer
                 }
                 else if (operation.Arguments.Length == 2)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 1), [621355968000000000L]) && IsTimeSpanZero(operation.Arguments[1]))
+                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 1), [621355968000000000L], context.CancellationToken) && IsTimeSpanZero(operation.Arguments[1]))
                         return true;
 
                     if (IsUnixEpochProperty(operation.Arguments[0]) && IsTimeSpanZero(operation.Arguments[1]))
@@ -102,17 +102,17 @@ public sealed class UseDateTimeUnixEpochAnalyzer : DiagnosticAnalyzer
                 }
                 else if (operation.Arguments.Length == 7)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 6), [1970, 1, 1, 0, 0, 0]) && IsTimeSpanZero(operation.Arguments[6]))
+                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 6), [1970, 1, 1, 0, 0, 0], context.CancellationToken) && IsTimeSpanZero(operation.Arguments[6]))
                         return true;
                 }
                 else if (operation.Arguments.Length == 8)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 7), [1970, 1, 1, 0, 0, 0, 0]) && IsTimeSpanZero(operation.Arguments[7]))
+                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 7), [1970, 1, 1, 0, 0, 0, 0], context.CancellationToken) && IsTimeSpanZero(operation.Arguments[7]))
                         return true;
                 }
                 else if (operation.Arguments.Length == 9)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 8), [1970, 1, 1, 0, 0, 0, 0, 0]) && IsTimeSpanZero(operation.Arguments[8]))
+                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 8), [1970, 1, 1, 0, 0, 0, 0, 0], context.CancellationToken) && IsTimeSpanZero(operation.Arguments[8]))
                         return true;
                 }
 
@@ -131,57 +131,57 @@ public sealed class UseDateTimeUnixEpochAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        private bool IsDateTimeUnixEpoch(IObjectCreationOperation operation)
+        private bool IsDateTimeUnixEpoch(IObjectCreationOperation operation, CancellationToken cancellationToken)
         {
             if (!operation.Type.IsEqualTo(_dateTimeSymbol))
                 return false;
 
             if (operation.Arguments.Length == 1)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(), [621355968000000000L]))
+                if (ArgumentsEquals(operation.Arguments.AsSpan(), [621355968000000000L], cancellationToken))
                     return true;
             }
             else if (operation.Arguments.Length == 2)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(0, 1), [621355968000000000L]) && IsDateTimeKindUtc(operation.Arguments[1]))
+                if (ArgumentsEquals(operation.Arguments.AsSpan(0, 1), [621355968000000000L], cancellationToken) && IsDateTimeKindUtc(operation.Arguments[1], cancellationToken))
                     return true;
             }
             else if (operation.Arguments.Length == 3)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(), [1970, 1, 1]))
+                if (ArgumentsEquals(operation.Arguments.AsSpan(), [1970, 1, 1], cancellationToken))
                     return true;
             }
             else if (operation.Arguments.Length == 6)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(), [1970, 1, 1, 0, 0, 0]))
+                if (ArgumentsEquals(operation.Arguments.AsSpan(), [1970, 1, 1, 0, 0, 0], cancellationToken))
                     return true;
             }
             else if (operation.Arguments.Length == 7)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(0, 6), [1970, 1, 1, 0, 0, 0]) && IsDateTimeKindUtc(operation.Arguments[6]))
+                if (ArgumentsEquals(operation.Arguments.AsSpan(0, 6), [1970, 1, 1, 0, 0, 0], cancellationToken) && IsDateTimeKindUtc(operation.Arguments[6], cancellationToken))
                     return true;
             }
 
             return false;
         }
 
-        private bool IsDateTimeKindUtc(IArgumentOperation argument)
+        private bool IsDateTimeKindUtc(IArgumentOperation argument, CancellationToken cancellationToken)
         {
             if (_dateTimeKindSymbol is null)
                 return false;
 
-            return argument.Value.ConstantValue.HasValue && (DateTimeKind)argument.Value.ConstantValue.Value! == DateTimeKind.Utc;
+            return argument.Value.TryGetConstantValue(out var value, cancellationToken) && (DateTimeKind)value! == DateTimeKind.Utc;
         }
 
-        private static bool ArgumentsEquals(ReadOnlySpan<IArgumentOperation> arguments, object[] expectedValues)
+        private static bool ArgumentsEquals(ReadOnlySpan<IArgumentOperation> arguments, object[] expectedValues, CancellationToken cancellationToken)
         {
             for (var i = 0; i < arguments.Length; i++)
             {
                 var argument = arguments[i];
-                if (!argument.Value.ConstantValue.HasValue)
+                if (!argument.Value.TryGetConstantValue(out var value, cancellationToken))
                     return false;
 
-                if (!Equals(argument.Value.ConstantValue.Value, expectedValues[i]))
+                if (!Equals(value, expectedValues[i]))
                     return false;
             }
 

--- a/src/Meziantou.Analyzer/Rules/UseGuidEmptyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseGuidEmptyAnalyzer.cs
@@ -50,7 +50,9 @@ public sealed class UseGuidEmptyAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (operation.Arguments is [{ Value.Type.SpecialType: SpecialType.System_String, Value.ConstantValue: { HasValue: true, Value: string value } }])
+        if (operation.Arguments is [{ Value: { Type.SpecialType: SpecialType.System_String } argumentValue }] &&
+            argumentValue.TryGetConstantValue(out var constantValue, context.CancellationToken) &&
+            constantValue is string value)
         {
             if (System.Guid.TryParse(value, out var guid) && guid == System.Guid.Empty)
             {
@@ -60,17 +62,17 @@ public sealed class UseGuidEmptyAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (operation.Arguments.Length == 11 && IsAllZero(operation.Arguments))
+        if (operation.Arguments.Length == 11 && IsAllZero(operation.Arguments, context.CancellationToken))
         {
             context.ReportDiagnostic(Rule, operation);
         }
     }
 
-    private static bool IsAllZero(ImmutableArray<IArgumentOperation> arguments)
+    private static bool IsAllZero(ImmutableArray<IArgumentOperation> arguments, CancellationToken cancellationToken)
     {
         foreach (var argument in arguments)
         {
-            if (!argument.Value.ConstantValue.HasValue || !NumericHelpers.IsZero(argument.Value.ConstantValue.Value))
+            if (!argument.Value.TryGetConstantValue(out var value, cancellationToken) || !NumericHelpers.IsZero(value))
                 return false;
         }
 
@@ -83,7 +85,9 @@ public sealed class UseGuidEmptyAnalyzer : DiagnosticAnalyzer
         if (!invocation.TargetMethod.ContainingType.IsEqualTo(guidType))
             return;
 
-        if (invocation is { TargetMethod.Name: "Parse", Arguments: [{ Value.Type.SpecialType: SpecialType.System_String, Value.ConstantValue: { HasValue: true, Value: string value } }] })
+        if (invocation is { TargetMethod.Name: "Parse", Arguments: [{ Value: { Type.SpecialType: SpecialType.System_String } argumentValue }] } &&
+            argumentValue.TryGetConstantValue(out var constantValue, context.CancellationToken) &&
+            constantValue is string value)
         {
             if (System.Guid.TryParse(value, out var guid) && guid == System.Guid.Empty)
             {

--- a/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
@@ -127,7 +127,7 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
                 if (method.ContainingType.IsOrImplements(type))
                     return;
 
-                if (operation.Instance is not null && operation.Instance.GetActualType()?.IsOrImplements(type) is true)
+                if (operation.Instance is not null && operation.Instance.GetActualType(ctx.CancellationToken)?.IsOrImplements(type) is true)
                     return;
             }
 

--- a/src/Meziantou.Analyzer/Rules/UseTimeSpanZeroAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseTimeSpanZeroAnalyzer.cs
@@ -59,10 +59,9 @@ public sealed class UseTimeSpanZeroAnalyzer : DiagnosticAnalyzer
         // Check if the argument is a constant value of 0
         foreach (var argument in operation.Arguments)
         {
-            if (!argument.Value.ConstantValue.HasValue)
+            if (!argument.Value.TryGetConstantValue(out var constantValue, context.CancellationToken))
                 return;
 
-            var constantValue = argument.Value.ConstantValue.Value;
             if (!NumericHelpers.IsZero(constantValue))
                 return;
         }

--- a/tests/Meziantou.Analyzer.Test/Internals/LocalDataFlowAnalysisTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Internals/LocalDataFlowAnalysisTests.cs
@@ -1,0 +1,223 @@
+using Meziantou.Analyzer.Internals;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Meziantou.Analyzer.Test.Internals;
+
+public sealed class LocalDataFlowAnalysisTests
+{
+    private static readonly PortableExecutableReference[] References = GetReferences();
+
+    [Fact]
+    public void GetActualType_FlowsFromLocalInitializer()
+    {
+        var operation = GetOperation("""
+            class Test
+            {
+                void M()
+                {
+                    Base target = new Derived();
+                    var result = target;
+                }
+            }
+
+            class Base { }
+            class Derived : Base { }
+            """);
+
+        var actualType = operation.GetActualType(CancellationToken.None);
+
+        Assert.Equal("Derived", actualType?.Name);
+    }
+
+    [Fact]
+    public void GetActualType_FlowsFromLastLocalAssignment()
+    {
+        var operation = GetOperation("""
+            class Test
+            {
+                void M()
+                {
+                    Base target;
+                    target = new Derived();
+                    var result = target;
+                }
+            }
+
+            class Base { }
+            class Derived : Base { }
+            """);
+
+        var actualType = operation.GetActualType(CancellationToken.None);
+
+        Assert.Equal("Derived", actualType?.Name);
+    }
+
+    [Fact]
+    public void GetActualType_UsesDeclaredTypeWhenLocalIsReassignedBeforeUsage()
+    {
+        var operation = GetOperation("""
+            class Test
+            {
+                void M(Base value)
+                {
+                    Base target = new Derived();
+                    target = value;
+                    var result = target;
+                }
+            }
+
+            class Base { }
+            class Derived : Base { }
+            """);
+
+        var actualType = operation.GetActualType(CancellationToken.None);
+
+        Assert.Equal("Base", actualType?.Name);
+    }
+
+    [Fact]
+    public void GetActualType_FlowsFromPrivateReadonlyFieldInitializer()
+    {
+        var operation = GetOperation("""
+            class Test
+            {
+                private readonly Base target = new Derived();
+
+                void M()
+                {
+                    var result = target;
+                }
+            }
+
+            class Base { }
+            class Derived : Base { }
+            """);
+
+        var actualType = operation.GetActualType(CancellationToken.None);
+
+        Assert.Equal("Derived", actualType?.Name);
+    }
+
+    [Fact]
+    public void GetActualType_UsesDeclaredTypeWhenReadonlyFieldIsAssignedOutsideInitializer()
+    {
+        var operation = GetOperation("""
+            class Test
+            {
+                private readonly Base target = new Derived();
+
+                Test(Base value)
+                {
+                    target = value;
+                }
+
+                void M()
+                {
+                    var result = target;
+                }
+            }
+
+            class Base { }
+            class Derived : Base { }
+            """);
+
+        var actualType = operation.GetActualType(CancellationToken.None);
+
+        Assert.Equal("Base", actualType?.Name);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_FlowsFromLocalInitializer()
+    {
+        var operation = GetOperation("""
+            class Test
+            {
+                void M()
+                {
+                    var target = 42;
+                    var result = target;
+                }
+            }
+            """);
+
+        var result = operation.TryGetConstantValue(out var value, CancellationToken.None);
+
+        Assert.True(result);
+        Assert.Equal(42, value);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_FlowsFromPrivateGetOnlyPropertyInitializer()
+    {
+        var operation = GetOperation("""
+            class Test
+            {
+                private string Target { get; } = "value";
+
+                void M()
+                {
+                    var result = Target;
+                }
+            }
+            """, "Target");
+
+        var result = operation.TryGetConstantValue(out var value, CancellationToken.None);
+
+        Assert.True(result);
+        Assert.Equal("value", value);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_ReturnsFalseWhenLocalIsWrittenBetweenInitializerAndUsage()
+    {
+        var operation = GetOperation("""
+            class Test
+            {
+                void M()
+                {
+                    var target = 42;
+                    target++;
+                    var result = target;
+                }
+            }
+            """);
+
+        var result = operation.TryGetConstantValue(out var value, CancellationToken.None);
+
+        Assert.False(result);
+        Assert.Null(value);
+    }
+
+    private static IOperation GetOperation(string source, string identifierName = "target")
+    {
+        var compilation = CreateCompilation(source);
+        var syntaxTree = compilation.SyntaxTrees.Single();
+        var diagnostics = compilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(diagnostics);
+
+        var root = syntaxTree.GetRoot(CancellationToken.None);
+        var identifier = root.DescendantNodes().OfType<IdentifierNameSyntax>().Last(node => node.Identifier.ValueText == identifierName);
+        var operation = compilation.GetSemanticModel(syntaxTree).GetOperation(identifier, CancellationToken.None);
+
+        return operation ?? throw new InvalidOperationException("The selected syntax node is not an operation.");
+    }
+
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        return CSharpCompilation.Create(
+            assemblyName: "Test",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview))],
+            references: References,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static PortableExecutableReference[] GetReferences()
+    {
+        return ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path))
+            .ToArray();
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotRaiseNotImplementedExceptionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotRaiseNotImplementedExceptionAnalyzerTests.cs
@@ -55,4 +55,23 @@ public sealed class DoNotRaiseNotImplementedExceptionAnalyzerTests
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task RaiseNotImplementedException_FlowedFromLocal_ShouldReportErrorAsync()
+    {
+        const string SourceCode = """
+            using System;
+            class TestAttribute
+            {
+                void Test()
+                {
+                    Exception exception = new NotImplementedException();
+                    [|throw exception;|]
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -2433,6 +2433,26 @@ class Sample
     }
 
     [Fact]
+    public async Task SemaphoreSlim_Wait_FlowedZero_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System.Threading;
+                using System.Threading.Tasks;
+                class Test
+                {
+                    public async Task A()
+                    {
+                        var semaphore = new SemaphoreSlim(1);
+                        var timeout = 0;
+                        semaphore.Wait(timeout);
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task SemaphoreSlim_Wait_TimeSpanZero_NoDiagnostic()
     {
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
@@ -140,6 +140,157 @@ sealed class Derived : Sample {  }
     }
 
     [Fact]
+    public async Task SealedType_FlowedFromLocalInitializer()
+    {
+        var sourceCode = """
+Sample a = new Derived();
+[|a.ToString()|];
+
+class Sample { }
+sealed class Derived : Sample { }
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task SealedType_FlowedFromLocalAssignment()
+    {
+        var sourceCode = """
+Sample a;
+a = new Derived();
+[|a.ToString()|];
+
+class Sample { }
+sealed class Derived : Sample { }
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task SealedType_FlowedFromLocalInitializer_Reassigned()
+    {
+        var sourceCode = """
+Sample a = new Derived();
+a = Get();
+a.ToString();
+
+Sample Get() => new Sample();
+
+class Sample { }
+sealed class Derived : Sample { }
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task SealedType_FlowedFromPrivateReadonlyFieldInitializer()
+    {
+        var sourceCode = """
+class Test
+{
+    private readonly Sample _value = new Derived();
+
+    void M()
+    {
+        [|_value.ToString()|];
+    }
+}
+
+class Sample { }
+sealed class Derived : Sample { }
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .WithOutputKind(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task SealedType_PrivateReadonlyFieldInitializer_AssignedInConstructor()
+    {
+        var sourceCode = """
+class Test
+{
+    private readonly Sample _value = new Derived();
+
+    public Test()
+    {
+        _value = new Sample();
+    }
+
+    void M()
+    {
+        _value.ToString();
+    }
+}
+
+class Sample { }
+sealed class Derived : Sample { }
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .WithOutputKind(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task SealedType_FlowedFromPrivateGetOnlyPropertyInitializer()
+    {
+        var sourceCode = """
+class Test
+{
+    private Sample Value { get; } = new Derived();
+
+    void M()
+    {
+        [|Value.ToString()|];
+    }
+}
+
+class Sample { }
+sealed class Derived : Sample { }
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .WithOutputKind(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task SealedType_PrivateGetOnlyPropertyInitializer_AssignedInConstructor()
+    {
+        var sourceCode = """
+class Test
+{
+    private Sample Value { get; } = new Derived();
+
+    public Test()
+    {
+        Value = new Sample();
+    }
+
+    void M()
+    {
+        Value.ToString();
+    }
+}
+
+class Sample { }
+sealed class Derived : Sample { }
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .WithOutputKind(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task SealedType_InheritsBaseToStringOverride()
     {
         var sourceCode = """

--- a/tests/Meziantou.Analyzer.Test/Rules/StringFormatShouldBeConstantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/StringFormatShouldBeConstantAnalyzerTests.cs
@@ -104,6 +104,155 @@ public sealed class StringFormatShouldBeConstantAnalyzerTests
     }
 
     [Fact]
+    public async Task StringFormat_WithConstantFormatStringFromLocal_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System;
+
+                class Test
+                {
+                    void Method()
+                    {
+                        var format = "value without placeholder";
+                        var result = [|string.Format(format, 123)|];
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StringFormat_WithConstantFormatStringFromLocalAssignment_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System;
+
+                class Test
+                {
+                    void Method()
+                    {
+                        string format;
+                        format = "value without placeholder";
+                        var result = [|string.Format(format, 123)|];
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StringFormat_WithReassignedFormatString_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System;
+
+                class Test
+                {
+                    void Method(string other)
+                    {
+                        var format = "value without placeholder";
+                        format = other;
+                        var result = string.Format(format, 123);
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StringFormat_WithPrivateGetOnlyPropertyFormatString_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System;
+
+                class Test
+                {
+                    private string Format { get; } = "value without placeholder";
+
+                    void Method()
+                    {
+                        var result = [|string.Format(Format, 123)|];
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StringFormat_WithPrivateGetOnlyPropertyFormatString_AssignedInConstructor_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System;
+
+                class Test
+                {
+                    private string Format { get; } = "value without placeholder";
+
+                    public Test(string format)
+                    {
+                        Format = format;
+                    }
+
+                    void Method()
+                    {
+                        var result = string.Format(Format, 123);
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StringFormat_WithPrivateReadonlyFieldFormatString_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System;
+
+                class Test
+                {
+                    private readonly string _format = "value without placeholder";
+
+                    void Method()
+                    {
+                        var result = [|string.Format(_format, 123)|];
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task StringFormat_WithPrivateReadonlyFieldFormatString_AssignedInConstructor_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                using System;
+
+                class Test
+                {
+                    private readonly string _format = "value without placeholder";
+
+                    public Test(string format)
+                    {
+                        _format = format;
+                    }
+
+                    void Method()
+                    {
+                        var result = string.Format(_format, 123);
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
     public async Task StringFormat_WithIFormatProvider_NoPlaceholder_ShouldReportDiagnostic()
     {
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/UseArrayEmptyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseArrayEmptyAnalyzerTests.cs
@@ -58,7 +58,7 @@ public sealed class UseArrayEmptyAnalyzerTests
     }
 
     [Fact]
-    public async Task Length_ShouldNotReportError()
+    public async Task Length_FlowedFromLocal_ShouldReportError()
     {
         const string SourceCode = """
             class TestClass
@@ -66,12 +66,22 @@ public sealed class UseArrayEmptyAnalyzerTests
                 void Test()
                 {
                     int length = 0;
-                    var a = new int[length];
+                    var a = [|new int[length]|];
                 }
             }
             """;
         await CreateProjectBuilder()
               .WithSourceCode(SourceCode)
+              .ShouldFixCodeWith("""
+            class TestClass
+            {
+                void Test()
+                {
+                    int length = 0;
+                    var a = System.Array.Empty<int>();
+                }
+            }
+            """)
               .ValidateAsync();
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseGuidEmptyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseGuidEmptyAnalyzerTests.cs
@@ -47,6 +47,33 @@ class TestClass
               .ValidateAsync();
     }
 
+    [Fact]
+    public async Task ShouldReportError_FlowedFromLocal()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+class TestClass
+{
+    void Test()
+    {
+        var value = "00000000-0000-0000-0000-000000000000";
+        _ = [|System.Guid.Parse(value)|];
+    }
+}
+""")
+              .ShouldFixCodeWith("""
+class TestClass
+{
+    void Test()
+    {
+        var value = "00000000-0000-0000-0000-000000000000";
+        _ = System.Guid.Empty;
+    }
+}
+""")
+              .ValidateAsync();
+    }
+
     [Theory]
     [InlineData("new System.Guid(\"\")")]
     [InlineData("new System.Guid(\"10752bc4-c151-50f5-f27b-df92d8af5a61\")")]

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTimeSpanZeroAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTimeSpanZeroAnalyzerTests.cs
@@ -108,4 +108,31 @@ class TestClass
 """)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task ShouldReportDiagnostic_FlowedFromLocal()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+class TestClass
+{
+    void Test()
+    {
+        var value = 0;
+        _ = [|System.TimeSpan.FromSeconds(value)|];
+    }
+}
+""")
+              .ShouldFixCodeWith("""
+class TestClass
+{
+    void Test()
+    {
+        var value = 0;
+        _ = System.TimeSpan.Zero;
+    }
+}
+""")
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
## Summary

- Add a reusable type helper to `LocalDataFlowAnalysis`.
- Refactor analyzers to use the shared helper for type checks and data-flow analysis.
- Extend coverage with focused unit tests for the helper and affected analyzers.

## Testing

- Added and updated analyzer unit tests covering the new type-analysis behavior and related diagnostics.
- Not run (not requested).