### PR TITLE
Fix MA0075 false positive on conditional and other compound expressions

### DIFF
--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -289,8 +289,9 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
         if (operation is IBinaryOperation binaryOperation)
             return GetCultureSensitivity(binaryOperation.Type, format: null, instance: null, options);
 
-        // Unknown operation
-        return CultureSensitivity.CultureSensitive;
+        // Unknown operation (conditional expression, coalesce expression, switch expression, await expression, ...).
+        // The formatting depends on the type of the value, so use it to determine the culture sensitivity.
+        return GetCultureSensitivity(operation.Type, format: null, instance: operation, options);
     }
 
     public bool IsInInterpolatedStringHandlerContext(IInterpolatedStringOperation operation)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -658,6 +658,146 @@ class Sample : System.IFormattable
     }
 
     [Fact]
+    public async Task Concat_ConditionalExpression_CultureInsensitiveBranches_NoDiagnostic()
+    {
+        var sourceCode = """
+using System;
+using System.Globalization;
+class Test
+{
+    void A(DateTime? date)
+    {
+        _ = "test" + (date.HasValue ? date.Value.ToString(CultureInfo.InvariantCulture) : string.Empty);
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_ConditionalExpression_CultureSensitiveType()
+    {
+        var sourceCode = """
+class Test
+{
+    void A(bool condition, double a, double b)
+    {
+        _ = "test" + ([|condition ? a : b|]);
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_CoalesceExpression_NoDiagnostic()
+    {
+        var sourceCode = """
+class Test
+{
+    void A(string value)
+    {
+        _ = "test" + (value ?? "");
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_CoalesceExpression_CultureSensitiveType()
+    {
+        var sourceCode = """
+class Test
+{
+    void A(double? value)
+    {
+        _ = "test" + ([|value ?? 1.5|]);
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_SwitchExpression_NoDiagnostic()
+    {
+        var sourceCode = """
+class Test
+{
+    void A(int value)
+    {
+        _ = "test" + (value switch { 0 => "a", _ => "b" });
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_SwitchExpression_CultureSensitiveType()
+    {
+        var sourceCode = """
+class Test
+{
+    void A(int value)
+    {
+        _ = "test" + ([|value switch { 0 => 1.5, _ => 2.5 }|]);
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_AwaitExpression_NoDiagnostic()
+    {
+        var sourceCode = """
+using System.Threading.Tasks;
+class Test
+{
+    async Task A(Task<string> task)
+    {
+        _ = "test" + await task;
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_AwaitExpression_CultureSensitiveType()
+    {
+        var sourceCode = """
+using System.Threading.Tasks;
+class Test
+{
+    async Task A(Task<double> task)
+    {
+        _ = "test" + [|await task|];
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task Object_Concat_NoDiagnostic()
     {
         var sourceCode = """


### PR DESCRIPTION
Fixes #1294

## Problem

```csharp
using System.Globalization;

DateTime? date = null;
_ = "test" + (date.HasValue ? date.Value.ToString(CultureInfo.InvariantCulture) : string.Empty);
```

This was reported as MA0075 even though the operand is a `string`.

## Cause

Before #1273, MA0075 only inspected concatenation operands that were an implicit conversion to `object`, and ignored everything else. #1273 changed it to run every operand through `CultureSensitiveFormattingContext.GetCultureSensitivity`, whose fallback for an unrecognized operation kind was:

```csharp
// Unknown operation
return CultureSensitivity.CultureSensitive;
```

`IConditionalOperation` has no case in that method, so the ternary fell through to "culture-sensitive" regardless of its type. The same false positive applied to coalesce expressions (`??`), switch expressions and `await` expressions.

## Fix

The fallback now uses the static type of the value, which is what determines the formatting behavior and is already how interpolated string parts are analyzed:

```csharp
// Unknown operation (conditional expression, coalesce expression, switch expression, await expression, ...).
// The formatting depends on the type of the value, so use it to determine the culture sensitivity.
return GetCultureSensitivity(operation.Type, format: null, instance: operation, options);
```

`"test" + (cond ? s : "")` is now clean, while `"test" + (cond ? a : b)` with `double` operands is still reported — same for `??`, `switch` and `await`.

## Notes for reviewers

- An operation with a `null` type (invalid code, method group) now maps to `MaybeCultureSensitiveOpaqueRuntimeType` instead of `CultureSensitive`, so it is no longer reported by default. That matches how `object`-typed values are already treated.
- `IInvocationOperation` is handled earlier in the method and is unaffected, so MA0011 (`UseIFormatProviderAnalyzer`) keeps its current behavior for invocations.

## Tests

8 tests added to `DoNotUseImplicitCultureSensitiveToStringAnalyzerTests` (a positive and a negative case for each expression kind, including the exact snippet from the issue).

- Full suite on the default Roslyn version: 3650 passed
- `roslyn4.8` (3520), `roslyn4.14` (3554), `roslyn5.0` (3593), `roslyn5.6` (3604): all passed
- `dotnet run --project src/DocumentationGenerator`: exit 0, no markdown changes