### PR TITLE
Update Meziantou.NET.Sdk to 1.0.149

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,9 +4,9 @@
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {
-    "Meziantou.NET.Sdk": "1.0.148",
-    "Meziantou.NET.Sdk.Test": "1.0.148",
-    "Meziantou.NET.Sdk.Web": "1.0.148"
+    "Meziantou.NET.Sdk": "1.0.149",
+    "Meziantou.NET.Sdk.Test": "1.0.149",
+    "Meziantou.NET.Sdk.Web": "1.0.149"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/global.json
+++ b/global.json
@@ -4,9 +4,9 @@
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {
-    "Meziantou.NET.Sdk": "1.0.149",
-    "Meziantou.NET.Sdk.Test": "1.0.149",
-    "Meziantou.NET.Sdk.Web": "1.0.149"
+    "Meziantou.NET.Sdk": "1.0.150",
+    "Meziantou.NET.Sdk.Test": "1.0.150",
+    "Meziantou.NET.Sdk.Web": "1.0.150"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
@@ -19,17 +19,17 @@ public sealed partial class ProjectBuilder
     {
         if (DiagnosticAnalyzer is null)
         {
-            Assert.Fail("DiagnosticAnalyzer is not configured");
+            Xunit.Assert.Fail("DiagnosticAnalyzer is not configured");
         }
 
         if (ExpectedFixedCode is not null && CodeFixProvider is null)
         {
-            Assert.Fail("CodeFixProvider is not configured");
+            Xunit.Assert.Fail("CodeFixProvider is not configured");
         }
 
         if (ExpectedDiagnosticResults is null)
         {
-            Assert.Fail("ExpectedDiagnostic is not configured");
+            Xunit.Assert.Fail("ExpectedDiagnostic is not configured");
         }
 
         await VerifyDiagnostic(ExpectedDiagnosticResults).ConfigureAwait(false);

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
@@ -19,17 +19,17 @@ public sealed partial class ProjectBuilder
     {
         if (DiagnosticAnalyzer is null)
         {
-            Xunit.Assert.Fail("DiagnosticAnalyzer is not configured");
+            Assert.Fail("DiagnosticAnalyzer is not configured");
         }
 
         if (ExpectedFixedCode is not null && CodeFixProvider is null)
         {
-            Xunit.Assert.Fail("CodeFixProvider is not configured");
+            Assert.Fail("CodeFixProvider is not configured");
         }
 
         if (ExpectedDiagnosticResults is null)
         {
-            Xunit.Assert.Fail("ExpectedDiagnostic is not configured");
+            Assert.Fail("ExpectedDiagnostic is not configured");
         }
 
         await VerifyDiagnostic(ExpectedDiagnosticResults).ConfigureAwait(false);


### PR DESCRIPTION
Update `Meziantou.NET.Sdk` from 1.0.148 to 1.0.149.

1.0.149 uses [`Meziantou.Framework.Assertions`](https://www.nuget.org/packages/Meziantou.Framework.Assertions) as the default assertion library, so `Assert` now refers to `Meziantou.Framework.Assertions.Assert` in the test projects.

Files changed:
- global.json
- tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs