### PR TITLE
Fix MA0112 false positive on IEnumerable<T>

### DIFF
--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -258,7 +258,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 if (ICollectionOfTSymbol is null && IReadOnlyCollectionOfTSymbol is null)
                     return;
 
-                var actualType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
+                // The reported member must be available on the type of the expression as written in the source code (IEnumerable<int> a = new List<int>())
+                var actualType = operation.Arguments[0].Value.GetActualType(useDataFlowAnalysis: false, context.CancellationToken);
                 if (actualType is null)
                     return;
 
@@ -296,7 +297,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             }
             else if (operation.TargetMethod.Name == nameof(Enumerable.LongCount))
             {
-                var actualType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
+                // The reported member must be available on the type of the expression as written in the source code (IEnumerable<int> a = new List<int>())
+                var actualType = operation.Arguments[0].Value.GetActualType(useDataFlowAnalysis: false, context.CancellationToken);
                 if (actualType is not null && actualType.TypeKind == TypeKind.Array)
                 {
                     var properties = CreateProperties(OptimizeLinqUsageData.UseLongLengthProperty);
@@ -313,7 +315,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (operation.Arguments.Length != 2)
                 return;
 
-            var firstArgumentType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
+            // The reported member must be available on the type of the expression as written in the source code (IEnumerable<int> a = new List<int>())
+            var firstArgumentType = operation.Arguments[0].Value.GetActualType(useDataFlowAnalysis: false, context.CancellationToken);
             if (firstArgumentType is null)
                 return;
 
@@ -349,7 +352,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (operation.Arguments.Length != 2)
                 return;
 
-            var firstArgumentType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
+            // The reported member must be available on the type of the expression as written in the source code (IEnumerable<int> a = new List<int>())
+            var firstArgumentType = operation.Arguments[0].Value.GetActualType(useDataFlowAnalysis: false, context.CancellationToken);
             if (firstArgumentType is null)
                 return;
 
@@ -381,7 +385,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (operation.Arguments.Length != 2)
                 return;
 
-            var firstArgumentType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
+            // The reported member must be available on the type of the expression as written in the source code (IEnumerable<int> a = new List<int>())
+            var firstArgumentType = operation.Arguments[0].Value.GetActualType(useDataFlowAnalysis: false, context.CancellationToken);
             if (firstArgumentType is null)
                 return;
 
@@ -435,7 +440,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (IListOfTSymbol is null && IReadOnlyListOfTSymbol is null)
                 return;
 
-            var actualType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
+            // The reported member must be available on the type of the expression as written in the source code (IEnumerable<int> a = new List<int>())
+            var actualType = operation.Arguments[0].Value.GetActualType(useDataFlowAnalysis: false, context.CancellationToken);
             if (actualType is null)
                 return;
 
@@ -897,7 +903,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 if (operation.Arguments.Length >= 2)
                     return;
 
-                var operandType = operation.Arguments[0].Value.GetActualType(context.CancellationToken);
+                // The reported member must be available on the type of the expression as written in the source code (IEnumerable<int> a = new List<int>())
+                var operandType = operation.Arguments[0].Value.GetActualType(useDataFlowAnalysis: false, context.CancellationToken);
                 if (operandType is null)
                     return;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseCountInsteadOfAnyTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseCountInsteadOfAnyTests.cs
@@ -156,4 +156,45 @@ class Test
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task Any_VariableTypedAsEnumerableAssignedToList()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                void A()
+                {
+                    IEnumerable<int> collection = new List<int>();
+                    _ = collection.Any();
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Any_ExplicitCastToEnumerable()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                void A(List<int> collection)
+                {
+                    _ = ((IEnumerable<int>)collection).Any();
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseDirectMethodsTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseDirectMethodsTests.cs
@@ -423,4 +423,46 @@ class Test
               .ShouldFixCodeWith(Fix)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task Count_VariableTypedAsEnumerableAssignedToList()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    IEnumerable<int> list = new List<int>();
+                    _ = list.Count();
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Exists_VariableTypedAsEnumerableAssignedToList()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    IEnumerable<int> list = new List<int>();
+                    _ = list.Any(x => x == 0);
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseIndexerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseIndexerTests.cs
@@ -248,4 +248,25 @@ class Test
               .ShouldFixCodeWith(CodeFix)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task ElementAt_VariableTypedAsEnumerableAssignedToList()
+    {
+        const string SourceCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    IEnumerable<int> list = new List<int>();
+                    _ = list.ElementAt(0);
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
Fixes #1303

## Problem

`OptimizeLinqUsageAnalyzer` reported `MA0112` (and `MA0020`/`MA0021`) using the data-flow type of the source expression, which is not necessarily the type of the expression as written in the source code. The reported member may not exist on that type, so the code fix produced code that doesn't compile:

```c#
IEnumerable<int> a = new List<int>();
a.Any();          // MA0112 => a.Count > 0 doesn't compile
a.Count();        // MA0020 => a.Count doesn't compile
a.ElementAt(0);   // MA0021 => a[0] doesn't compile
a.Any(x => x == 0); // MA0020 => a.Exists(…) doesn't compile
```

This is a regression from #1275, which switched the analyzer to the data-flow aware `GetActualType`.

## Fix

The rules that suggest replacing a LINQ method by a member of the source expression (`Count`, `LongCount`, `FirstOrDefault`, `All`, `Any`, `ElementAt`, `First`, `Last`) now use `GetActualType(useDataFlowAnalysis: false, …)`, so the reported member is always available on the type of the expression.

`UseCastInsteadOfSelect` still uses the data-flow type: it inspects a conversion inside the lambda and not the source expression, so it is not impacted.

## Tests

One test per impacted rule (`Any`, `Count()`, `Any(predicate)`, `ElementAt`), plus a test ensuring an explicit cast to `IEnumerable<T>` is not reported. The 4 new tests fail without the change.

- Full test suite on Roslyn 5.9: 3663 passed
- `OptimizeLinqUsage` tests on Roslyn 4.8, 4.14, 5.0, 5.6: 139 passed each
- `dotnet run --project src/DocumentationGenerator`: no documentation change