### PR TITLE
Split the tests into 2 shards per Roslyn version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "meziantou.shardedtest": {
+      "version": "1.1.0",
+      "commands": [
+        "sharded-test"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,24 +152,45 @@ jobs:
 
   build_and_test:
     runs-on: ${{ matrix.runs-on }}
+    name: build_and_test (${{ matrix.runs-on }}, ${{ matrix.configuration }}, ${{ matrix.roslyn-version }}, shard ${{ matrix.shard-index }})
     env:
       TestResultsDirectory: ${{ github.workspace}}/TestResults
+      TotalShards: 2
+      # Options added by Meziantou.NET.Sdk.Test to every test run. They are set explicitly because
+      # 'EnableDefaultTestSettings' has to be disabled: sharded-test lists the tests before running them,
+      # and both '--report-trx' and '--minimum-expected-tests' make 'dotnet test --list-tests' report no test.
+      # The trx report is passed on the sharded-test command line instead, so it is removed from the discovery
+      # step and each batch writes a report with a distinct file name.
+      MtpArguments: --report-gh --report-gh-slow-test-notices off --coverage --crashdump --crashdump-type mini --hangdump --hangdump-timeout 10m --hangdump-type mini
     strategy:
       matrix:
         runs-on: [ ubuntu-latest ]
         configuration: [ Release ]
         roslyn-version: [ 'roslyn4.8', 'roslyn4.14', 'roslyn5.0', 'roslyn5.6', 'roslyn5.9', 'default' ]
+        shard-index: [ 1, 2 ]
       fail-fast: false
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Setup .NET Core (global.json)
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
-    - run: dotnet test --configuration ${{ matrix.configuration }} --results-directory "${{ env.TestResultsDirectory }}" /p:RoslynVersion=${{ matrix.roslyn-version}}
+    - run: dotnet tool install --global Meziantou.ShardedTest --version 1.1.0
+      name: Install sharded-test
+    - run: >
+        sharded-test
+        --shard-index ${{ matrix.shard-index }}
+        --total-shards ${{ env.TotalShards }}
+        --project tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj
+        --configuration ${{ matrix.configuration }}
+        --results-directory "${{ env.TestResultsDirectory }}"
+        /p:RoslynVersion=${{ matrix.roslyn-version}}
+        /p:EnableDefaultTestSettings=false
+        "/p:TestingPlatformCommandLineArguments=${{ env.MtpArguments }}"
+        --report-trx --report-trx-filename "report_{pid}.trx"
       name: Run tests
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()
       with:
-        name: test-results-${{ matrix.runs-on }}-${{ matrix.roslyn-version }}-${{ matrix.configuration }}
+        name: test-results-${{ matrix.runs-on }}-${{ matrix.roslyn-version }}-${{ matrix.configuration }}-shard${{ matrix.shard-index }}
         if-no-files-found: error
         retention-days: 3
         path: ${{ env.TestResultsDirectory }}/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,10 +173,10 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Setup .NET Core (global.json)
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
-    - run: dotnet tool install --global Meziantou.ShardedTest --version 1.1.0
-      name: Install sharded-test
+    - run: dotnet tool restore
+      name: Restore the local tools
     - run: >
-        sharded-test
+        dotnet sharded-test
         --shard-index ${{ matrix.shard-index }}
         --total-shards ${{ env.TotalShards }}
         --project tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.csproj

--- a/Meziantou.Analyzer.slnx
+++ b/Meziantou.Analyzer.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/Solution Items/">
+    <File Path=".config/dotnet-tools.json" />
     <File Path=".editorconfig" />
     <File Path=".github/workflows/ci.yml" />
     <File Path="CHANGELOG.md" />


### PR DESCRIPTION
Use [Meziantou.ShardedTest](https://www.nuget.org/packages/Meziantou.ShardedTest/1.1.0) to split the test project into 2 shards, so the `build_and_test` matrix goes from 6 to 12 jobs (2 per Roslyn version).

The job also targets the test project instead of the solution, so the Roslyn version specific projects and `Meziantou.Analyzer.Pack` are no longer rebuilt by every test job — they are already built by `create_nuget`.

### Why `EnableDefaultTestSettings` is disabled

`sharded-test` runs `dotnet test --list-tests` before running the tests. With the options `Meziantou.NET.Sdk.Test` adds by default, discovery reports **0 test**, which makes the tool fail. The two options responsible are:

| Option | `dotnet test --list-tests` |
| --- | --- |
| `--report-trx` | `Discovered 0 tests.` |
| `--minimum-expected-tests 1` | `Discovered 0 tests.` |
| `--report-gh --report-gh-slow-test-notices off` | `Discovered 3650 tests.` |
| `--crashdump --crashdump-type mini` | `Discovered 3650 tests.` |
| `--hangdump --hangdump-timeout 10m --hangdump-type mini` | `Discovered 3650 tests.` |
| `--coverage` | `Discovered 3650 tests.` |

So the workflow sets `EnableDefaultTestSettings=false` and passes the options itself:

- the ones that do not break discovery are passed through `TestingPlatformCommandLineArguments`, so they apply to both steps;
- `--report-trx --report-trx-filename "report_{pid}.trx"` is passed on the `sharded-test` command line, so the tool removes it from the discovery step and each batch writes a report with a distinct file name;
- `--minimum-expected-tests` is dropped. `sharded-test` already fails when discovery returns no test.

Note that `--report-gh-slow-test-notices off` cannot be passed on the `sharded-test` command line: the tool removes `--report-gh-slow-test-notices` from the discovery command but leaves the `off` value behind, which then breaks discovery.

### Results

Both shards pass locally (1842 + 1808 of the 3650 tests). Timings are in the PR comments.