### PR TITLE
Improve MA0195 to detect static fields initialized in the static constructor

### DIFF
--- a/docs/Rules/MA0195.md
+++ b/docs/Rules/MA0195.md
@@ -3,14 +3,15 @@
 Source: [DoNotUseNotYetInitializedStaticFieldAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzer.cs)
 <!-- sources -->
 
-Static fields are initialized in declaration order. Reading another static field in a field initializer can observe the default value when that field is declared later.
+Static fields are initialized in declaration order, and the static constructor runs after all the static field initializers. Reading another static field in a field initializer can observe the default value when that field is initialized later.
 
 This rule reports references to static fields from static field initializers when:
 
 - the referenced field is declared later in the same partial declaration, or
-- the referenced field is declared in another partial declaration of the same type.
+- the referenced field is declared in another partial declaration of the same type, or
+- the referenced field has no initializer and is assigned in the static constructor.
 
-Fields without an explicit initializer are ignored.
+Fields without an explicit initializer that are never assigned in the static constructor are ignored.
 
 ````csharp
 public class Example
@@ -27,5 +28,20 @@ public class Example
     public static readonly bool P1 = true;
     public static readonly bool P2 = false;
     public static readonly bool[] Both = new[] { P1, P2 }; // compliant
+}
+````
+
+````csharp
+public class Example
+{
+    public static readonly string Path;
+    public static readonly string Value = Compute(Path); // MA0195: Path is still null as the static constructor has not run yet
+
+    static Example()
+    {
+        Path = "path";
+    }
+
+    private static string Compute(string? path = null) => path ?? "default";
 }
 ````

--- a/src/Meziantou.Analyzer/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzer.cs
@@ -12,27 +12,19 @@ namespace Meziantou.Analyzer.Rules;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzer : DiagnosticAnalyzer
 {
+    private const string StaticConstructorReason = " because it is assigned in the static constructor, which runs after the static field initializers";
+
     private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.DoNotUseNotYetInitializedStaticField,
         title: "Do not use static fields before they are initialized",
-        messageFormat: "Static field '{0}' may not be initialized yet",
+        messageFormat: "Static field '{0}' may not be initialized yet{1}",
         RuleCategories.Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.DoNotUseNotYetInitializedStaticField));
 
-    private static readonly DiagnosticDescriptor RuleStaticConstructor = new(
-        RuleIdentifiers.DoNotUseNotYetInitializedStaticField,
-        title: "Do not use static fields before they are initialized",
-        messageFormat: "Static field '{0}' is assigned in the static constructor, which runs after the static field initializers",
-        RuleCategories.Usage,
-        DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
-        description: "",
-        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.DoNotUseNotYetInitializedStaticField));
-
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule, RuleStaticConstructor);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -110,14 +102,14 @@ public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzer : DiagnosticAna
                     if (!_fieldsAssignedInStaticConstructor.ContainsKey(referencedField))
                         continue;
 
-                    context.ReportDiagnostic(RuleStaticConstructor, location, [referencedField.Name]);
+                    context.ReportDiagnostic(Rule, location, referencedField.Name, StaticConstructorReason);
                     continue;
                 }
 
                 if (!ShouldReport(currentFieldInfo.Value, referencedFieldInfo.Value))
                     continue;
 
-                context.ReportDiagnostic(Rule, location, [referencedField.Name]);
+                context.ReportDiagnostic(Rule, location, referencedField.Name, "");
             }
         }
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzer.cs
@@ -22,7 +22,17 @@ public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzer : DiagnosticAna
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.DoNotUseNotYetInitializedStaticField));
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    private static readonly DiagnosticDescriptor RuleStaticConstructor = new(
+        RuleIdentifiers.DoNotUseNotYetInitializedStaticField,
+        title: "Do not use static fields before they are initialized",
+        messageFormat: "Static field '{0}' is assigned in the static constructor, which runs after the static field initializers",
+        RuleCategories.Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.DoNotUseNotYetInitializedStaticField));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule, RuleStaticConstructor);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -32,45 +42,101 @@ public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzer : DiagnosticAna
         context.RegisterCompilationStartAction(context =>
         {
             var fieldDeclarationInfos = new ConcurrentDictionary<IFieldSymbol, FieldDeclarationInfo?>(SymbolEqualityComparer.Default);
-            context.RegisterOperationAction(context => AnalyzeFieldReference(context, fieldDeclarationInfos), OperationKind.FieldReference);
+
+            context.RegisterSymbolStartAction(context =>
+            {
+                var analyzerContext = new AnalyzerContext(fieldDeclarationInfos);
+                context.RegisterOperationAction(analyzerContext.AnalyzeFieldReference, OperationKind.FieldReference);
+                context.RegisterSymbolEndAction(analyzerContext.ReportDiagnostics);
+            }, SymbolKind.NamedType);
         });
     }
 
-    private static void AnalyzeFieldReference(OperationAnalysisContext context, ConcurrentDictionary<IFieldSymbol, FieldDeclarationInfo?> fieldDeclarationInfos)
+    private sealed class AnalyzerContext(ConcurrentDictionary<IFieldSymbol, FieldDeclarationInfo?> fieldDeclarationInfos)
     {
-        var fieldReferenceOperation = (IFieldReferenceOperation)context.Operation;
-        if (fieldReferenceOperation.IsInNameofOperation())
-            return;
+        private readonly ConcurrentBag<FieldReferenceInfo> _candidates = [];
+        private readonly ConcurrentDictionary<IFieldSymbol, bool> _fieldsAssignedInStaticConstructor = new(SymbolEqualityComparer.Default);
 
-        if (IsInDeferredExecutionContext(fieldReferenceOperation))
-            return;
+        public void AnalyzeFieldReference(OperationAnalysisContext context)
+        {
+            var fieldReferenceOperation = (IFieldReferenceOperation)context.Operation;
+            if (fieldReferenceOperation.IsInNameofOperation())
+                return;
 
-        var referencedField = fieldReferenceOperation.Field;
-        if (referencedField is not { IsImplicitlyDeclared: false, IsStatic: true, IsConst: false })
-            return;
+            if (IsInDeferredExecutionContext(fieldReferenceOperation))
+                return;
 
-        if (!TryGetContainingFieldInitializerField(fieldReferenceOperation, out var currentField))
-            return;
+            var referencedField = fieldReferenceOperation.Field;
+            if (referencedField is not { IsImplicitlyDeclared: false, IsStatic: true, IsConst: false })
+                return;
 
-        if (!referencedField.ContainingType.IsEqualTo(currentField.ContainingType))
-            return;
+            if (!TryGetContainingFieldInitializerField(fieldReferenceOperation, out var currentField))
+            {
+                if (IsWrittenInStaticConstructor(context, fieldReferenceOperation))
+                {
+                    _fieldsAssignedInStaticConstructor.TryAdd(referencedField, true);
+                }
 
-        if (referencedField.IsEqualTo(currentField))
-            return;
+                return;
+            }
 
-        var currentFieldInfo = GetFieldDeclarationInfo(currentField, fieldDeclarationInfos, context.CancellationToken);
-        if (currentFieldInfo is null)
-            return;
+            if (!referencedField.ContainingType.IsEqualTo(currentField.ContainingType))
+                return;
 
-        var referencedFieldInfo = GetFieldDeclarationInfo(referencedField, fieldDeclarationInfos, context.CancellationToken);
-        if (referencedFieldInfo is null || referencedFieldInfo.Value.Initializer is null)
-            return;
+            if (referencedField.IsEqualTo(currentField))
+                return;
 
-        if (!ShouldReport(currentFieldInfo.Value, referencedFieldInfo.Value))
-            return;
+            _candidates.Add(new(fieldReferenceOperation.Syntax.GetLocation(), referencedField, currentField));
+        }
 
-        context.ReportDiagnostic(Rule, fieldReferenceOperation, referencedField.Name);
+        public void ReportDiagnostics(SymbolAnalysisContext context)
+        {
+            foreach (var (location, referencedField, currentField) in _candidates)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+
+                var currentFieldInfo = GetFieldDeclarationInfo(currentField, fieldDeclarationInfos, context.CancellationToken);
+                if (currentFieldInfo is null)
+                    continue;
+
+                var referencedFieldInfo = GetFieldDeclarationInfo(referencedField, fieldDeclarationInfos, context.CancellationToken);
+                if (referencedFieldInfo is null)
+                    continue;
+
+                if (referencedFieldInfo.Value.Initializer is null)
+                {
+                    // A field with no initializer is only observed as not-yet-initialized when the static constructor
+                    // assigns it, as the static constructor body runs after all the static field initializers.
+                    if (!_fieldsAssignedInStaticConstructor.ContainsKey(referencedField))
+                        continue;
+
+                    context.ReportDiagnostic(RuleStaticConstructor, location, [referencedField.Name]);
+                    continue;
+                }
+
+                if (!ShouldReport(currentFieldInfo.Value, referencedFieldInfo.Value))
+                    continue;
+
+                context.ReportDiagnostic(Rule, location, [referencedField.Name]);
+            }
+        }
+
+        private static bool IsWrittenInStaticConstructor(OperationAnalysisContext context, IFieldReferenceOperation operation)
+        {
+            if (context.ContainingSymbol is not IMethodSymbol { MethodKind: MethodKind.StaticConstructor })
+                return false;
+
+            return operation.Parent switch
+            {
+                IAssignmentOperation assignment => assignment.Target == operation,
+                IIncrementOrDecrementOperation incrementOrDecrement => incrementOrDecrement.Target == operation,
+                IArgumentOperation { Parameter.RefKind: RefKind.Ref or RefKind.Out } => true,
+                _ => false,
+            };
+        }
     }
+
+    private readonly record struct FieldReferenceInfo(Location Location, IFieldSymbol ReferencedField, IFieldSymbol CurrentField);
 
     private static bool IsInDeferredExecutionContext(IOperation operation)
     {

--- a/src/Meziantou.Analyzer/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzer.cs
@@ -37,14 +37,31 @@ public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzer : DiagnosticAna
 
             context.RegisterSymbolStartAction(context =>
             {
-                var analyzerContext = new AnalyzerContext(fieldDeclarationInfos);
+                // Delegates have no field, and all the fields of an enum are const, so they can never report anything.
+                // Most other types have no static field either, so this avoids allocating the analyzer context for them.
+                var symbol = (INamedTypeSymbol)context.Symbol;
+                if (!HasCandidateStaticField(symbol))
+                    return;
+
+                var analyzerContext = new AnalyzerContext(symbol, fieldDeclarationInfos);
                 context.RegisterOperationAction(analyzerContext.AnalyzeFieldReference, OperationKind.FieldReference);
                 context.RegisterSymbolEndAction(analyzerContext.ReportDiagnostics);
             }, SymbolKind.NamedType);
         });
     }
 
-    private sealed class AnalyzerContext(ConcurrentDictionary<IFieldSymbol, FieldDeclarationInfo?> fieldDeclarationInfos)
+    private static bool HasCandidateStaticField(INamedTypeSymbol symbol)
+    {
+        foreach (var member in symbol.GetMembers())
+        {
+            if (member is IFieldSymbol { IsImplicitlyDeclared: false, IsStatic: true, IsConst: false })
+                return true;
+        }
+
+        return false;
+    }
+
+    private sealed class AnalyzerContext(INamedTypeSymbol containingType, ConcurrentDictionary<IFieldSymbol, FieldDeclarationInfo?> fieldDeclarationInfos)
     {
         private readonly ConcurrentBag<FieldReferenceInfo> _candidates = [];
         private readonly ConcurrentDictionary<IFieldSymbol, bool> _fieldsAssignedInStaticConstructor = new(SymbolEqualityComparer.Default);
@@ -64,7 +81,7 @@ public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzer : DiagnosticAna
 
             if (!TryGetContainingFieldInitializerField(fieldReferenceOperation, out var currentField))
             {
-                if (IsWrittenInStaticConstructor(context, fieldReferenceOperation))
+                if (referencedField.ContainingType.IsEqualTo(containingType) && IsWrittenInStaticConstructor(context, fieldReferenceOperation))
                 {
                     _fieldsAssignedInStaticConstructor.TryAdd(referencedField, true);
                 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzerTests.cs
@@ -126,6 +126,128 @@ public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzerTests
     }
 
     [Fact]
+    public async Task ReportDiagnostic_WhenReferencedFieldIsOnlyAssignedInStaticConstructor()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class Sample
+                  {
+                      private static readonly int Other;
+                      private static readonly int Value = [|Other|];
+
+                      static Sample()
+                      {
+                          Other = 42;
+                      }
+                  }
+                  """)
+              .ShouldReportDiagnosticWithMessage("Static field 'Other' is assigned in the static constructor, which runs after the static field initializers")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_WhenReferencedFieldAssignedInStaticConstructorIsUsedInMethodCall()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class Sample
+                  {
+                      private static readonly string Path;
+                      private static readonly string Value = Compute([|Path|]);
+
+                      static Sample()
+                      {
+                          Path = "path";
+                      }
+
+                      private static string Compute(string? path = null) => path ?? "default";
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_WhenReferencedFieldIsAssignedInStaticConstructorOfAnotherPartialDeclaration()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  partial class Sample
+                  {
+                      private static readonly int Value = [|Other|];
+                  }
+
+                  partial class Sample
+                  {
+                      private static readonly int Other;
+
+                      static Sample()
+                      {
+                          Other = 42;
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenFieldIsOnlyReadInStaticConstructor()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class Sample
+                  {
+                      private static readonly int Other;
+                      private static int Value;
+
+                      static Sample()
+                      {
+                          Value = Other;
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenReferencedFieldIsAssignedInAnInstanceConstructor()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class Sample
+                  {
+                      private static int Other;
+                      private static readonly int Value = Other;
+
+                      public Sample()
+                      {
+                          Other = 42;
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_WhenReferencedFieldIsAssignedInAStaticConstructorLambda()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  class Sample
+                  {
+                      private static int Other;
+                      private static readonly int Value = Other;
+
+                      static Sample()
+                      {
+                          System.Action action = () => Other = 42;
+                          action();
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task NoDiagnostic_WhenReferenceIsInLambda()
     {
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzerTests.cs
@@ -248,6 +248,39 @@ public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzerTests
     }
 
     [Fact]
+    public async Task ReportDiagnostic_WhenTypeIsAnInterface()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  interface ISample
+                  {
+                      private static readonly int Other;
+                      private static readonly int Value = [|Other|];
+
+                      static ISample()
+                      {
+                          Other = 42;
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NoDiagnostic_ForEnumMembers()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  enum Sample
+                  {
+                      A = 1,
+                      B = A + 1,
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task NoDiagnostic_WhenReferenceIsInLambda()
     {
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzerTests.cs
@@ -141,7 +141,7 @@ public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzerTests
                       }
                   }
                   """)
-              .ShouldReportDiagnosticWithMessage("Static field 'Other' is assigned in the static constructor, which runs after the static field initializers")
+              .ShouldReportDiagnosticWithMessage("Static field 'Other' may not be initialized yet because it is assigned in the static constructor, which runs after the static field initializers")
               .ValidateAsync();
     }
 


### PR DESCRIPTION
Fix #1299.

## Problem

MA0195 only reported a static field reference when the referenced field had a *field initializer* declared later. A field with **no initializer** that is assigned in the static constructor was silently ignored:

```csharp
class Sample
{
    private static readonly string Path;
    private static readonly string Value = Compute(Path); // Path is null here

    static Sample() { Path = "path"; }

    private static string Compute(string? path = null) => path ?? "default";
}
```

The static constructor body always runs *after* every static field initializer, so this reference always observes the default value. In the reported case this silently took the `?? "default"` branch of an optional parameter, with no compiler warning because the parameter was nullable.

## Changes

- The `FieldReference` handler now also records static fields **written** in the static constructor body: simple/compound/coalesce assignment, increment/decrement, and `ref`/`out` arguments. Writes inside lambdas or local functions are ignored, since they may never run.
- A referenced field with no initializer is now reported when the static constructor assigns it. This case is unconditional (no declaration-order check needed).
- The message format gained an optional reason suffix, following the pattern already used by `DoNotIgnoreReturnValueAnalyzer` (`"The return value of '{0}' should be used{1}"`). It stays empty for the declaration-order case, so **the existing message is unchanged**, and explains the ordering for the new one: `Static field 'X' may not be initialized yet because it is assigned in the static constructor, which runs after the static field initializers`. This keeps a single `DiagnosticDescriptor` rather than duplicating the title, category, severity and help link.
- The analysis moved from a bare `RegisterOperationAction` to `RegisterSymbolStartAction` / `RegisterSymbolEndAction` over named types. This is required because the decision for a field reference depends on the static constructor, which may live in another partial declaration or file — the symbol-end action guarantees every operation of the type has been visited before reporting.
- Candidates are stored as `(Location, ReferencedField, CurrentField)` rather than the `IFieldReferenceOperation`, to avoid retaining operation trees for the duration of the symbol analysis.

## Notes for reviewers

- Existing behavior is unchanged: a field with no initializer that is never assigned in the static constructor is still not reported (`NoDiagnostic_WhenReferencedFieldHasNoInitializer` still passes).
- A field that has *both* an initializer and an assignment in the static constructor keeps the previous declaration-order logic, to stay conservative.
- 6 new tests: the direct case (asserting the message), the method-call case from the issue, the cross-partial-declaration case, plus no-diagnostic cases for read-only-in-static-ctor, assignment in an *instance* constructor, and assignment inside a lambda in the static constructor.

## Verification

- Full test suite passes on the default Roslyn version (3656/3656).
- MA0195 tests pass on `roslyn4.8`, `roslyn4.14`, `roslyn5.0`, and `roslyn5.6` (14/14 each).
- `dotnet run --project src/DocumentationGenerator` exits 0 with no generated-markdown changes; `docs/Rules/MA0195.md` was updated by hand with the new condition and an example.
