### PR TITLE
Add MA0002.report_only_non_ordinal option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 |Id|Category|Description|Severity|Is enabled|Code fix|Configurable|
 |--|--------|-----------|:------:|:--------:|:------:|:----------:|
 |[MA0001](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0001.md)|Usage|StringComparison is missing|<span title='Info'>ℹ️</span>|✔️|✔️|❌|
-|[MA0002](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0002.md)|Usage|IEqualityComparer\<string\> or IComparer\<string\> is missing|<span title='Warning'>⚠️</span>|✔️|✔️|<span title='MA0002.exclude_query_operator_syntaxes&#xA;MA0002.report_collection_expressions'>✔️</span>|
+|[MA0002](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0002.md)|Usage|IEqualityComparer\<string\> or IComparer\<string\> is missing|<span title='Warning'>⚠️</span>|✔️|✔️|<span title='MA0002.exclude_query_operator_syntaxes&#xA;MA0002.report_collection_expressions&#xA;MA0002.report_only_non_ordinal'>✔️</span>|
 |[MA0003](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0003.md)|Style|Add parameter name to improve readability|<span title='Info'>ℹ️</span>|✔️|✔️|<span title='MA0003.excluded_methods&#xA;MA0003.excluded_methods_regex&#xA;MA0003.expression_kinds&#xA;MA0003.minimum_method_parameters'>✔️</span>|
 |[MA0004](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0004.md)|Usage|Use Task.ConfigureAwait|<span title='Warning'>⚠️</span>|✔️|✔️|<span title='MA0004.report'>✔️</span>|
 |[MA0005](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0005.md)|Performance|Use Array.Empty\<T\>()|<span title='Warning'>⚠️</span>|✔️|✔️|❌|

--- a/docs/Rules/MA0002.md
+++ b/docs/Rules/MA0002.md
@@ -44,8 +44,6 @@ list.Distinct(StringComparer.Ordinal);
 
 `IQueryable` query-operator calls are excluded from this recommendation because comparer overloads are often not translatable by query providers.
 
-Calls to `Meziantou.Framework.Assertions.Assert` are excluded because assertion methods intentionally choose the comparison semantics.
-
 # Configuration
 
 The rule can be configured using an `.editorconfig` file:
@@ -57,6 +55,13 @@ MA0002.exclude_query_operator_syntaxes = false
 # Report collection expressions ([]) for C#14 and lower
 # C# preview reports those diagnostics by default
 MA0002.report_collection_expressions = false
+
+# Only report APIs whose default string comparison is not known to be ordinal.
+# When enabled, equality-based APIs whose default comparer is already ordinal are not reported
+# (e.g. HashSet, Dictionary, ConcurrentDictionary, ToDictionary, ToImmutableDictionary, Distinct,
+# GroupBy, and Meziantou.Framework.Assertions.Assert), while culture-sensitive ordering APIs are
+# still reported (e.g. SortedDictionary, SortedSet, SortedList, OrderBy, ThenBy, Order).
+MA0002.report_only_non_ordinal = false
 ```
 
 ## Additional resources

--- a/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
@@ -42,6 +42,48 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
         { "ToLookup", 1 },
     };
 
+    // Methods whose default string comparison is ordinal (equality-based). Ordering methods
+    // (Order/OrderBy/OrderByDescending/ThenBy/ThenByDescending) are intentionally excluded because
+    // their default is Comparer<string>.Default (= StringComparer.CurrentCulture, culture-sensitive).
+    private static readonly HashSet<string> KnownOrdinalMethodNames = new(StringComparer.Ordinal)
+    {
+        // System.Linq.Enumerable / System.Linq.Queryable (methods taking IEqualityComparer<string>).
+        // Ordering methods (Order/OrderBy/OrderByDescending/OrderDescending/ThenBy/ThenByDescending) and
+        // Min/Max/MinBy/MaxBy take IComparer<string> (culture-sensitive) and are intentionally excluded.
+        "AggregateBy",
+        "Contains",
+        "CountBy",
+        "Distinct",
+        "DistinctBy",
+        "Except",
+        "ExceptBy",
+        "GroupBy",
+        "GroupJoin",
+        "Intersect",
+        "IntersectBy",
+        "Join",
+        "LeftJoin",
+        "RightJoin",
+        "SequenceEqual",
+        "ToDictionary",
+        "ToHashSet",
+        "ToLookup",
+        "Union",
+        "UnionBy",
+
+        // System.Collections.Immutable / System.Collections.Frozen factory methods. These names also
+        // exist on the Sorted variants (IComparer<string>, culture-sensitive), but those are excluded
+        // by scoping to the containers in BuildKnownOrdinalContainerTypes.
+        "Create",
+        "CreateBuilder",
+        "CreateRange",
+        "CreateRangeWithOverwrite",
+        "ToImmutableDictionary",
+        "ToImmutableHashSet",
+        "ToFrozenDictionary",
+        "ToFrozenSet",
+    };
+
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.UseStringComparer,
         title: "IEqualityComparer<string> or IComparer<string> is missing",
@@ -53,6 +95,7 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseStringComparer));
 
     private static readonly ConfigurationDefinition<bool> ExcludeQueryOperatorSyntaxesConfiguration = new(Rule.Id + ".exclude_query_operator_syntaxes", defaultValue: false);
+    private static readonly ConfigurationDefinition<bool> ReportOnlyNonOrdinalConfiguration = new(Rule.Id + ".report_only_non_ordinal", defaultValue: false);
 #if ROSLYN_4_14_OR_GREATER
     private static readonly ConfigurationDefinition<bool> ReportCollectionExpressionsConfiguration = new(Rule.Id + ".report_collection_expressions", defaultValue: false);
 #endif
@@ -80,6 +123,15 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
         private readonly OverloadFinder _overloadFinder = new(compilation);
         private readonly OperationUtilities _operationUtilities = new(compilation);
 
+        // Types whose default string comparison is ordinal (equality-based collections). Ordering
+        // collections (SortedDictionary/SortedList/SortedSet) are intentionally excluded because their
+        // default is Comparer<string>.Default (= StringComparer.CurrentCulture, culture-sensitive).
+        private readonly HashSet<INamedTypeSymbol> _knownOrdinalTypes = BuildKnownOrdinalTypes(compilation);
+
+        // Static classes hosting the known-ordinal methods, used to avoid suppressing unrelated
+        // user-defined methods that happen to share a name with a BCL method.
+        private readonly HashSet<INamedTypeSymbol> _knownOrdinalContainerTypes = BuildKnownOrdinalContainerTypes(compilation);
+
         public INamedTypeSymbol? EqualityComparerStringType { get; } = GetIEqualityComparerString(compilation);
         public INamedTypeSymbol? ComparerStringType { get; } = GetIComparerString(compilation);
         public INamedTypeSymbol? EnumerableType { get; } = compilation.GetBestTypeByMetadataName("System.Linq.Enumerable");
@@ -102,6 +154,9 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
             if ((EqualityComparerStringType is not null && _overloadFinder.HasOverloadWithAdditionalParameterOfType(method, options: default, [EqualityComparerStringType])) ||
                 (ComparerStringType is not null && _overloadFinder.HasOverloadWithAdditionalParameterOfType(method, options: default, [ComparerStringType])))
             {
+                if (ctx.Options.GetConfigurationValue(operation, ReportOnlyNonOrdinalConfiguration) && IsKnownOrdinalType(operation.Type))
+                    return;
+
                 ctx.ReportDiagnostic(Rule, operation);
             }
         }
@@ -116,8 +171,6 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
                 return;
 
             var method = operation.TargetMethod;
-            if (method.ContainingType.IsEqualTo(MeziantouFrameworkAssertType))
-                return;
 
             // Most ISet implementation already configured the IEqualityComparer in this constructor,
             // so it should be ok to skip method calls on those types.
@@ -145,6 +198,9 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
             if ((EqualityComparerStringType is not null && _overloadFinder.HasOverloadWithAdditionalParameterOfType(operation, options: default, [EqualityComparerStringType])) ||
                 (ComparerStringType is not null && _overloadFinder.HasOverloadWithAdditionalParameterOfType(operation, options: default, [ComparerStringType])))
             {
+                if (IsInvocationReportSuppressedByOrdinalOption(ctx, operation, method))
+                    return;
+
                 ctx.ReportDiagnostic(Rule, operation, DefaultDiagnosticInvocationReportOptions);
                 return;
             }
@@ -179,6 +235,9 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
 
                 if (!HasEqualityComparerArgument(operation.Arguments))
                 {
+                    if (IsInvocationReportSuppressedByOrdinalOption(ctx, operation, method))
+                        return;
+
                     ctx.ReportDiagnostic(Rule, operation, DefaultDiagnosticInvocationReportOptions);
                 }
             }
@@ -210,6 +269,9 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
             if ((EqualityComparerStringType is not null && _overloadFinder.HasOverloadWithAdditionalParameterOfType(constructMethod, options: default, [EqualityComparerStringType])) ||
                 (ComparerStringType is not null && _overloadFinder.HasOverloadWithAdditionalParameterOfType(constructMethod, options: default, [ComparerStringType])))
             {
+                if (ctx.Options.GetConfigurationValue(operation, ReportOnlyNonOrdinalConfiguration) && IsKnownOrdinalType(operation.Type))
+                    return;
+
                 ctx.ReportDiagnostic(Rule, operation);
             }
 
@@ -266,6 +328,50 @@ public sealed class UseStringComparerAnalyzer : DiagnosticAnalyzer
         }
 #pragma warning restore RSEXPERIMENTAL006
 #endif
+
+        private bool IsInvocationReportSuppressedByOrdinalOption(OperationAnalysisContext ctx, IInvocationOperation operation, IMethodSymbol method)
+        {
+            if (!ctx.Options.GetConfigurationValue(operation, ReportOnlyNonOrdinalConfiguration))
+                return false;
+
+            if (method.ContainingType.IsEqualTo(MeziantouFrameworkAssertType))
+                return true;
+
+            return KnownOrdinalMethodNames.Contains(method.Name)
+                && _knownOrdinalContainerTypes.Contains(method.ContainingType.OriginalDefinition);
+        }
+
+        private bool IsKnownOrdinalType(ITypeSymbol? type)
+        {
+            return type is INamedTypeSymbol namedType
+                && _knownOrdinalTypes.Contains(namedType.OriginalDefinition);
+        }
+
+        private static HashSet<INamedTypeSymbol> BuildKnownOrdinalTypes(Compilation compilation)
+        {
+            var result = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Generic.HashSet`1"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Generic.Dictionary`2"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Generic.OrderedDictionary`2"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Concurrent.ConcurrentDictionary`2"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Immutable.ImmutableDictionary`2"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Immutable.ImmutableHashSet`1"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Frozen.FrozenDictionary`2"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Frozen.FrozenSet`1"));
+            return result;
+        }
+
+        private static HashSet<INamedTypeSymbol> BuildKnownOrdinalContainerTypes(Compilation compilation)
+        {
+            var result = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Linq.Enumerable"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Linq.Queryable"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Immutable.ImmutableDictionary"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Immutable.ImmutableHashSet"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Frozen.FrozenDictionary"));
+            result.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Frozen.FrozenSet"));
+            return result;
+        }
 
         private static INamedTypeSymbol? GetIEqualityComparerString(Compilation compilation)
         {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -371,6 +371,25 @@ public sealed class UseStringComparerAnalyzerTests
     }
 
     [Fact]
+    public async Task HashSet_String_CollectionExpression_WithElements_ReportOnlyNonOrdinal_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+              .AddAnalyzerConfiguration(ReportCollectionExpressionsConfigurationName, "true")
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.HashSet<string> a = ["a", "b"];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task FrozenSet_String_CollectionExpression_DefaultOnCSharp12_ShouldNotReportDiagnostic()
     {
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -7,6 +7,7 @@ namespace Meziantou.Analyzer.Test.Rules;
 public sealed class UseStringComparerAnalyzerTests
 {
     private const string ReportCollectionExpressionsConfigurationName = "MA0002.report_collection_expressions";
+    private const string ReportOnlyNonOrdinalConfigurationName = "MA0002.report_only_non_ordinal";
 
     private static ProjectBuilder CreateProjectBuilder()
     {
@@ -326,6 +327,25 @@ public sealed class UseStringComparerAnalyzerTests
                       public void Test()
                       {
                           System.Collections.Generic.HashSet<string> a = [|[]|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task HashSet_String_CollectionExpression_ReportOnlyNonOrdinal_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12)
+              .AddAnalyzerConfiguration(ReportCollectionExpressionsConfigurationName, "true")
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.HashSet<string> a = [];
                       }
                   }
                   """)
@@ -768,7 +788,77 @@ public sealed class UseStringComparerAnalyzerTests
     }
 
     [Fact]
-    public async Task MeziantouFrameworkAssertions_Assert_ShouldNotReportDiagnostic()
+    public async Task ImmutableDictionary_Create_String_ShouldReportDiagnostic()
+    {
+        const string SourceCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    System.Collections.Immutable.ImmutableDictionary.[|Create<string, string>()|];
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net4_8)
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MeziantouFrameworkAssertions_Assert_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  namespace Meziantou.Framework.Assertions
+                  {
+                      static class Assert
+                      {
+                          public static void AreEqual(string expected, string actual) { }
+                          public static void AreEqual(string expected, string actual, System.Collections.Generic.IEqualityComparer<string> comparer) { }
+                      }
+                  }
+
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          Meziantou.Framework.Assertions.Assert.[|AreEqual("a", "b")|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MeziantouFrameworkAssertions_Assert_ReportOnlyNonOrdinal_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  namespace Meziantou.Framework.Assertions
+                  {
+                      static class Assert
+                      {
+                          public static void AreEqual(string expected, string actual) { }
+                          public static void AreEqual(string expected, string actual, System.Collections.Generic.IEqualityComparer<string> comparer) { }
+                      }
+                  }
+
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          Meziantou.Framework.Assertions.Assert.AreEqual("a", "b");
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MeziantouFrameworkAssertions_Assert_WithoutComparerOverload_ShouldNotReportDiagnostic()
     {
         await CreateProjectBuilder()
               .WithTargetFramework(TargetFramework.Net10_0)
@@ -780,6 +870,205 @@ public sealed class UseStringComparerAnalyzerTests
                       {
                           System.Collections.Generic.ICollection<string> values = new[] { "abc" };
                           Meziantou.Framework.Assertions.Assert.Contains("abc", values);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_HashSet_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          new System.Collections.Generic.HashSet<string>();
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_Dictionary_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          new System.Collections.Generic.Dictionary<string, int>();
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_ConcurrentDictionary_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          new System.Collections.Concurrent.ConcurrentDictionary<string, int>();
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_EnumerableDistinct_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  using System.Linq;
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.IEnumerable<string> obj = null;
+                          obj.Distinct();
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_EnumerableToDictionary_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  using System.Linq;
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.IEnumerable<string> obj = null;
+                          obj.ToDictionary(p => p);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_ImmutableDictionaryCreateBuilder_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net4_8)
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Immutable.ImmutableDictionary.CreateBuilder<string, string>();
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_ImmutableDictionaryCreate_ShouldNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net4_8)
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Immutable.ImmutableDictionary.Create<string, string>();
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_ImmutableSortedDictionaryCreate_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net4_8)
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Immutable.ImmutableSortedDictionary.[|Create<string, string>()|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_SortedDictionary_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          [|new System.Collections.Generic.SortedDictionary<string, int>()|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_OrderBy_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  using System.Linq;
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.IEnumerable<string> obj = null;
+                          obj.[|OrderBy(p => p)|];
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportOnlyNonOrdinal_Order_ShouldReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net7_0)
+              .AddAnalyzerConfiguration(ReportOnlyNonOrdinalConfigurationName, "true")
+              .WithSourceCode("""
+                  using System.Linq;
+                  class TypeName
+                  {
+                      public void Test()
+                      {
+                          System.Collections.Generic.IEnumerable<string> obj = null;
+                          obj.[|Order()|];
                       }
                   }
                   """)


### PR DESCRIPTION
## What

Adds a new opt-in EditorConfig option **`MA0002.report_only_non_ordinal`** (default `false`, so existing behavior is unchanged).

MA0002 currently reports whenever a string-keyed collection or LINQ operation has an `IEqualityComparer<string>`/`IComparer<string>` overload but none is supplied — even when the default comparison is already **ordinal** (and therefore safe), e.g. `new HashSet<string>()`, `new Dictionary<string,int>()`, `ToDictionary`, `ToImmutableDictionary`.

When `MA0002.report_only_non_ordinal = true`, the analyzer suppresses diagnostics for a curated, exhaustive list of **known-ordinal (equality-default)** APIs while still reporting the genuinely risky **culture-sensitive ordering** APIs (`SortedDictionary`, `SortedSet`, `SortedList`, `OrderBy`, `ThenBy`, `Order`, ...), which default to `Comparer<string>.Default` (= `StringComparer.CurrentCulture`).

## Known-ordinal set (suppressed when the option is on)

- **Types (constructors / collection expressions):** `HashSet`, `Dictionary`, `ConcurrentDictionary`, `OrderedDictionary`, `ImmutableDictionary`, `ImmutableHashSet`, `FrozenDictionary`, `FrozenSet`.
- **Methods:** LINQ equality methods (`Distinct`, `DistinctBy`, `Contains`, `Except`, `ExceptBy`, `Intersect`, `IntersectBy`, `Union`, `UnionBy`, `GroupBy`, `GroupJoin`, `Join`, `LeftJoin`, `RightJoin`, `SequenceEqual`, `ToDictionary`, `ToHashSet`, `ToLookup`, `CountBy`, `AggregateBy`) and immutable/frozen factories (`Create`, `CreateBuilder`, `CreateRange`, `CreateRangeWithOverwrite`, `ToImmutableDictionary`, `ToImmutableHashSet`, `ToFrozenDictionary`, `ToFrozenSet`).

The method names are **scoped to their BCL container types** (`Enumerable`, `Queryable`, `ImmutableDictionary`, `ImmutableHashSet`, `FrozenDictionary`, `FrozenSet`), so the `Sorted*` factories that share names like `Create`/`CreateRange` keep reporting. The list was verified by reflecting over the actual `net10.0` assemblies rather than by guessing.

Because this is an allow-list (only suppress what is known-ordinal), the only failure mode is under-suppression — a culture-sensitive API can never be silently hidden.

## Behavior change to note

`Meziantou.Framework.Assertions.Assert` was previously **unconditionally excluded** from MA0002. It is now folded into the option: reported by default and suppressed only when `report_only_non_ordinal = true`. This means Assert methods with a comparer overload start being reported by default.

## Tests / docs

- Added analyzer tests for the option: suppressed known-ordinal cases (types, LINQ, collection expression, immutable factories, Assert) and still-reported ordering cases (`SortedDictionary`, `OrderBy`, `Order`, `ImmutableSortedDictionary.Create`).
- Updated `docs/Rules/MA0002.md` and regenerated `docs/README.md`.
- MA0002 tests pass on default Roslyn and on `roslyn4.2` / `roslyn4.14`.