### PR TITLE
Build one project per Roslyn version and use the artifacts output layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,22 +66,9 @@ jobs:
 
     - run: dotnet run --project src/ListDotNetTypes/ListDotNetTypes.csproj -- src/Meziantou.Analyzer/Resources/
 
-    - run: dotnet build src/Meziantou.Analyzer/Meziantou.Analyzer.csproj --configuration Release /p:RoslynVersion=roslyn4.8 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.roslyn4.8.binlog
-    - run: dotnet build src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.csproj --configuration Release /p:RoslynVersion=roslyn4.8 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.CodeFixers.roslyn4.8.binlog
+    # Meziantou.Analyzer.Pack references one project per Roslyn version, so this builds all of them in the right order
+    - run: dotnet build src/Meziantou.Analyzer.Pack/Meziantou.Analyzer.Pack.csproj --configuration Release /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.Pack.build.binlog
 
-    - run: dotnet build src/Meziantou.Analyzer/Meziantou.Analyzer.csproj --configuration Release /p:RoslynVersion=roslyn4.14 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.roslyn4.14.binlog
-    - run: dotnet build src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.csproj --configuration Release /p:RoslynVersion=roslyn4.14 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.CodeFixers.roslyn4.14.binlog
-
-    - run: dotnet build src/Meziantou.Analyzer/Meziantou.Analyzer.csproj --configuration Release /p:RoslynVersion=roslyn5.0 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.roslyn5.0.binlog
-    - run: dotnet build src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.csproj --configuration Release /p:RoslynVersion=roslyn5.0 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.CodeFixers.roslyn5.0.binlog
-
-    - run: dotnet build src/Meziantou.Analyzer/Meziantou.Analyzer.csproj --configuration Release /p:RoslynVersion=roslyn5.6 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.roslyn5.6.binlog
-    - run: dotnet build src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.csproj --configuration Release /p:RoslynVersion=roslyn5.6 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.CodeFixers.roslyn5.6.binlog
-
-    - run: dotnet build src/Meziantou.Analyzer/Meziantou.Analyzer.csproj --configuration Release /p:RoslynVersion=roslyn5.9 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.roslyn5.9.binlog
-    - run: dotnet build src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.csproj --configuration Release /p:RoslynVersion=roslyn5.9 /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.CodeFixers.roslyn5.9.binlog
-
-    - run: dotnet restore src/Meziantou.Analyzer.Pack/Meziantou.Analyzer.Pack.csproj -bl:Meziantou.Analyzer.Pack.restore.binlog
     - run: dotnet pack src/Meziantou.Analyzer.Pack/Meziantou.Analyzer.Pack.csproj --configuration Release --no-build /p:Version=${{ needs.compute_package_version.outputs.package_version }} /bl:Meziantou.Analyzer.Pack.pack.binlog
     - run: dotnet pack src/Meziantou.Analyzer.Annotations/Meziantou.Analyzer.Annotations.csproj --configuration Release /bl:Meziantou.Analyzer.Annotations.pack.binlog
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,43 @@ jobs:
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}
+      - name: Validate the content of the analyzer package
+        run: |
+          $packages = @(Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Filter *.nupkg | Where-Object { $_.Name -match '^Meziantou\.Analyzer\.\d' })
+          if ($packages.Count -ne 1) {
+            Write-Host "::error::Expected 1 Meziantou.Analyzer package, found $($packages.Count)"
+            exit 1
+          }
+
+          # The expected Roslyn versions are the ones that have a project, the same way Meziantou.Analyzer.Pack discovers them
+          $versions = @(Get-ChildItem "src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn*.csproj" | ForEach-Object { $_.BaseName -replace '^.*\.(roslyn.*)$', '$1' })
+          if ($versions.Count -eq 0) {
+            Write-Host "::error::No Roslyn version specific project found"
+            exit 1
+          }
+
+          $expected = $versions | ForEach-Object {
+            "analyzers/dotnet/$_/cs/Meziantou.Analyzer.dll"
+            "analyzers/dotnet/$_/cs/Meziantou.Analyzer.CodeFixers.dll"
+          }
+
+          $zip = [System.IO.Compression.ZipFile]::OpenRead($packages[0].FullName)
+          try { $entries = @($zip.Entries.FullName) } finally { $zip.Dispose() }
+
+          $analyzers = @($entries | Where-Object { $_ -like 'analyzers/*' })
+          $errors = @()
+          $errors += $expected | Where-Object { $_ -notin $analyzers } | ForEach-Object { "Missing from the package: $_" }
+          $errors += $analyzers | Where-Object { $_ -notin $expected } | ForEach-Object { "Unexpected analyzer in the package: $_" }
+          # The analyzers must not be shipped as a regular library
+          $errors += $entries | Where-Object { $_ -like 'lib/*' } | ForEach-Object { "The package must not contain any assembly under lib: $_" }
+
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Host "::error::$_" }
+            exit 1
+          }
+
+          Write-Host "$($packages[0].Name) contains the analyzers for: $($versions -join ', ')"
+
       - name: Run dotnet validate
         run: |
           dotnet tool update Meziantou.Framework.NuGetPackageValidation.Tool --global

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,23 @@ This project supports multiple versions of Roslyn to ensure compatibility with d
 - `roslyn5.9` - Roslyn 5.9.0
 - `default` - Roslyn 5.9.0
 
+### Project layout
+
+There is one project per Roslyn version for both the analyzer and the code fixers:
+
+- `src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn<version>.csproj`
+- `src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn<version>.csproj`
+
+Those projects pin their own Roslyn version (using `TreatAsLocalProperty="RoslynVersion"`), so `/p:RoslynVersion` has no effect on them. That property is all they set: everything else is defined in the `Directory.Build.props` of their folder, which is shared by all the projects of the folder and imports the `Directory.Build.props` of the repository root.
+
+`Meziantou.Analyzer.csproj` and `Meziantou.Analyzer.CodeFixers.csproj` are the development projects: they honor `/p:RoslynVersion` and are the ones referenced by the tests and by `DocumentationGenerator`. When adding a file or a package reference, update the `Directory.Build.props` of the folder so that all Roslyn versions get it.
+
+`Meziantou.Analyzer.Pack.csproj` references every `roslyn<version>` project with `ReferenceOutputAssembly="false" PrivateAssets="all"`, so building or packing it builds all Roslyn versions in the right order without adding them as NuGet package dependencies.
+
+### Output folders
+
+The repository uses the [artifacts output layout](https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output), enabled in the `Directory.Build.props` of the repository root. There is no `bin` or `obj` folder next to the projects: the build output is in `artifacts/bin/<project name>/<configuration>_<target framework>`, the intermediate output in `artifacts/obj/<project name>/<configuration>_<target framework>`, and the NuGet packages in `artifacts/package/<configuration>`. This is what keeps the outputs of the Roslyn-specific projects separate, as they share their source folder.
+
 ### Building with a specific Roslyn version
 
 To build the project with a specific Roslyn version, use the `/p:RoslynVersion` MSBuild property:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ Those projects pin their own Roslyn version (using `TreatAsLocalProperty="Roslyn
 
 `Meziantou.Analyzer.csproj` and `Meziantou.Analyzer.CodeFixers.csproj` are the development projects: they honor `/p:RoslynVersion` and are the ones referenced by the tests and by `DocumentationGenerator`. When adding a file or a package reference, update the `Directory.Build.props` of the folder so that all Roslyn versions get it.
 
-`Meziantou.Analyzer.Pack.csproj` references every `roslyn<version>` project with `ReferenceOutputAssembly="false" PrivateAssets="all"`, so building or packing it builds all Roslyn versions in the right order without adding them as NuGet package dependencies.
+`Meziantou.Analyzer.Pack.csproj` discovers the `roslyn<version>` projects with a wildcard and references them with `ReferenceOutputAssembly="false" PrivateAssets="all"`, so building or packing it builds all Roslyn versions in the right order without adding them as NuGet package dependencies. Its `AddAnalyzersToPackage` target then asks each project for the assembly it produces (`GetTargetPath`) and packs it under `analyzers/dotnet/<roslyn version>/cs`. Adding support for a new Roslyn version therefore only requires adding its entry in `Directory.Build.targets` and its two projects.
 
 ### Output folders
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,14 @@
 <Project>
 
   <PropertyGroup>
+    <!-- https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output -->
+    <!-- ArtifactsPath is set explicitly because some folders have their own Directory.Build.props,
+         and the default location is the folder of the Directory.Build.props found for the project -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <LangVersion>preview</LangVersion>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <MeziantouPolyfill_IncludedPolyfills>*</MeziantouPolyfill_IncludedPolyfills>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,6 @@
 <Project>
   <!-- https://www.nuget.org/packages/Microsoft.CodeAnalysis.Analyzers/ -->
   <!-- https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp.Workspaces/ -->
-  <PropertyGroup>
-    <RoslynVersion></RoslynVersion>
-  </PropertyGroup>
-
   <Choose>
     <!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?WT.mc_id=DT-MVP-5003978 -->
     <!-- https://learn.microsoft.com/en-us/visualstudio/releases/2026/servicing-vs?WT.mc_id=DT-MVP-5003978#support-for-older-versions -->

--- a/Meziantou.Analyzer.slnx
+++ b/Meziantou.Analyzer.slnx
@@ -13,7 +13,17 @@
   <Project Path="src/ListDotNetTypes/ListDotNetTypes.csproj" />
   <Project Path="src/Meziantou.Analyzer.Annotations/Meziantou.Analyzer.Annotations.csproj" />
   <Project Path="src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.csproj" />
+  <Project Path="src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn4.8.csproj" />
+  <Project Path="src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn4.14.csproj" />
+  <Project Path="src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn5.0.csproj" />
+  <Project Path="src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn5.6.csproj" />
+  <Project Path="src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn5.9.csproj" />
   <Project Path="src/Meziantou.Analyzer.Pack/Meziantou.Analyzer.Pack.csproj" />
   <Project Path="src/Meziantou.Analyzer/Meziantou.Analyzer.csproj" />
+  <Project Path="src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn4.8.csproj" />
+  <Project Path="src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn4.14.csproj" />
+  <Project Path="src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.0.csproj" />
+  <Project Path="src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.6.csproj" />
+  <Project Path="src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.9.csproj" />
   <Project Path="tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj" />
 </Solution>

--- a/src/Meziantou.Analyzer.CodeFixers/Directory.Build.props
+++ b/src/Meziantou.Analyzer.CodeFixers/Directory.Build.props
@@ -1,0 +1,42 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Meziantou.Analyzer.CodeFixers</AssemblyName>
+    <RootNamespace>Meziantou.Analyzer</RootNamespace>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- Only Meziantou.Analyzer.Pack produces a NuGet package, and all the projects of this folder would use the same package output folder -->
+    <IsPackable>false</IsPackable>
+    <Version>1.0.1</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\BannedSymbols.txt" />
+
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\RuleIdentifiers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\CompilationExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\EnumerableExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\LanguageVersionExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\LocationExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\MethodSymbolExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\NamespaceSymbolExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\ObjectPool.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\OperationExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\StringExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\SymbolExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\OverloadFinder.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\OverloadOptions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\OverloadParameterType.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\TypeSymbolExtensions.cs" LinkBase="Internals" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Rules\DoNotUseBlockingCallInAsyncContextData.cs" LinkBase="Rules" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Rules\OptimizeLinqUsageData.cs" LinkBase="Rules" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Rules\OptimizeStringBuilderUsageData.cs" LinkBase="Rules" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Rules\*Common.cs" LinkBase="Rules" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.csproj
+++ b/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.csproj
@@ -1,37 +1,5 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Version>1.0.1</Version>
-    <BaseOutputPath>bin\$(RoslynVersion)\</BaseOutputPath>
-    <RootNamespace>Meziantou.Analyzer</RootNamespace>
-  </PropertyGroup>
-  <ItemGroup>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\BannedSymbols.txt" />
-
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\RuleIdentifiers.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\CompilationExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\EnumerableExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\LanguageVersionExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\LocationExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\MethodSymbolExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\NamespaceSymbolExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\ObjectPool.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\OperationExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\StringExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\SymbolExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\OverloadFinder.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\OverloadOptions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\OverloadParameterType.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Internals\TypeSymbolExtensions.cs" LinkBase="Internals" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Rules\DoNotUseBlockingCallInAsyncContextData.cs" LinkBase="Rules" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Rules\OptimizeLinqUsageData.cs" LinkBase="Rules" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Rules\OptimizeStringBuilderUsageData.cs" LinkBase="Rules" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\Rules\*Common.cs" LinkBase="Rules" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" PrivateAssets="all" />
-  </ItemGroup>
+  <!-- Development project. The Roslyn version can be selected with the RoslynVersion property.
+       The projects used to build the NuGet package are the Meziantou.Analyzer.CodeFixers.roslyn*.csproj ones.
+       The content of the project is defined in Directory.Build.props. -->
 </Project>

--- a/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn4.14.csproj
+++ b/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn4.14.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn4.14</RoslynVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn4.8.csproj
+++ b/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn4.8.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn4.8</RoslynVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn5.0.csproj
+++ b/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn5.0.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn5.0</RoslynVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn5.6.csproj
+++ b/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn5.6.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn5.6</RoslynVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn5.9.csproj
+++ b/src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn5.9.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn5.9</RoslynVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Meziantou.Analyzer.Pack/Meziantou.Analyzer.Pack.csproj
+++ b/src/Meziantou.Analyzer.Pack/Meziantou.Analyzer.Pack.csproj
@@ -14,11 +14,8 @@
     <PackageTags>Meziantou.Analyzer, csharp, roslyn, static-analysis, analyzer, code-quality, analyzers, roslyn-analyzers</PackageTags>
 
     <SearchReadmeFileAbove>true</SearchReadmeFileAbove>
-  </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Artifacts pivot of the analyzer projects: they are multi-targeted, and only the netstandard2.0 assemblies are packed -->
-    <_AnalyzerArtifactsPivot>$(Configuration.ToLowerInvariant())_netstandard2.0</_AnalyzerArtifactsPivot>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddAnalyzersToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,34 +24,29 @@
     <None Include="buildTransitive/**" Pack="true" PackagePath="buildTransitive" />
 
     <None Include="configuration/*.editorconfig" Pack="true" PackagePath="configuration" />
-
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn4.8\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs/" />
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn4.8\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs/" />
-
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn4.14\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.14/cs/" />
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn4.14\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.14/cs/" />
-
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn5.0\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.0/cs/" />
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn5.0\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.0/cs/" />
-
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn5.6\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.6/cs/" />
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn5.6\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.6/cs/" />
-
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn5.9\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.9/cs/" />
-    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn5.9\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.9/cs/" />
   </ItemGroup>
 
-  <!-- Build order only: the assemblies are packed using the None items above, and PrivateAssets="all" keeps those projects out of the NuGet package dependencies -->
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn4.8.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn4.8.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn4.14.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn4.14.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn5.0.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn5.0.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn5.6.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn5.6.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn5.9.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn5.9.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <!-- Discover the projects instead of listing them, so adding a Roslyn version only means adding its projects -->
+    <AnalyzerProject Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn*.csproj" />
+    <AnalyzerProject Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn*.csproj" />
+
+    <!-- Build order only: the assemblies are packed by AddAnalyzersToPackage, and PrivateAssets="all" keeps those projects out of the NuGet package dependencies -->
+    <ProjectReference Include="@(AnalyzerProject)" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>
+
+  <!-- Ask each project for the assembly it produces instead of guessing its output folder -->
+  <Target Name="AddAnalyzersToPackage">
+    <Error Condition="'@(AnalyzerProject)' == ''" Text="No Roslyn version specific project found. The package would not contain any analyzer." />
+
+    <MSBuild Projects="@(AnalyzerProject)" Targets="GetTargetPath" Properties="TargetFramework=netstandard2.0;Configuration=$(Configuration)">
+      <Output TaskParameter="TargetOutputs" ItemName="_AnalyzerAssembly" />
+    </MSBuild>
+
+    <ItemGroup>
+      <!-- The Roslyn version is the suffix of the project file name, e.g. Meziantou.Analyzer.roslyn4.8.csproj -->
+      <TfmSpecificPackageFile Include="@(_AnalyzerAssembly)"
+                              PackagePath="analyzers/dotnet/$([System.Text.RegularExpressions.Regex]::Replace('%(MSBuildSourceProjectFile)', '^.*\.(roslyn.*)\.csproj$', '$1'))/cs/" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Meziantou.Analyzer.Pack/Meziantou.Analyzer.Pack.csproj
+++ b/src/Meziantou.Analyzer.Pack/Meziantou.Analyzer.Pack.csproj
@@ -16,6 +16,11 @@
     <SearchReadmeFileAbove>true</SearchReadmeFileAbove>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Artifacts pivot of the analyzer projects: they are multi-targeted, and only the netstandard2.0 assemblies are packed -->
+    <_AnalyzerArtifactsPivot>$(Configuration.ToLowerInvariant())_netstandard2.0</_AnalyzerArtifactsPivot>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="build/**" Pack="true" PackagePath="build" />
     <None Include="buildMultiTargeting/**" Pack="true" PackagePath="buildMultiTargeting" />
@@ -23,19 +28,33 @@
 
     <None Include="configuration/*.editorconfig" Pack="true" PackagePath="configuration" />
 
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\bin\roslyn4.8\$(Configuration)\netstandard2.0\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs/" />
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer.CodeFixers\bin\roslyn4.8\$(Configuration)\netstandard2.0\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn4.8\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn4.8\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs/" />
 
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\bin\roslyn4.14\$(Configuration)\netstandard2.0\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.14/cs/" />
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer.CodeFixers\bin\roslyn4.14\$(Configuration)\netstandard2.0\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.14/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn4.14\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.14/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn4.14\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.14/cs/" />
 
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\bin\roslyn5.0\$(Configuration)\netstandard2.0\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.0/cs/" />
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer.CodeFixers\bin\roslyn5.0\$(Configuration)\netstandard2.0\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.0/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn5.0\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.0/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn5.0\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.0/cs/" />
 
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\bin\roslyn5.6\$(Configuration)\netstandard2.0\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.6/cs/" />
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer.CodeFixers\bin\roslyn5.6\$(Configuration)\netstandard2.0\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.6/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn5.6\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.6/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn5.6\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.6/cs/" />
 
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\bin\roslyn5.9\$(Configuration)\netstandard2.0\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.9/cs/" />
-    <None Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer.CodeFixers\bin\roslyn5.9\$(Configuration)\netstandard2.0\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.9/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.roslyn5.9\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.9/cs/" />
+    <None Include="$(ArtifactsPath)\bin\Meziantou.Analyzer.CodeFixers.roslyn5.9\$(_AnalyzerArtifactsPivot)\Meziantou.Analyzer.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.9/cs/" />
+  </ItemGroup>
+
+  <!-- Build order only: the assemblies are packed using the None items above, and PrivateAssets="all" keeps those projects out of the NuGet package dependencies -->
+  <ItemGroup>
+    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn4.8.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn4.8.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn4.14.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn4.14.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn5.0.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn5.0.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn5.6.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn5.6.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\Meziantou.Analyzer\Meziantou.Analyzer.roslyn5.9.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="..\Meziantou.Analyzer.CodeFixers\Meziantou.Analyzer.CodeFixers.roslyn5.9.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Meziantou.Analyzer/Directory.Build.props
+++ b/src/Meziantou.Analyzer/Directory.Build.props
@@ -1,0 +1,49 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Meziantou.Analyzer</AssemblyName>
+    <RootNamespace>Meziantou.Analyzer</RootNamespace>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- Only Meziantou.Analyzer.Pack produces a NuGet package, and all the projects of this folder would use the same package output folder -->
+    <IsPackable>false</IsPackable>
+    <Version>1.0.1</Version>
+
+    <!-- Cannot use Meziantou.Analyzer, so the analyzer can be added to this project -->
+    <PackageId>Dummy</PackageId>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <developmentDependency>true</developmentDependency>
+    <Description>A Roslyn analyzer to enforce some good practices in C#</Description>
+    <PackageTags>Meziantou.Analyzer, analyzers</PackageTags>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\docs\**\*" LinkBase="docs" />
+    <EmbeddedResource Include="Resources\*.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Internals\ContextExtensions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ContextExtensions.g.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Internals\ContextExtensions.g.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ContextExtensions.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/src/Meziantou.Analyzer/Meziantou.Analyzer.csproj
+++ b/src/Meziantou.Analyzer/Meziantou.Analyzer.csproj
@@ -1,48 +1,5 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Version>1.0.1</Version>
-    
-    <!-- Cannot use Meziantou.Analyzer, so the analyzer can be added to this project -->
-    <PackageId>Dummy</PackageId>
-    <GenerateDependencyFile>false</GenerateDependencyFile>
-    <developmentDependency>true</developmentDependency>
-    <Description>A Roslyn analyzer to enforce some good practices in C#</Description>
-    <PackageTags>Meziantou.Analyzer, analyzers</PackageTags>
-    <NoPackageAnalysis>true</NoPackageAnalysis>
-    
-    <BaseOutputPath>bin\$(RoslynVersion)\</BaseOutputPath>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)..\..\docs\**\*" LinkBase="docs" />
-    <EmbeddedResource Include="Resources\*.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />    
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(OutputPath)\netstandard2.0\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="Internals\ContextExtensions.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>ContextExtensions.g.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="Internals\ContextExtensions.g.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>ContextExtensions.tt</DependentUpon>
-    </Compile>
-  </ItemGroup>
+  <!-- Development project. The Roslyn version can be selected with the RoslynVersion property.
+       The projects used to build the NuGet package are the Meziantou.Analyzer.roslyn*.csproj ones.
+       The content of the project is defined in Directory.Build.props. -->
 </Project>

--- a/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn4.14.csproj
+++ b/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn4.14.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn4.14</RoslynVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn4.8.csproj
+++ b/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn4.8.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn4.8</RoslynVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.0.csproj
+++ b/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.0.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn5.0</RoslynVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.6.csproj
+++ b/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.6.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn5.6</RoslynVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.9.csproj
+++ b/src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.9.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
+  <!-- The content of the project is defined in Directory.Build.props -->
+  <PropertyGroup>
+    <RoslynVersion>roslyn5.9</RoslynVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## What

Replaces the "one project built N times with `/p:RoslynVersion`" scheme with one project per supported Roslyn version, and switches the repository to the [artifacts output layout](https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output).

### One project per Roslyn version

New projects, for both the analyzer and the code fixers:

- `src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn{4.8,4.14,5.0,5.6,5.9}.csproj`
- `src/Meziantou.Analyzer.CodeFixers/Meziantou.Analyzer.CodeFixers.roslyn{4.8,4.14,5.0,5.6,5.9}.csproj`

Each one only pins its version; `TreatAsLocalProperty` makes that pin win over a global `/p:RoslynVersion`:

```xml
<Project Sdk="Meziantou.NET.Sdk" TreatAsLocalProperty="RoslynVersion">
  <PropertyGroup>
    <RoslynVersion>roslyn4.8</RoslynVersion>
  </PropertyGroup>
</Project>
```

Everything else moved to a `Directory.Build.props` per folder, which imports the one of the repository root with `GetPathOfFileAbove`.

`Meziantou.Analyzer.csproj` and `Meziantou.Analyzer.CodeFixers.csproj` stay as the development projects — still driven by `/p:RoslynVersion`, still the ones referenced by the tests and by `DocumentationGenerator`, so the test matrix is unchanged.

### Pack project drives the build order

`Meziantou.Analyzer.Pack.csproj` discovers the version-specific projects with a wildcard and references them with `ReferenceOutputAssembly="false" PrivateAssets="all"`: build order is guaranteed when building the solution, and none of them becomes a dependency of the NuGet package. The `create_nuget` CI job goes from ten explicit `dotnet build` commands plus a `restore` down to a `build` and a `pack` of that single project.

Rather than hardcoding where the assemblies land, an `AddAnalyzersToPackage` target asks each project for the assembly it produces, and derives the package folder from the project file name:

```xml
<Target Name="AddAnalyzersToPackage">
  <Error Condition="'@(AnalyzerProject)' == ''" Text="No Roslyn version specific project found. The package would not contain any analyzer." />

  <MSBuild Projects="@(AnalyzerProject)" Targets="GetTargetPath" Properties="TargetFramework=netstandard2.0;Configuration=$(Configuration)">
    <Output TaskParameter="TargetOutputs" ItemName="_AnalyzerAssembly" />
  </MSBuild>

  <ItemGroup>
    <TfmSpecificPackageFile Include="@(_AnalyzerAssembly)"
                            PackagePath="analyzers/dotnet/$([System.Text.RegularExpressions.Regex]::Replace('%(MSBuildSourceProjectFile)', '^.*\.(roslyn.*)\.csproj$', '$1'))/cs/" />
  </ItemGroup>
</Target>
```

So the pack project no longer repeats the output layout, and adding support for a new Roslyn version only requires its entry in `Directory.Build.targets` and its two projects.

### Artifacts output

Enabled in the root `Directory.Build.props`. Since `artifacts/bin/<project name>/` already separates projects by name, this is what keeps the outputs of the version-specific projects apart even though they share their source folder — no `BaseOutputPath`/`BaseIntermediateOutputPath` overrides needed.

`ArtifactsPath` is set explicitly, because it otherwise defaults to the folder of *the* `Directory.Build.props` the SDK found for a project — which is now a nested one for the analyzer and the code fixers, so the default would have created `src/Meziantou.Analyzer/artifacts`.

## Notes for the reviewer

- `Directory.Build.targets` no longer resets `RoslynVersion` to an empty value. That assignment was a no-op before (the property was always a global one, which cannot be overridden by a project), but it would now clear the value set by the version-specific projects.
- `IsPackable=false` on the analyzer and code fixer projects: `PackageOutputPath` is now a single shared `artifacts/package/<configuration>` folder, so 12 projects all claiming `PackageId=Dummy` would collide there on a solution-wide `dotnet pack`. `PackageId=Dummy` itself is kept — it is what lets these projects reference the published `Meziantou.Analyzer` package.
- The now-dead `<None Include="$(OutputPath)\netstandard2.0\...` `Pack="true"` item was removed.
- No CI path changes were needed for the artifacts switch: `**/*.nupkg` still matches `artifacts/package/release/`, and `.gitignore` already ignored `artifacts/`.

### CI asserts the package shape

`validate_nuget` only ran the generic package validation, so a change in the pack project could have moved or dropped the analyzers unnoticed. A new step asserts that every expected assembly is at the location Roslyn looks for. The expected Roslyn versions are discovered from the version-specific projects — the same way the pack project discovers them — so a new version is covered without editing the workflow. The comparison is exact in both directions, so an analyzer at an unexpected location fails too, and assemblies under `lib/` are rejected.

## Verification

- `dotnet build Meziantou.Analyzer.slnx -c Release` — succeeds, 0 warnings; no `bin`/`obj` folder is left next to any project.
- `dotnet build` + `dotnet pack --no-build` on the pack project produce a package **identical to the previous one**: same 25 entries, same `analyzers/dotnet/roslyn*/cs/` layout, empty dependency group, and `/p:Version` flows through the project references into the assemblies.
- Auto-discovery checked by dropping in a throwaway `Meziantou.Analyzer.roslyn6.0.csproj` / `Meziantou.Analyzer.CodeFixers.roslyn6.0.csproj`: the package picked up `analyzers/dotnet/roslyn6.0/cs/` with no change to the pack project (12 analyzer entries instead of 10). The throwaway projects were then removed.
- Each version-specific project resolves its own Roslyn (`Microsoft.CodeAnalysis.CSharp` 4.8.0 → 5.9.0), and keeps its own `DefineConstants` even when a conflicting `/p:RoslynVersion` is passed on the command line.
- All six test configurations pass: roslyn4.8 3512, roslyn4.14 3546, roslyn5.0 3585, roslyn5.6 3596, roslyn5.9 3642, default 3642.
- `dotnet run --project src/DocumentationGenerator` reports no markdown changes.
- The new CI assertion was run locally with `pwsh`, extracting the script straight out of the parsed workflow so the exact text CI runs is what was tested. It passes on the real package, and fails as expected on hand-crafted packages with an analyzer at a wrong location, an assembly under `lib/`, and a missing `roslyn5.6` code fixer — plus on a `roslyn6.0` project with no matching package entry. It correctly ignores the `Meziantou.Analyzer.Annotations` package sitting next to it.


