### PR TITLE
Support C# 15 closed hierarchies in MA0150

### DIFF
--- a/docs/Rules/MA0150.md
+++ b/docs/Rules/MA0150.md
@@ -14,3 +14,24 @@ o.ToString(); // Non-compliant as Foo doesn't override ToString and is sealed
 
 sealed class Foo {}
 ```
+
+A `closed` type (C# 15) cannot be inherited from outside its containing module, so the whole set of possible runtime types is known.
+The diagnostic is reported when no type of the hierarchy overrides `ToString`:
+
+```c#
+Shape shape = ...;
+shape.ToString(); // Non-compliant as no type of the closed hierarchy overrides ToString
+
+closed class Shape;
+sealed class Circle : Shape;
+sealed class Square : Shape;
+```
+
+```c#
+Shape shape = ...;
+shape.ToString(); // compliant as Square overrides ToString
+
+closed class Shape;
+sealed class Circle : Shape;
+sealed class Square : Shape { public override string ToString() => "square"; }
+```

--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -324,7 +324,7 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
         return typeSymbol is not null && InterpolatedStringHandlerAttributeSymbol is not null && typeSymbol.HasAttribute(InterpolatedStringHandlerAttributeSymbol);
     }
 
-    public static bool UsesObjectToString(ITypeSymbol? typeSymbol)
+    public static bool UsesObjectToString(ITypeSymbol? typeSymbol, CancellationToken cancellationToken)
     {
         if (typeSymbol is null)
             return false;
@@ -332,27 +332,85 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
         if (typeSymbol.IsEnum())
             return false;
 
-        if (!typeSymbol.IsSealed)
+        if (typeSymbol.IsAnonymousType)
             return false;
 
-        if (typeSymbol.IsAnonymousType)
+        // A non-sealed type may be instantiated by a derived type overriding ToString, unless the whole set of derived types is known (closed hierarchy).
+        if (!typeSymbol.IsSealed && !IsClosedHierarchyWithoutToStringOverride(typeSymbol, cancellationToken))
             return false;
 
         // Look at the whole type hierarchy, as a sealed type may inherit a ToString override from a base class.
         // Stop before System.Object / System.ValueType, whose own ToString() is the "default" implementation this rule warns about.
         for (var current = typeSymbol; current is not null && current.SpecialType is not (SpecialType.System_Object or SpecialType.System_ValueType); current = current.BaseType)
         {
-            foreach (var member in current.GetMembers(nameof(ToString)).OfType<IMethodSymbol>())
-            {
-                if (member.Parameters.Length != 0)
-                    continue;
-
-                if (member.IsOverride)
-                    return false;
-            }
+            if (DeclaresToStringOverride(current))
+                return false;
         }
 
         return true;
+    }
+
+    private static bool DeclaresToStringOverride(ITypeSymbol typeSymbol)
+    {
+        foreach (var member in typeSymbol.GetMembers(nameof(ToString)).OfType<IMethodSymbol>())
+        {
+            if (member.Parameters.Length != 0)
+                continue;
+
+            if (member.IsOverride)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// A <c>closed</c> type cannot be inherited from outside its containing module, so the compiler knows every possible runtime type.
+    /// When no type of that hierarchy overrides <c>ToString</c>, the call is guaranteed to use <c>object.ToString</c>, just like for a sealed type.
+    /// </summary>
+    private static bool IsClosedHierarchyWithoutToStringOverride(ITypeSymbol typeSymbol, CancellationToken cancellationToken)
+    {
+#if ROSLYN_5_9_OR_GREATER
+#pragma warning disable RSEXPERIMENTAL006
+        const int MaxClosedHierarchyDepth = 32;
+
+        if (!typeSymbol.IsClosed)
+            return false;
+
+        return VisitDerivedTypes(typeSymbol, depth: 0, cancellationToken);
+
+        static bool VisitDerivedTypes(ITypeSymbol typeSymbol, int depth, CancellationToken cancellationToken)
+        {
+            // Generic closed hierarchies can expand indefinitely, so give up instead of recursing forever
+            if (depth > MaxClosedHierarchyDepth)
+                return false;
+
+            var derivedTypeInfo = typeSymbol.GetClosedDerivedTypeInfo(cancellationToken);
+            if (!derivedTypeInfo.IsComplete)
+                return false;
+
+            foreach (var derivedType in derivedTypeInfo.ClosedDerivedTypes)
+            {
+                if (DeclaresToStringOverride(derivedType))
+                    return false;
+
+                if (derivedType.IsSealed)
+                    continue;
+
+                // A derived type that is neither sealed nor closed can be inherited by an unknown type overriding ToString
+                if (!derivedType.IsClosed)
+                    return false;
+
+                if (!VisitDerivedTypes(derivedType, depth + 1, cancellationToken))
+                    return false;
+            }
+
+            return true;
+        }
+#pragma warning restore RSEXPERIMENTAL006
+#else
+        return false;
+#endif
     }
 
     private CultureSensitivity GetCultureSensitivity(ITypeSymbol? typeSymbol, CultureSensitiveOptions options)

--- a/src/Meziantou.Analyzer/Internals/LanguageVersionExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/LanguageVersionExtensions.cs
@@ -31,7 +31,11 @@ internal static class LanguageVersionExtensions
 
     public static bool IsCSharp15OrAbove(this LanguageVersion languageVersion)
     {
-        return languageVersion >= (LanguageVersion)1500;
+#if ROSLYN_5_6_OR_GREATER
+        return languageVersion >= (LanguageVersion)1500 || languageVersion is LanguageVersion.Preview;
+#else
+        return false;
+#endif
     }
 
     public static bool IsCSharp8OrAbove(this LanguageVersion languageVersion)

--- a/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
@@ -149,7 +149,7 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
                     context.ReportDiagnostic(StringInterpolationRule, part);
                 }
 
-                if (CultureSensitiveFormattingContext.UsesObjectToString(type))
+                if (CultureSensitiveFormattingContext.UsesObjectToString(type, context.CancellationToken))
                 {
                     context.ReportDiagnostic(ObjectToStringRule, expression);
                 }

--- a/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
@@ -84,7 +84,7 @@ public sealed class DoNotUseToStringIfObjectAnalyzer : DiagnosticAnalyzer
             if (actualType is null)
                 return;
 
-            if (actualType.IsSealed) // Method cannot be overridden
+            if (CultureSensitiveFormattingContext.UsesObjectToString(actualType, context.CancellationToken))
             {
                 context.ReportDiagnostic(Rule, operation, actualType.ToDisplayString());
             }
@@ -109,7 +109,7 @@ public sealed class DoNotUseToStringIfObjectAnalyzer : DiagnosticAnalyzer
             if (actualType.IsAnonymousType)
                 return;
 
-            if (CultureSensitiveFormattingContext.UsesObjectToString(actualType))
+            if (CultureSensitiveFormattingContext.UsesObjectToString(actualType, cancellationToken))
             {
                 reporter.ReportDiagnostic(Rule, operation, [actualType.ToDisplayString()]);
             }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
@@ -13,6 +13,14 @@ public sealed class DoNotUseToStringIfObjectAnalyzerTests
             .WithOutputKind(Microsoft.CodeAnalysis.OutputKind.ConsoleApplication);
     }
 
+#if CSHARP15_OR_GREATER
+    private static ProjectBuilder CreatePreviewProjectBuilder()
+    {
+        return CreateProjectBuilder()
+            .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview);
+    }
+#endif
+
     [Fact]
     public async Task Object_ToString()
     {
@@ -291,6 +299,18 @@ sealed class Derived : Sample { }
     }
 
     [Fact]
+    public async Task SealedType_FlowedFromLocalInitializer_InheritsBaseToStringOverride()
+    {
+        var sourceCode = """
+object o = "abc";
+o.ToString();
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task SealedType_InheritsBaseToStringOverride()
     {
         var sourceCode = """
@@ -304,6 +324,185 @@ sealed class Derived : Base { }
               .WithSourceCode(sourceCode)
               .ValidateAsync();
     }
+
+#if CSHARP15_OR_GREATER
+    [Fact]
+    public async Task ClosedType_NoToStringOverrideInHierarchy()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+[|((Shape)a).ToString()|];
+
+closed class Shape;
+sealed class Circle : Shape;
+sealed class Square : Shape;
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ClosedType_DerivedTypeOverridesToString()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+((Shape)a).ToString();
+
+closed class Shape;
+sealed class Circle : Shape;
+sealed class Square : Shape { public override string ToString() => "square"; }
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ClosedType_NestedClosedHierarchy_NoToStringOverride()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+[|((Shape)a).ToString()|];
+
+closed class Shape;
+closed class Round : Shape;
+sealed class Circle : Round;
+sealed class Square : Shape;
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ClosedType_NestedClosedHierarchy_LeafOverridesToString()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+((Shape)a).ToString();
+
+closed class Shape;
+closed class Round : Shape;
+sealed class Circle : Round { public override string ToString() => "circle"; }
+sealed class Square : Shape;
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ClosedType_NestedClosedHierarchy_IntermediateTypeOverridesToString()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+((Shape)a).ToString();
+
+closed class Shape;
+closed class Round : Shape { public override string ToString() => "round"; }
+sealed class Circle : Round;
+sealed class Square : Shape;
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ClosedType_DerivedTypeIsNeitherSealedNorClosed()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+((Shape)a).ToString();
+
+closed class Shape;
+class Circle : Shape;
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ClosedType_OverridesToString()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+((Shape)a).ToString();
+
+closed class Shape { public override string ToString() => "shape"; }
+sealed class Circle : Shape;
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ClosedType_UnspeakableDerivedType()
+    {
+        var sourceCode = """
+class Test
+{
+    void M<T>(Shape<T> value) => value.ToString();
+}
+
+closed class Shape<T>;
+sealed class Circle : Shape<int>;
+sealed class Square<T> : Shape<T[]>;
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .WithOutputKind(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InterpolatedString_ClosedType_NoToStringOverrideInHierarchy()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+_ = $"{[|(Shape)a|]}";
+
+closed class Shape;
+sealed class Circle : Shape;
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InterpolatedString_ClosedType_DerivedTypeOverridesToString()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+_ = $"{(Shape)a}";
+
+closed class Shape;
+sealed class Circle : Shape { public override string ToString() => "circle"; }
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_ClosedType_NoToStringOverrideInHierarchy()
+    {
+        var sourceCode = """
+Shape a = new Circle();
+_ = "" + [|(Shape)a|];
+
+closed class Shape;
+sealed class Circle : Shape;
+""";
+        await CreatePreviewProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+#endif
 
     [Fact]
     public async Task InterpolatedString_Sealed_Interpolation()


### PR DESCRIPTION
MA0150 only considered `sealed` types. With C# 15 `closed` types, the compiler knows every possible runtime type of a hierarchy, so the rule can report when none of them overrides `ToString`.

```c#
Shape shape = ...;
shape.ToString(); // Non-compliant: no type of the closed hierarchy overrides ToString

closed class Shape;
sealed class Circle : Shape;
sealed class Square : Shape;
```

## What changed

`CultureSensitiveFormattingContext.UsesObjectToString` now accepts a non-sealed type when it is `closed` and no type of the hierarchy overrides `ToString`. It uses `ITypeSymbol.IsClosed` and `ITypeSymbol.GetClosedDerivedTypeInfo`, which are only available on Roslyn 5.9 and are experimental, hence the `ROSLYN_5_9_OR_GREATER` and `RSEXPERIMENTAL006` guards.

The walk recurses because `GetClosedDerivedTypeInfo` only returns the *direct* derived types. It gives up when:

- **`IsComplete` is `false`** — happens for generic closed types with unspeakable subtypes. Given `closed class Shape<T>;` and `sealed class Square<T> : Shape<T[]>;`, `Shape<T>` reports `IsComplete=false` with only `Circle` in the derived types, so the set cannot be trusted.
- **A derived type is neither `sealed` nor `closed`** — this is genuinely reachable, not just defensive: `closed class Root; public class OpenChild : Root;` compiles, and a *different assembly* can then derive from `OpenChild`. That external type could override `ToString`.
- **The recursion gets too deep** — generic closed hierarchies can expand indefinitely, and a stack overflow inside an analyzer would take down the IDE.

`DoNotUseToStringIfObjectAnalyzer.AnalyzeInvocation` used a bare `actualType.IsSealed` check; it now calls the same shared predicate as the interpolation and concatenation paths.

## Incidental fix

Sharing the predicate also fixes a pre-existing false positive on the invocation path. `GetActualType` performs local data flow analysis, so:

```c#
object o = "abc";
o.ToString();
```

resolved the actual type to `string` — which is sealed — and reported *"ToString on 'string' will use the default object.ToString"*, even though `string` overrides `ToString`. I confirmed the old behavior by reverting the line and running the new test against it. Covered by `SealedType_FlowedFromLocalInitializer_InheritsBaseToStringOverride`.

## Notes for reviewers

- `closed` is not valid on interfaces (`error CS0106`), so there is no interface case to handle.
- Records generate an implicit `ToString` override, so a `closed record` hierarchy is correctly not reported.
- The 11 `closed` tests are behind `#if CSHARP15_OR_GREATER`. I checked the `.trx` to confirm they actually run on the default target rather than being silently compiled out.

## Validation

- Full test suite passes on every supported Roslyn version: 4.8 (3512), 4.14 (3545), 5.0 (3584), 5.6 (3596), 5.9/default (3620).
- `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes after the MA0150.md update.
