### PR TITLE
Limit the number of concurrent tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,17 @@ dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn4.8.cspr
 dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn4.8.csproj --filter "FullyQualifiedName~UseRegexSourceGeneratorAnalyzerTests.NewRegex_Options"
 ```
 
+### Limiting the number of concurrent tests
+
+Every test compiles code with Roslyn, so running one test per CPU thread uses a lot of memory. [`tests/Meziantou.Analyzer.Test/testconfig.json`](/tests/Meziantou.Analyzer.Test/testconfig.json) limits the number of tests running at the same time in a test project (`xUnit.maxParallelThreads`). It is shared by all the Roslyn versions, as they are in the same folder, and `Microsoft.Testing.Platform.MSBuild` copies it to the output folder of each project as `Meziantou.Analyzer.Test.testconfig.json`.
+
+The test projects still run in parallel when they run together, which multiplies the memory usage by the number of projects. Use `--max-parallel-test-modules` to limit them:
+
+```bash
+# Run at most 2 test projects at the same time
+dotnet test --max-parallel-test-modules 2
+```
+
 ### When to test with multiple Roslyn versions
 
 You SHOULD test with multiple Roslyn versions when:

--- a/tests/Meziantou.Analyzer.Test/testconfig.json
+++ b/tests/Meziantou.Analyzer.Test/testconfig.json
@@ -1,0 +1,5 @@
+{
+  "xUnit": {
+    "maxParallelThreads": 8
+  }
+}


### PR DESCRIPTION
Every test compiles code with Roslyn, so running one test per CPU thread uses a lot of memory. On a 15 thread machine, a single test project peaks at **20 GB**, and `dotnet test` at the solution level runs the 5 Roslyn version projects in parallel, which multiplies it.

## Changes

- `tests/Meziantou.Analyzer.Test/testconfig.json`: limits `xUnit.maxParallelThreads` to 8. The file is shared by all the Roslyn versions, as their projects are in the same folder, and `Microsoft.Testing.Platform.MSBuild` copies it to the output folder of each project as `Meziantou.Analyzer.Test.testconfig.json`.
- `AGENTS.md`: documents the new file, and `dotnet test --max-parallel-test-modules` to limit how many test projects run at the same time (there is no configuration file equivalent for that one).

## Measurements

Roslyn 5.9 test project (3663 tests), Release, 15 CPU threads:

| Max parallel threads | Peak RSS | Duration |
| --- | --- | --- |
| default (1 per CPU thread) | 20.2 GB | 57s |
| 8 | 3.0 GB | 56s |
| 4 | 1.5 GB | 64s |

The memory grows much faster than the throughput, so 8 divides the memory by ~7 for the same duration.

## Notes for the reviewer

- The value is a fixed number rather than a multiplier such as `"0.5x"`, because the CI machines have 4 threads: a multiplier would halve their current parallelism and slow the jobs down, while 8 leaves them unchanged and only caps the bigger development machines.
- `--max-parallel-test-modules` bounds the number of test projects, not the memory of one project, so it does not replace this setting: a single project would still peak at 20 GB.

## Verification

- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn4.8.csproj --configuration Release`: 3533/3533 passed
- Roslyn 5.9 test project: 3663/3663 passed, peaking at 3.7 GB instead of 20 GB
- The generated `Meziantou.Analyzer.Test.testconfig.json` is in the output folder of both the roslyn4.8 and the roslyn5.9 projects
