### PR TITLE
Use global using directives for the most common namespaces

### DIFF
--- a/src/DocumentationGenerator/Program.cs
+++ b/src/DocumentationGenerator/Program.cs
@@ -2,7 +2,6 @@
 #pragma warning disable CA1849
 #pragma warning disable MA0004
 #pragma warning disable MA0009
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;

--- a/src/Meziantou.Analyzer.CodeFixers/Directory.Build.props
+++ b/src/Meziantou.Analyzer.CodeFixers/Directory.Build.props
@@ -11,6 +11,22 @@
     <Version>1.0.1</Version>
   </PropertyGroup>
 
+  <!-- Global using directives shared by all the files of this project.
+       The files shared with Meziantou.Analyzer rely on the same namespaces being global in both projects. -->
+  <ItemGroup>
+    <Using Include="System.Collections.Immutable" />
+    <Using Include="System.Composition" />
+    <Using Include="Meziantou.Analyzer.Internals" />
+    <Using Include="Meziantou.Framework.Roslyn" />
+    <Using Include="Microsoft.CodeAnalysis" />
+    <Using Include="Microsoft.CodeAnalysis.CodeActions" />
+    <Using Include="Microsoft.CodeAnalysis.CodeFixes" />
+    <Using Include="Microsoft.CodeAnalysis.CSharp" />
+    <Using Include="Microsoft.CodeAnalysis.CSharp.Syntax" />
+    <Using Include="Microsoft.CodeAnalysis.Editing" />
+    <Using Include="Microsoft.CodeAnalysis.Operations" />
+  </ItemGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\..\Meziantou.Analyzer\BannedSymbols.txt" />
 

--- a/src/Meziantou.Analyzer.CodeFixers/Internals/ParenthesesExtensions.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Internals/ParenthesesExtensions.cs
@@ -1,7 +1,4 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Simplification;
-using Microsoft.CodeAnalysis;
 
 namespace Meziantou.Analyzer.Internals;
 internal static class ParenthesesExtensions

--- a/src/Meziantou.Analyzer.CodeFixers/Internals/SyntaxNodeExtensions.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Internals/SyntaxNodeExtensions.cs
@@ -1,5 +1,3 @@
-using Microsoft.CodeAnalysis;
-
 namespace Meziantou.Analyzer.Internals;
 internal static class SyntaxNodeExtensions
 {

--- a/src/Meziantou.Analyzer.CodeFixers/Internals/SyntaxTokenListExtensions.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Internals/SyntaxTokenListExtensions.cs
@@ -1,6 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-
 namespace Meziantou.Analyzer.Internals;
 
 internal static class SyntaxTokenListExtensions

--- a/src/Meziantou.Analyzer.CodeFixers/Refactorings/ConvertToStringFormatRefactoring.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Refactorings/ConvertToStringFormatRefactoring.cs
@@ -1,11 +1,4 @@
-using System.Composition;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 
 namespace Meziantou.Analyzer.Refactorings;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Refactorings/MakeInterpolatedStringRefactoring.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Refactorings/MakeInterpolatedStringRefactoring.cs
@@ -1,10 +1,4 @@
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 
 namespace Meziantou.Analyzer.Refactorings;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/AbstractTypesShouldNotHaveConstructorsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/AbstractTypesShouldNotHaveConstructorsFixer.cs
@@ -1,12 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ArgumentExceptionShouldSpecifyArgumentNameFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ArgumentExceptionShouldSpecifyArgumentNameFixer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidClosureWhenUsingConcurrentDictionaryFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidClosureWhenUsingConcurrentDictionaryFixer.cs
@@ -1,18 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Linq;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidComparisonWithBoolConstantFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidComparisonWithBoolConstantFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidUnusedInternalTypesFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidUnusedInternalTypesFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidUsingRedundantElseFixAllProvider.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidUsingRedundantElseFixAllProvider.cs
@@ -1,7 +1,3 @@
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
-
 namespace Meziantou.Analyzer.Rules;
 
 internal sealed class AvoidUsingRedundantElseFixAllProvider : DocumentBasedFixAllProvider

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidUsingRedundantElseFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidUsingRedundantElseFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/BlazorPropertyInjectionFixAllProvider.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/BlazorPropertyInjectionFixAllProvider.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-
 namespace Meziantou.Analyzer.Rules;
 
 internal sealed class BlazorPropertyInjectionFixAllProvider : FixAllProvider

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Rename;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ClassMustBeSealedFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ClassMustBeSealedFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/CommaFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/CommaFixer.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ConditionalCompilationBranchesAreIdenticalFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ConditionalCompilationBranchesAreIdenticalFixer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotNaNInComparisonsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotNaNInComparisonsFixer.cs
@@ -1,15 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotRemoveOriginalExceptionFromThrowStatementFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotRemoveOriginalExceptionFromThrowStatementFixer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseBlockingCallInAsyncContextFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseBlockingCallInAsyncContextFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseEmptyPropertyPatternOnNonNullableValueTypeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseEmptyPropertyPatternOnNonNullableValueTypeFixer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseEqualityComparerDefaultOfStringFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseEqualityComparerDefaultOfStringFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseEqualityOperatorsForSpanOfCharFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseEqualityOperatorsForSpanOfCharFixer.cs
@@ -1,11 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseImplicitCultureSensitiveToStringInterpolationFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseImplicitCultureSensitiveToStringInterpolationFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Simplification;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseInterpolatedStringWithoutParametersFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseInterpolatedStringWithoutParametersFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseStringGetHashCodeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseStringGetHashCodeFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseZeroToInitializeAnEnumValueFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseZeroToInitializeAnEnumValueFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/EmbedCaughtExceptionAsInnerExceptionFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/EmbedCaughtExceptionAsInnerExceptionFixer.cs
@@ -1,15 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/EqualityShouldBeCorrectlyImplementedFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/EqualityShouldBeCorrectlyImplementedFixer.cs
@@ -1,15 +1,3 @@
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/EventsShouldHaveProperArgumentsFixer.MA0091.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/EventsShouldHaveProperArgumentsFixer.MA0091.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ILoggerParameterTypeShouldMatchContainingTypeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ILoggerParameterTypeShouldMatchContainingTypeFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/InheritdocShouldNotBeUsedOnTypesFixer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/JSInvokableMethodsMustBePublicFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/JSInvokableMethodsMustBePublicFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MakeClassStaticFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MakeClassStaticFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MakeMemberReadOnlyFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MakeMemberReadOnlyFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MakeMethodStaticFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MakeMethodStaticFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MarkAttributesWithAttributeUsageAttributeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MarkAttributesWithAttributeUsageAttributeFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MergeIsPatternChecksFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MergeIsPatternChecksFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MethodOverridesShouldNotChangeParameterDefaultsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MethodOverridesShouldNotChangeParameterDefaultsFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixFixer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Rename;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MissingNotNullWhenAttributeOnEqualsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MissingNotNullWhenAttributeOnEqualsFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/NamedParameterFixAllProvider.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/NamedParameterFixAllProvider.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
-
 namespace Meziantou.Analyzer.Rules;
 
 internal sealed class NamedParameterFixAllProvider : DocumentBasedFixAllProvider

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/NamedParameterFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/NamedParameterFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/NotPatternShouldBeParenthesizedCodeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/NotPatternShouldBeParenthesizedCodeFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeGuidCreationFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeGuidCreationFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStartsWithFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStartsWithFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptionalParametersAttributeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptionalParametersAttributeFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ParameterAttributeForRazorComponentFixer.AddParameterAttribute.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ParameterAttributeForRazorComponentFixer.AddParameterAttribute.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/PreserveParamsOnOverrideFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/PreserveParamsOnOverrideFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RecordClassDeclarationShouldBeExplicitFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RecordClassDeclarationShouldBeExplicitFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RecordClassDeclarationShouldBeImplicitFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RecordClassDeclarationShouldBeImplicitFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveEmptyBlockFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveEmptyBlockFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveEmptyStatementFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveEmptyStatementFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryBracesInTypeDeclarationFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryBracesInTypeDeclarationFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryPartialModifierFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryPartialModifierFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUselessToStringFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUselessToStringFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ReplaceEnumToStringWithNameofFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ReplaceEnumToStringWithNameofFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ReturnTaskFromResultInsteadOfReturningNullFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ReturnTaskFromResultInsteadOfReturningNullFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ReturnTaskInsteadOfAwaitingItFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ReturnTaskInsteadOfAwaitingItFixer.cs
@@ -1,13 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/SimplifyCallerArgumentExpressionFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/SimplifyCallerArgumentExpressionFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/SimplifyNegatedBooleanExpressionFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/SimplifyNegatedBooleanExpressionFixer.cs
@@ -1,14 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/StringShouldNotContainsNonDeterministicEndOfLineFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/StringShouldNotContainsNonDeterministicEndOfLineFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/TaskInUsingFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/TaskInUsingFixer.cs
@@ -1,14 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ThrowIfNullWithNonNullableInstanceFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ThrowIfNullWithNonNullableInstanceFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/TypeNameShouldEndWithSuffixFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/TypeNameShouldEndWithSuffixFixer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Rename;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_AwaitForEach.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_AwaitForEach.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasMidpointRoundingFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasMidpointRoundingFixer.cs
@@ -1,16 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasTimeProviderFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasTimeProviderFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseArrayEmptyFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseArrayEmptyFixer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAttributeIsDefinedFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAttributeIsDefinedFixer.cs
@@ -1,15 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAwaitInsteadOfReturningTaskFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAwaitInsteadOfReturningTaskFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseContainsKeyInsteadOfTryGetValueFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseContainsKeyInsteadOfTryGetValueFixer.cs
@@ -1,12 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseDateTimeUnixEpochFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseDateTimeUnixEpochFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseEqualsMethodInsteadOfOperatorFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseEqualsMethodInsteadOfOperatorFixer.cs
@@ -1,13 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseEventArgsEmptyFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseEventArgsEmptyFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseExclusiveOrOperatorFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseExclusiveOrOperatorFixer.cs
@@ -1,13 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseGuidEmptyFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseGuidEmptyFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseHasFlagMethodFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseHasFlagMethodFixer.cs
@@ -1,15 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseIFormatProviderFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseIFormatProviderFixer.cs
@@ -1,15 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseInKeywordForInParameterFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseInKeywordForInParameterFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseInlineArrayInsteadOfFixedBufferFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseInlineArrayInsteadOfFixedBufferFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseInlineXmlCommentSyntaxWhenPossibleFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseInlineXmlCommentSyntaxWhenPossibleFixer.cs
@@ -1,13 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Composition;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+﻿using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseIsPatternInsteadOfSequenceEqualFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseIsPatternInsteadOfSequenceEqualFixer.cs
@@ -1,13 +1,3 @@
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis;
-using System.Composition;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseJSRuntimeInvokeVoidAsyncWhenReturnValueIsNotUsedFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseJSRuntimeInvokeVoidAsyncWhenReturnValueIsNotUsedFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Editing;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseLazyInitializerEnsureInitializeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseLazyInitializerEnsureInitializeFixer.cs
@@ -1,13 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseMultiLineXmlCommentSyntaxFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseMultiLineXmlCommentSyntaxFixer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseOperatingSystemInsteadOfRuntimeInformationFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseOperatingSystemInsteadOfRuntimeInformationFixer.cs
@@ -1,12 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexFixer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixAllProvider.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixAllProvider.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Meziantou.Analyzer.Rules;
 
 internal sealed class UsePatternMatchingForEqualityComparisonsFixAllProvider : DocumentBasedFixAllProvider

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
@@ -1,15 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingInsteadOfHasvalueFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingInsteadOfHasvalueFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexExplicitCaptureOptionsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexExplicitCaptureOptionsFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexSourceGeneratorFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexSourceGeneratorFixer.cs
@@ -1,15 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Rename;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseShellExecuteMustBeSetFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseShellExecuteMustBeSetFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparerFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparerFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparisonFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparisonFixer.cs
@@ -1,14 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringCreateInsteadOfFormattableStringFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringCreateInsteadOfFormattableStringFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringEqualsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringEqualsFixer.cs
@@ -1,12 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringEqualsInsteadOfIsPatternFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringEqualsInsteadOfIsPatternFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStructLayoutAttributeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStructLayoutAttributeFixer.cs
@@ -1,12 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
 using System.Runtime.InteropServices;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Simplification;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseSystemThreadingLockInsteadOfObjectFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseSystemThreadingLockInsteadOfObjectFixer.cs
@@ -1,14 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseTaskUnwrapFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseTaskUnwrapFixer.cs
@@ -1,13 +1,4 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseTimeSpanZeroFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseTimeSpanZeroFixer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editing;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateArgumentsCorrectlyFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateArgumentsCorrectlyFixer.cs
@@ -1,13 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateUnsafeAccessorAttributeUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateUnsafeAccessorAttributeUsageFixer.cs
@@ -1,12 +1,3 @@
-using System.Collections.Immutable;
-using System.Composition;
-using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Meziantou.Analyzer/Configurations/AnalyzerOptionsExtensions.cs
+++ b/src/Meziantou.Analyzer/Configurations/AnalyzerOptionsExtensions.cs
@@ -1,6 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Configurations;
 
 public static class AnalyzerOptionsExtensions

--- a/src/Meziantou.Analyzer/Configurations/ConfigurationDefinition.cs
+++ b/src/Meziantou.Analyzer/Configurations/ConfigurationDefinition.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis.Operations;
 namespace Meziantou.Analyzer.Configurations;
 
 public sealed class ConfigurationDefinition<T>

--- a/src/Meziantou.Analyzer/Directory.Build.props
+++ b/src/Meziantou.Analyzer/Directory.Build.props
@@ -19,6 +19,16 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
 
+  <!-- Global using directives shared by all the files of this project -->
+  <ItemGroup>
+    <Using Include="System.Collections.Immutable" />
+    <Using Include="Meziantou.Analyzer.Internals" />
+    <Using Include="Meziantou.Framework.Roslyn" />
+    <Using Include="Microsoft.CodeAnalysis" />
+    <Using Include="Microsoft.CodeAnalysis.Diagnostics" />
+    <Using Include="Microsoft.CodeAnalysis.Operations" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\..\docs\**\*" LinkBase="docs" />
     <EmbeddedResource Include="Resources\*.txt" />

--- a/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
+++ b/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
@@ -1,5 +1,3 @@
-using Microsoft.CodeAnalysis;
-
 namespace Meziantou.Analyzer.Internals;
 
 // The attribute can be defined in multiple assemblies, so it's identified by its full name only

--- a/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
+++ b/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
@@ -1,7 +1,4 @@
 using System.Collections.Concurrent;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Internals;
 internal sealed class AwaitableTypes

--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -1,7 +1,3 @@
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Internals;
 
 internal sealed class CultureSensitiveFormattingContext(Compilation compilation)

--- a/src/Meziantou.Analyzer/Internals/MethodSymbolExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/MethodSymbolExtensions.cs
@@ -1,6 +1,3 @@
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-
 namespace Meziantou.Analyzer.Internals;
 
 internal static class MethodSymbolExtensions

--- a/src/Meziantou.Analyzer/Internals/OperationExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/OperationExtensions.cs
@@ -1,8 +1,5 @@
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Internals;
 

--- a/src/Meziantou.Analyzer/Internals/OperationUtilities.cs
+++ b/src/Meziantou.Analyzer/Internals/OperationUtilities.cs
@@ -1,8 +1,4 @@
-﻿using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Internals;
+﻿namespace Meziantou.Analyzer.Internals;
 
 internal sealed class OperationUtilities(Compilation compilation)
 {

--- a/src/Meziantou.Analyzer/Internals/OverloadFinder.cs
+++ b/src/Meziantou.Analyzer/Internals/OverloadFinder.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Internals;
 
 internal sealed class OverloadFinder(Compilation compilation)

--- a/src/Meziantou.Analyzer/Internals/OverloadOptions.cs
+++ b/src/Meziantou.Analyzer/Internals/OverloadOptions.cs
@@ -1,6 +1,3 @@
-using System;
-using Microsoft.CodeAnalysis;
-
 namespace Meziantou.Analyzer.Internals;
 
 internal record struct OverloadOptions(

--- a/src/Meziantou.Analyzer/Internals/OverloadParameterType.cs
+++ b/src/Meziantou.Analyzer/Internals/OverloadParameterType.cs
@@ -1,5 +1,3 @@
-using Microsoft.CodeAnalysis;
-
 namespace Meziantou.Analyzer.Internals;
 
 internal record struct OverloadParameterType(ITypeSymbol? Symbol, bool AllowInherits = false);

--- a/src/Meziantou.Analyzer/Internals/SymbolExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/SymbolExtensions.cs
@@ -1,5 +1,4 @@
 using System.Reflection.Metadata.Ecma335;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Meziantou.Analyzer.Internals;

--- a/src/Meziantou.Analyzer/Internals/TimeSpanOperation.cs
+++ b/src/Meziantou.Analyzer/Internals/TimeSpanOperation.cs
@@ -1,7 +1,3 @@
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Internals;
 
 internal sealed class TimeSpanOperation(Compilation compilation)

--- a/src/Meziantou.Analyzer/Internals/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/TypeSymbolExtensions.cs
@@ -1,6 +1,3 @@
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-
 namespace Meziantou.Analyzer.Internals;
 
 // http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Extensions/ITypeSymbolExtensions.cs,190b4ed0932458fd,references

--- a/src/Meziantou.Analyzer/Rules/AbstractTypesShouldNotHaveConstructorsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AbstractTypesShouldNotHaveConstructorsAnalyzer.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/AddOverloadWithSpanOrMemoryAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AddOverloadWithSpanOrMemoryAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/AnonymousDelegatesShouldNotBeUsedToUnsubscribeFromEventsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AnonymousDelegatesShouldNotBeUsedToUnsubscribeFromEventsAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class AnonymousDelegatesShouldNotBeUsedToUnsubscribeFromEventsAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzer.cs
@@ -1,11 +1,5 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/AttributeNameShouldEndWithAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AttributeNameShouldEndWithAttributeAnalyzer.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class AttributeNameShouldEndWithAttributeAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/AvoidClosureWhenUsingConcurrentDictionaryAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidClosureWhenUsingConcurrentDictionaryAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/AvoidComparisonWithBoolConstantAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidComparisonWithBoolConstantAnalyzer.cs
@@ -1,9 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/AvoidLockingOnPubliclyAccessibleInstanceAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidLockingOnPubliclyAccessibleInstanceAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/AvoidUnusedInternalTypesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidUnusedInternalTypesAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
@@ -1,9 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzerCommon.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer/Rules/AwaitAwaitableMethodInSyncMethodAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AwaitAwaitableMethodInSyncMethodAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/AwaitTaskBeforeDisposingResourcesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AwaitTaskBeforeDisposingResourcesAnalyzer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Linq;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzer.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/BothSideOfTheConditionAreIdenticalAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/BothSideOfTheConditionAreIdenticalAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/ClassMustBeSealedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ClassMustBeSealedAnalyzer.cs
@@ -1,9 +1,4 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/CommaAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/CommaAnalyzer.cs
@@ -1,10 +1,6 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzer.cs
@@ -1,7 +1,4 @@
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalCommon.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Meziantou.Analyzer/Rules/ConstructorArgumentParametersShouldExistInConstructorsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ConstructorArgumentParametersShouldExistInConstructorsAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 // https://learn.microsoft.com/en-us/dotnet/api/system.windows.markup.constructorargumentattribute?view=netcore-3.1

--- a/src/Meziantou.Analyzer/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzer.cs
@@ -1,11 +1,6 @@
-using System.Collections.Immutable;
 using System.Diagnostics;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DeclareTypesInNamespacesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DeclareTypesInNamespacesAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DeclareTypesInNamespacesAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/DoNotCallVirtualMethodInConstructorAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotCallVirtualMethodInConstructorAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotDeclareStaticMembersOnGenericTypes.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotDeclareStaticMembersOnGenericTypes.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotIgnoreReturnValueAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotIgnoreReturnValueAnalyzer.cs
@@ -1,11 +1,5 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotImplicitlyConvertDateTimeToDateTimeOffsetAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotImplicitlyConvertDateTimeToDateTimeOffsetAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DoNotImplicitlyConvertDateTimeToDateTimeOffsetAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/DoNotLogClassifiedDataAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotLogClassifiedDataAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotNaNInComparisonsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotNaNInComparisonsAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotOverwriteRazorComponentParameterValue.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotOverwriteRazorComponentParameterValue.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotRaiseApplicationExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotRaiseApplicationExceptionAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DoNotRaiseApplicationExceptionAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/DoNotRaiseNotImplementedExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotRaiseNotImplementedExceptionAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DoNotRaiseNotImplementedExceptionAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/DoNotRaiseReservedExceptionTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotRaiseReservedExceptionTypeAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotRemoveOriginalExceptionFromThrowStatementAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotRemoveOriginalExceptionFromThrowStatementAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinalizerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinalizerAnalyzer.cs
@@ -1,9 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinallyBlockAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinallyBlockAnalyzer.cs
@@ -1,9 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseAsyncDelegateForSyncDelegateAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseAsyncDelegateForSyncDelegateAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DoNotUseAsyncDelegateForSyncDelegateAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/DoNotUseAsyncVoidAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseAsyncVoidAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DoNotUseAsyncVoidAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -1,11 +1,5 @@
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseCastAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseCastAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotUseEmptyPropertyPatternOnNonNullableValueTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseEmptyPropertyPatternOnNonNullableValueTypeAnalyzer.cs
@@ -1,11 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseEqualityComparerDefaultOfStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseEqualityComparerDefaultOfStringAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotUseEqualityOperatorsForSpanOfCharAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseEqualityOperatorsForSpanOfCharAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotUseFinalizerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseFinalizerAnalyzer.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DoNotUseFinalizerAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
@@ -1,11 +1,5 @@
-using System.Collections.Immutable;
 using System.Diagnostics;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzer.cs
@@ -1,12 +1,5 @@
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseNullForgivenessAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseNullForgivenessAnalyzer.cs
@@ -1,9 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseReturnTagForVoidMethodAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseReturnTagForVoidMethodAnalyzer.cs
@@ -1,8 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseServerCertificateValidationCallbackAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseServerCertificateValidationCallbackAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotUseStringGetHashCodeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseStringGetHashCodeAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DoNotUseStringGetHashCodeAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseToStringIfObjectAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DoNotUseUnknownParameterForRazorComponentAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseUnknownParameterForRazorComponentAnalyzer.cs
@@ -1,11 +1,5 @@
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseZeroToInitializeAnEnumValue.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseZeroToInitializeAnEnumValue.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Linq;
-using Meziantou.Analyzer.Configurations;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
+﻿using Meziantou.Analyzer.Configurations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/DontTagInstanceFieldsWithThreadStaticAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DontTagInstanceFieldsWithThreadStaticAttributeAnalyzer.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DontTagInstanceFieldsWithThreadStaticAttributeAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/DontUseDangerousThreadingMethodsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DontUseDangerousThreadingMethodsAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
@@ -1,10 +1,5 @@
-using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/EmbedCaughtExceptionAsInnerExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EmbedCaughtExceptionAsInnerExceptionAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerCommon.cs
@@ -1,8 +1,4 @@
-﻿using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 internal static class EqualityShouldBeCorrectlyImplementedAnalyzerCommon
 {

--- a/src/Meziantou.Analyzer/Rules/EventArgsNameShouldEndWithEventArgsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventArgsNameShouldEndWithEventArgsAnalyzer.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class EventArgsNameShouldEndWithEventArgsAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/EventsShouldHaveProperArgumentsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventsShouldHaveProperArgumentsAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/ExceptionNameShouldEndWithExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ExceptionNameShouldEndWithExceptionAnalyzer.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ExceptionNameShouldEndWithExceptionAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -1,13 +1,7 @@
-using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/FixToDoAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FixToDoAnalyzer.cs
@@ -1,8 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer/Rules/GeneratedRegexAttributeUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/GeneratedRegexAttributeUsageAnalyzer.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class GeneratedRegexAttributeUsageAnalyzer : RegexUsageAnalyzerBase

--- a/src/Meziantou.Analyzer/Rules/ILoggerParameterTypeShouldMatchContainingTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ILoggerParameterTypeShouldMatchContainingTypeAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/IfElseBranchesAreIdenticalAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/IfElseBranchesAreIdenticalAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class IfElseBranchesAreIdenticalAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/InheritdocOnTypesAnalyzerHelper.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocOnTypesAnalyzerHelper.cs
@@ -1,7 +1,4 @@
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzer.cs
@@ -1,8 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldHaveSourceOnTypesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldHaveSourceOnTypesAnalyzer.cs
@@ -1,7 +1,3 @@
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzer.cs
@@ -1,7 +1,3 @@
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzer.cs
@@ -1,7 +1,3 @@
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/JSInteropMustNotBeUsedInOnInitializedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/JSInteropMustNotBeUsedInOnInitializedAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class JSInteropMustNotBeUsedInOnInitializedAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/JSInvokableMethodsMustBePublicAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/JSInvokableMethodsMustBePublicAnalyzer.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class JSInvokableMethodsMustBePublicAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/LocalVariablesShouldNotHideSymbolsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/LocalVariablesShouldNotHideSymbolsAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
@@ -1,13 +1,7 @@
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Meziantou.Analyzer.Configurations;
 using Microsoft.CodeAnalysis.CSharp;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/MakeClassStaticAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MakeClassStaticAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/MakeMemberReadOnlyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MakeMemberReadOnlyAnalyzer.cs
@@ -1,10 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/MakeMethodStaticAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MakeMethodStaticAnalyzer.cs
@@ -1,11 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/MarkAttributesWithAttributeUsageAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MarkAttributesWithAttributeUsageAttributeAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class MarkAttributesWithAttributeUsageAttributeAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/MergeIsPatternChecksAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MergeIsPatternChecksAnalyzer.cs
@@ -1,10 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/MergeIsPatternChecksCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/MergeIsPatternChecksCommon.cs
@@ -1,8 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/MethodOverridesShouldNotChangeParameterDefaultsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MethodOverridesShouldNotChangeParameterDefaultsAnalyzer.cs
@@ -1,8 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/MethodShouldNotBeTooLongAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MethodShouldNotBeTooLongAnalyzer.cs
@@ -1,10 +1,6 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/MissingNotNullWhenAttributeOnEqualsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MissingNotNullWhenAttributeOnEqualsAnalyzer.cs
@@ -1,9 +1,4 @@
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
@@ -1,15 +1,9 @@
-using System.Collections.Immutable;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/NonConstantStaticFieldsShouldNotBeVisibleAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NonConstantStaticFieldsShouldNotBeVisibleAnalyzer.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class NonConstantStaticFieldsShouldNotBeVisibleAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzer.cs
@@ -1,9 +1,4 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/NotPatternShouldBeParenthesizedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NotPatternShouldBeParenthesizedAnalyzer.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/NullableAttributeUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NullableAttributeUsageAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/ObjectGetTypeOnTypeInstanceAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ObjectGetTypeOnTypeInstanceAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ObjectGetTypeOnTypeInstanceAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/ObsoleteAttributesShouldIncludeExplanationsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ObsoleteAttributesShouldIncludeExplanationsAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ObsoleteAttributesShouldIncludeExplanationsAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/OptimizeGuidCreationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeGuidCreationAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class OptimizeGuidCreationAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -1,12 +1,6 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/OptimizeStartsWithAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStartsWithAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzerCommon.cs
@@ -1,8 +1,3 @@
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 internal static class OptimizeStringBuilderUsageAnalyzerCommon

--- a/src/Meziantou.Analyzer/Rules/OptionalParametersAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptionalParametersAttributeAnalyzer.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class OptionalParametersAttributeAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/ParameterAttributeForRazorComponentAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ParameterAttributeForRazorComponentAnalyzer.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/PreferReturningCollectionAbstractionInsteadOfImplementationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/PreferReturningCollectionAbstractionInsteadOfImplementationAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/PreserveParamsOnOverrideAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/PreserveParamsOnOverrideAnalyzer.cs
@@ -1,8 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/PrimaryConstructorParameterShouldBeReadOnlyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/PrimaryConstructorParameterShouldBeReadOnlyAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/ProcessStartAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ProcessStartAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/RecordClassDeclarationShouldBeExplicitAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RecordClassDeclarationShouldBeExplicitAnalyzer.cs
@@ -1,9 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/RecordClassDeclarationShouldBeImplicitAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RecordClassDeclarationShouldBeImplicitAnalyzer.cs
@@ -1,9 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/RegexMethodUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RegexMethodUsageAnalyzer.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class RegexMethodUsageAnalyzer : RegexUsageAnalyzerBase

--- a/src/Meziantou.Analyzer/Rules/RegexUsageAnalyzerBase.cs
+++ b/src/Meziantou.Analyzer/Rules/RegexUsageAnalyzerBase.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
 using System.Text.RegularExpressions;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/RemoveEmptyBlockAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RemoveEmptyBlockAnalyzer.cs
@@ -1,9 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/RemoveEmptyStatementAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RemoveEmptyStatementAnalyzer.cs
@@ -1,9 +1,5 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzer.cs
@@ -1,10 +1,5 @@
-using System.Collections.Immutable;
-using System.Linq;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryClosedModifierAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryClosedModifierAnalyzer.cs
@@ -1,9 +1,6 @@
 #if ROSLYN_5_9_OR_GREATER
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryPartialModifierAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryPartialModifierAnalyzer.cs
@@ -1,9 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/RemoveUselessToStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RemoveUselessToStringAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/ReplaceEnumToStringWithNameofAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ReplaceEnumToStringWithNameofAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ReplaceEnumToStringWithNameofAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/ReturnTaskFromResultInsteadOfReturningNullAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ReturnTaskFromResultInsteadOfReturningNullAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/ReturnTaskFromResultInsteadOfReturningNullAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/ReturnTaskFromResultInsteadOfReturningNullAnalyzerCommon.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis;
 
 namespace Meziantou.Analyzer.Rules;
 internal static class ReturnTaskFromResultInsteadOfReturningNullAnalyzerCommon

--- a/src/Meziantou.Analyzer/Rules/ReturnTaskInsteadOfAwaitingItAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ReturnTaskInsteadOfAwaitingItAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/SequenceNumberMustBeAConstantAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/SequenceNumberMustBeAConstantAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/SimplifyCallerArgumentExpressionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/SimplifyCallerArgumentExpressionAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/SimplifyNegatedBooleanExpressionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/SimplifyNegatedBooleanExpressionAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/SimplifyNegatedBooleanExpressionCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/SimplifyNegatedBooleanExpressionCommon.cs
@@ -1,8 +1,3 @@
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 internal sealed class SimplifyNegatedBooleanExpressionCommon

--- a/src/Meziantou.Analyzer/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/StringFormatShouldBeConstantAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/StringFormatShouldBeConstantAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzer.cs
@@ -1,9 +1,5 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/TaskInUsingAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/TaskInUsingAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class TaskInUsingAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/ThrowIfNullWithNonNullableInstanceAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ThrowIfNullWithNonNullableInstanceAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/TypeCannotBeUsedInAnAttributeParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/TypeCannotBeUsedInAnAttributeParameterAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/TypeNameMustNotMatchNamespaceAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/TypeNameMustNotMatchNamespaceAnalyzer.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/TypesShouldNotExtendSystemApplicationExceptionAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/TypesShouldNotExtendSystemApplicationExceptionAnalyzer.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class TypesShouldNotExtendSystemApplicationExceptionAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
@@ -1,14 +1,8 @@
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasMidpointRoundingAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasMidpointRoundingAnalyzer.cs
@@ -1,11 +1,3 @@
-using System.Collections.Immutable;
-using System.Linq;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
@@ -1,11 +1,5 @@
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using System.Runtime.InteropServices;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseArrayEmptyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseArrayEmptyAnalyzer.cs
@@ -1,9 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseAttributeIsDefinedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAttributeIsDefinedAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseAwaitInsteadOfReturningTaskAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAwaitInsteadOfReturningTaskAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
@@ -1,12 +1,6 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseDateTimeUnixEpochAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseDateTimeUnixEpochAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseEqualsMethodInsteadOfOperatorAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseEqualsMethodInsteadOfOperatorAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseEventArgsEmptyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseEventArgsEmptyAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class UseEventArgsEmptyAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/UseEventHandlerOfTAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseEventHandlerOfTAnalyzer.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseExclusiveOrOperatorAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseExclusiveOrOperatorAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseExclusiveOrOperatorCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseExclusiveOrOperatorCommon.cs
@@ -1,7 +1,3 @@
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 internal static class UseExclusiveOrOperatorCommon

--- a/src/Meziantou.Analyzer/Rules/UseGuidEmptyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseGuidEmptyAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class UseGuidEmptyAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseIFormatProviderAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseIFormatProviderAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
+﻿using Meziantou.Analyzer.Configurations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseInKeywordForInParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseInKeywordForInParameterAnalyzer.cs
@@ -1,11 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseInlineArrayInsteadOfFixedBufferAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseInlineArrayInsteadOfFixedBufferAnalyzer.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzer.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Configurations;
-using Microsoft.CodeAnalysis;
+﻿using Meziantou.Analyzer.Configurations;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzer.cs
@@ -1,10 +1,3 @@
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Operations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseJSRuntimeInvokeVoidAsyncWhenReturnValueIsNotUsedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseJSRuntimeInvokeVoidAsyncWhenReturnValueIsNotUsedAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
@@ -1,9 +1,4 @@
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
 using System.Linq.Expressions;
 
 namespace Meziantou.Analyzer.Rules;

--- a/src/Meziantou.Analyzer/Rules/UseLazyInitializerEnsureInitializeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLazyInitializerEnsureInitializeAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer.cs
@@ -1,10 +1,4 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseMultiLineXmlCommentSyntaxAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseMultiLineXmlCommentSyntaxAnalyzer.cs
@@ -1,7 +1,4 @@
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseOperatingSystemInsteadOfRuntimeInformationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseOperatingSystemInsteadOfRuntimeInformationAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsCommon.cs
@@ -1,8 +1,4 @@
-﻿using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 internal static class UsePatternMatchingForEqualityComparisonsCommon
 {
     public static bool IsNull(IOperation operation)

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingInsteadOfHasValueAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingInsteadOfHasValueAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseReadOnlyStructForRefReadOnlyParametersAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseReadOnlyStructForRefReadOnlyParametersAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseRegexSourceGeneratorAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseRegexSourceGeneratorAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringComparerAnalyzer.cs
@@ -1,11 +1,5 @@
-using System.Collections.Immutable;
 using Meziantou.Analyzer.Configurations;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseStringComparisonAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringComparisonAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseStringCreateInsteadOfFormattableStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringCreateInsteadOfFormattableStringAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseStringEqualsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringEqualsAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseStringEqualsInsteadOfIsPatternAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringEqualsInsteadOfIsPatternAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseStructLayoutAttributeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStructLayoutAttributeAnalyzer.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzer.cs
@@ -1,10 +1,5 @@
 ﻿using System.Collections.Concurrent;
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/UseTaskUnwrapAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseTaskUnwrapAnalyzer.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class UseTaskUnwrapAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Rules/UseTimeProviderInsteadOfInterfaceAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseTimeProviderInsteadOfInterfaceAnalyzer.cs
@@ -1,9 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/UseTimeSpanZeroAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseTimeSpanZeroAnalyzer.cs
@@ -1,10 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/ValidateArgumentsCorrectlyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ValidateArgumentsCorrectlyAnalyzer.cs
@@ -1,11 +1,5 @@
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 

--- a/src/Meziantou.Analyzer/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzer.cs
@@ -1,8 +1,3 @@
-using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Meziantou.Analyzer/Rules/ValidateUnsafeAccessorAttributeUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ValidateUnsafeAccessorAttributeUsageAnalyzer.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ValidateUnsafeAccessorAttributeUsageAnalyzer : DiagnosticAnalyzer

--- a/src/Meziantou.Analyzer/Suppressors/CA1507SerializationPropertyNameSuppressor.cs
+++ b/src/Meziantou.Analyzer/Suppressors/CA1507SerializationPropertyNameSuppressor.cs
@@ -1,8 +1,3 @@
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Meziantou.Analyzer.Suppressors;

--- a/src/Meziantou.Analyzer/Suppressors/CA1822DecoratedMethodSuppressor.cs
+++ b/src/Meziantou.Analyzer/Suppressors/CA1822DecoratedMethodSuppressor.cs
@@ -1,10 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-
-namespace Meziantou.Analyzer.Suppressors;
+﻿namespace Meziantou.Analyzer.Suppressors;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class CA1822DecoratedMethodSuppressor : DiagnosticSuppressor

--- a/src/Meziantou.Analyzer/Suppressors/IDE0058Suppressor.cs
+++ b/src/Meziantou.Analyzer/Suppressors/IDE0058Suppressor.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Immutable;
-using Meziantou.Analyzer.Internals;
-using Meziantou.Framework.Roslyn;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
-
-namespace Meziantou.Analyzer.Suppressors;
+﻿namespace Meziantou.Analyzer.Suppressors;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class IDE0058Suppressor : DiagnosticSuppressor

--- a/tests/Meziantou.Analyzer.Test/Directory.Build.props
+++ b/tests/Meziantou.Analyzer.Test/Directory.Build.props
@@ -10,6 +10,13 @@
     <TestingPlatformCommandLineArguments>--report-trx-filename $(MSBuildProjectName).trx</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
+  <!-- Global using directives shared by all the files of this project -->
+  <ItemGroup>
+    <Using Include="Meziantou.Analyzer.Rules" />
+    <Using Include="Meziantou.Analyzer.Test.Helpers" />
+    <Using Include="TestHelper" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Meziantou.Analyzer.Internals;
-using Meziantou.Analyzer.Test.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
@@ -5,7 +5,6 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
 using Meziantou.Analyzer.Annotations;
-using Meziantou.Analyzer.Test.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;

--- a/tests/Meziantou.Analyzer.Test/RuleHelpUri.cs
+++ b/tests/Meziantou.Analyzer.Test/RuleHelpUri.cs
@@ -1,4 +1,3 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Test;

--- a/tests/Meziantou.Analyzer.Test/Rules/AbstractTypesShouldNotHaveConstructorsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AbstractTypesShouldNotHaveConstructorsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class AbstractTypesShouldNotHaveConstructorsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/AddOverloadWithSpanOrMemoryAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AddOverloadWithSpanOrMemoryAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class AddOverloadWithSpanOrMemoryAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/AnonymousDelegatesShouldNotBeUsedToUnsubscribeFromEventsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AnonymousDelegatesShouldNotBeUsedToUnsubscribeFromEventsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class AnonymousDelegatesShouldNotBeUsedToUnsubscribeFromEventsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzer_UseNameofTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzer_UseNameofTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ArgumentExceptionShouldSpecifyArgumentNameAnalyzer_UseNameofTests

--- a/tests/Meziantou.Analyzer.Test/Rules/AttributeNameShouldEndWithAttributeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AttributeNameShouldEndWithAttributeAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class AttributeNameShouldEndWithAttributeAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidComparisonWithBoolConstantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidComparisonWithBoolConstantAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class AvoidComparisonWithBoolConstantAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidLockingOnPubliclyAccessibleInstanceAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidLockingOnPubliclyAccessibleInstanceAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class AvoidLockingOnPubliclyAccessibleInstanceAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
@@ -1,7 +1,4 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUsingRedundantElseAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUsingRedundantElseAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class AvoidUsingRedundantElseAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/AwaitAwaitableMethodInSyncMethodAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AwaitAwaitableMethodInSyncMethodAnalyzerTests.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class AwaitAwaitableMethodInSyncMethodAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/AwaitTaskBeforeDisposingResourcesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AwaitTaskBeforeDisposingResourcesAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public class AwaitTaskBeforeDisposingResourcesAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzerTests.cs
@@ -1,7 +1,4 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
 using Microsoft.CodeAnalysis.CSharp;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/BothSideOfTheConditionAreIdenticalAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/BothSideOfTheConditionAreIdenticalAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class BothSideOfTheConditionAreIdenticalAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ClassMustBeSealedAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/CommaAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/CommaAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class CommaAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0105.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0105.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public class ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0105

--- a/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0106.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0106.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public class ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0106

--- a/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ConditionalCompilationBranchesAreIdenticalAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ConstructorArgumentParametersShouldExistInConstructorsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConstructorArgumentParametersShouldExistInConstructorsAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ConstructorArgumentParametersShouldExistInConstructorsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DeclareTypesInNamespacesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DeclareTypesInNamespacesAnalyzerTests.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotCallVirtualMethodInConstructorAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotCallVirtualMethodInConstructorAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotCallVirtualMethodInConstructorAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotCompareDateTimeWithDateTimeOffsetAnalyzerTests_MA0132.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotCompareDateTimeWithDateTimeOffsetAnalyzerTests_MA0132.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotCompareDateTimeWithDateTimeOffsetAnalyzerTests_MA0133.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotCompareDateTimeWithDateTimeOffsetAnalyzerTests_MA0133.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotDeclareStaticMembersOnGenericTypesTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotDeclareStaticMembersOnGenericTypesTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotDeclareStaticMembersOnGenericTypesTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotIgnoreReturnValueAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotIgnoreReturnValueAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotIgnoreReturnValueAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotLogClassifiedDataAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotLogClassifiedDataAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class DoNotLogClassifiedDataAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotNaNInComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotNaNInComparisonsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotNaNInComparisonsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotOverwriteRazorComponentParameterValueTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotOverwriteRazorComponentParameterValueTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public class DoNotOverwriteRazorComponentParameterValueTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotRaiseApplicationExceptionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotRaiseApplicationExceptionAnalyzerTests.cs
@@ -1,6 +1,4 @@
 #pragma warning disable CA1030 // Use events where appropriate
-using Meziantou.Analyzer.Rules;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotRaiseNotImplementedExceptionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotRaiseNotImplementedExceptionAnalyzerTests.cs
@@ -1,6 +1,4 @@
 #pragma warning disable CA1030 // Use events where appropriate
-using Meziantou.Analyzer.Rules;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotRaiseReservedExceptionTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotRaiseReservedExceptionTypeAnalyzerTests.cs
@@ -1,6 +1,4 @@
 #pragma warning disable CA1030 // Use events where appropriate
-using Meziantou.Analyzer.Rules;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotRemoveOriginalExceptionFromThrowStatementAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotRemoveOriginalExceptionFromThrowStatementAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotRemoveOriginalExceptionFromThrowStatementAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinalizerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinalizerAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotThrowFromFinalizerAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinallyBlockAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinallyBlockAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotThrowFromFinallyBlockAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseAsyncDelegateForSyncDelegateAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseAsyncDelegateForSyncDelegateAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseAsyncDelegateForSyncDelegateAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseAsyncVoidAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseAsyncVoidAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class DoNotUseAsyncVoidAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -1,10 +1,6 @@
 using System.Collections.Immutable;
-using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseCastAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseCastAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseCastAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer_EqualsTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer_EqualsTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer_EqualsTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer_HashSetTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer_HashSetTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer_HashSetTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseEmptyPropertyPatternOnNonNullableValueTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseEmptyPropertyPatternOnNonNullableValueTypeAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseEmptyPropertyPatternOnNonNullableValueTypeAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseEqualityComparerDefaultOfStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseEqualityComparerDefaultOfStringAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseEqualityComparerDefaultOfStringAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseEqualityOperatorsForSpanOfCharAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseEqualityOperatorsForSpanOfCharAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseEqualityOperatorsForSpanOfCharAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseFinalizerAnalyzerTests.cs.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseFinalizerAnalyzerTests.cs.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseFinalizerAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseInterpolatedStringWithoutParametersAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNotYetInitializedStaticFieldAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseNotYetInitializedStaticFieldAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNullForgivenessAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseNullForgivenessAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-using Xunit;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseNullForgivenessAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseReturnTagForVoidMethodAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseReturnTagForVoidMethodAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseReturnTagForVoidMethodAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseServerCertificateValidationCallbackAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseServerCertificateValidationCallbackAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseServerCertificateValidationCallbackAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseStringGetHashCodeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseStringGetHashCodeAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseStringGetHashCodeAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class DoNotUseToStringIfObjectAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseUnknownParameterForRazorComponentAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseUnknownParameterForRazorComponentAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public class DoNotUseUnknownParameterForRazorComponentAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseZeroToInitializeAnEnumValueTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseZeroToInitializeAnEnumValueTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public class DoNotUseZeroToInitializeAnEnumValueTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DontTagInstanceFieldsWithThreadStaticAttributeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DontTagInstanceFieldsWithThreadStaticAttributeAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DontTagInstanceFieldsWithThreadStaticAttributeAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DontUseDangerousThreadingMethodsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DontUseDangerousThreadingMethodsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DontUseDangerousThreadingMethodsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/DotNotUseNameFromBCLAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DotNotUseNameFromBCLAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DotNotUseNameFromBCLAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/EmbedCaughtExceptionAsInnerExceptionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EmbedCaughtExceptionAsInnerExceptionAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class EmbedCaughtExceptionAsInnerExceptionAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests

--- a/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0094Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0094Tests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0094Tests

--- a/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0095Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0095Tests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0095Tests

--- a/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0097Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0097Tests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0097Tests

--- a/tests/Meziantou.Analyzer.Test/Rules/EventArgsNameShouldEndWithEventArgsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EventArgsNameShouldEndWithEventArgsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class EventArgsNameShouldEndWithEventArgsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/EventsShouldHaveProperArgumentsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EventsShouldHaveProperArgumentsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class EventsShouldHaveProperArgumentsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ExceptionNameShouldEndWithExceptionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ExceptionNameShouldEndWithExceptionAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ExceptionNameShouldEndWithExceptionAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class FileNameMustMatchTypeNameAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/FixToDoAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FixToDoAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class FixToDoAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ILoggerParameterTypeShouldMatchContainingTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ILoggerParameterTypeShouldMatchContainingTypeAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ILoggerParameterTypeShouldMatchContainingTypeAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/IfElseBranchesAreIdenticalAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/IfElseBranchesAreIdenticalAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class IfElseBranchesAreIdenticalAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldBeUsedOnInheritingMemberAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class InheritdocShouldBeUsedOnInheritingMemberAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldHaveSourceOnTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldHaveSourceOnTypesAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class InheritdocShouldHaveSourceOnTypesAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class InheritdocShouldNotBeAmbiguousOnTypesAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InheritdocShouldNotBeUsedOnTypesAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class InheritdocShouldNotBeUsedOnTypesAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/JSInteropMustNotBeUsedInOnInitializedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/JSInteropMustNotBeUsedInOnInitializedAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class JSInteropMustNotBeUsedInOnInitializedAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/JSInvokableMethodsMustBePublicAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/JSInvokableMethodsMustBePublicAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public class JSInvokableMethodsMustBePublicAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/LocalVariablesShouldNotHideSymbolsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LocalVariablesShouldNotHideSymbolsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class LocalVariablesShouldNotHideSymbolsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class LoggerParameterTypeAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzer_SerilogTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzer_SerilogTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class LoggerParameterTypeAnalyzer_SerilogTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/MakeClassStaticAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MakeClassStaticAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class MakeClassStaticAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/MakeMemberReadOnlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MakeMemberReadOnlyAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class MakeMemberReadOnlyAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/MakeMethodStaticAnalyzerTests_Methods.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MakeMethodStaticAnalyzerTests_Methods.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class MakeMethodStaticAnalyzerTests_Methods

--- a/tests/Meziantou.Analyzer.Test/Rules/MakeMethodStaticAnalyzerTests_Properties.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MakeMethodStaticAnalyzerTests_Properties.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class MakeMethodStaticAnalyzerTests_Properties

--- a/tests/Meziantou.Analyzer.Test/Rules/MarkAttributesWithAttributeUsageAttributeTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MarkAttributesWithAttributeUsageAttributeTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class MarkAttributesWithAttributeUsageAttributeTests

--- a/tests/Meziantou.Analyzer.Test/Rules/MergeIsPatternChecksAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MergeIsPatternChecksAnalyzerTests.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/MethodOverridesShouldNotChangeParameterDefaultsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MethodOverridesShouldNotChangeParameterDefaultsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class MethodOverridesShouldNotChangeParameterDefaultsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/MethodShouldNotBeTooLongAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MethodShouldNotBeTooLongAnalyzerTests.cs
@@ -1,7 +1,5 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/MissingNotNullWhenAttributeOnEqualsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MissingNotNullWhenAttributeOnEqualsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class NamedParameterAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/NonConstantStaticFieldsShouldNotBeVisibleAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NonConstantStaticFieldsShouldNotBeVisibleAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class NonConstantStaticFieldsShouldNotBeVisibleAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/NotPatternShouldBeParenthesizedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NotPatternShouldBeParenthesizedAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class NotPatternShouldBeParenthesizedAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/NullableAttributeUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NullableAttributeUsageAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class NullableAttributeUsageAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ObjectGetTypeOnTypeInstanceAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ObjectGetTypeOnTypeInstanceAnalyzerTests.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class ObjectGetTypeOnTypeInstanceAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ObsoleteAttributesShouldIncludeExplanationsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ObsoleteAttributesShouldIncludeExplanationsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ObsoleteAttributesShouldIncludeExplanationsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeGuidParsingAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeGuidParsingAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeGuidParsingAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerCombineLinqMethodsTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerCombineLinqMethodsTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeLinqUsageAnalyzerCombineLinqMethodsTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerCountTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerCountTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeLinqUsageAnalyzerCountTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerDuplicateOrderByTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerDuplicateOrderByTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeLinqUsageAnalyzerDuplicateOrderByTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerOrderTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerOrderTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeLinqUsageAnalyzerOrderTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseCastInsteadOfSelectTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseCastInsteadOfSelectTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeLinqUsageAnalyzerUseCastInsteadOfSelectTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseCountInsteadOfAnyTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseCountInsteadOfAnyTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeLinqUsageAnalyzerUseCountInsteadOfAnyTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseDirectMethodsTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseDirectMethodsTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeLinqUsageAnalyzerUseDirectMethodsTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseIndexerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseIndexerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeLinqUsageAnalyzerUseIndexerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerWhereBeforeOrderByTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerWhereBeforeOrderByTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeLinqUsageAnalyzerWhereBeforeOrderByTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStartsWithAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStartsWithAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeStartsWithAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptimizeStringBuilderUsageAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptionalParametersAttributeAnalyzerMA0087Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptionalParametersAttributeAnalyzerMA0087Tests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptionalParametersAttributeAnalyzerMA0087Tests

--- a/tests/Meziantou.Analyzer.Test/Rules/OptionalParametersAttributeAnalyzerMA0088Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptionalParametersAttributeAnalyzerMA0088Tests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class OptionalParametersAttributeAnalyzerMA0088Tests

--- a/tests/Meziantou.Analyzer.Test/Rules/ParameterAttributeForRazorComponentAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ParameterAttributeForRazorComponentAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class ParameterAttributeForRazorComponentAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/PreferReturningCollectionAbstractionInsteadOfImplementationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/PreferReturningCollectionAbstractionInsteadOfImplementationAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class PreferReturningCollectionAbstractionInsteadOfImplementationAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/PreserveParamsOnOverrideAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/PreserveParamsOnOverrideAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class PreserveParamsOnOverrideAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/PrimaryConstructorParameterShouldBeReadOnlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/PrimaryConstructorParameterShouldBeReadOnlyAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class PrimaryConstructorParameterShouldBeReadOnlyAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ProcessStartAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ProcessStartAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ProcessStartAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/RecordClassDeclarationShouldBeExplicitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RecordClassDeclarationShouldBeExplicitAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class RecordClassDeclarationShouldBeExplicitAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/RecordClassDeclarationShouldBeImplicitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RecordClassDeclarationShouldBeImplicitAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class RecordClassDeclarationShouldBeImplicitAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveEmptyBlockAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveEmptyBlockAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class RemoveEmptyBlockAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveEmptyStatementAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveEmptyStatementAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class RemoveEmptyStatementAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis.CSharp;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryClosedModifierAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryClosedModifierAnalyzerTests.cs
@@ -1,8 +1,5 @@
 #if ROSLYN_5_9_OR_GREATER
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
 using Microsoft.CodeAnalysis.CSharp;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryPartialModifierAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryPartialModifierAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class RemoveUnnecessaryPartialModifierAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUselessToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUselessToStringAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class RemoveUselessToStringAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ReplaceEnumToStringWithNameofAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ReplaceEnumToStringWithNameofAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ReplaceEnumToStringWithNameofAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ReturnTaskFromResultInsteadOfReturningNullAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ReturnTaskFromResultInsteadOfReturningNullAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ReturnTaskFromResultInsteadOfReturningNullAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ReturnTaskInsteadOfAwaitingItAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ReturnTaskInsteadOfAwaitingItAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ReturnTaskInsteadOfAwaitingItAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/SequenceNumberMustBeAConstantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SequenceNumberMustBeAConstantAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class SequenceNumberMustBeAConstantAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyCallerArgumentExpressionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyCallerArgumentExpressionAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public class SimplifyCallerArgumentExpressionAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyNegatedBooleanExpressionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyNegatedBooleanExpressionAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class SimplifyNegatedBooleanExpressionAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/StringFormatShouldBeConstantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/StringFormatShouldBeConstantAnalyzerTests.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/TaskInUsingAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/TaskInUsingAnalyzerTests.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class TaskInUsingAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ThrowIfNullWithNonNullableInstanceAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ThrowIfNullWithNonNullableInstanceAnalyzerTests.cs
@@ -1,7 +1,4 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class ThrowIfNullWithNonNullableInstanceAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/TypeCannotBeUsedInAnAttributeParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/TypeCannotBeUsedInAnAttributeParameterAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class TypeCannotBeUsedInAnAttributeParameterAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/TypeNameMustNotMatchNamespaceAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/TypeNameMustNotMatchNamespaceAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class TypeNameMustNotMatchNamespaceAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/TypesShouldNotExtendSystemApplicationExceptionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/TypesShouldNotExtendSystemApplicationExceptionAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class TypesShouldNotExtendSystemApplicationExceptionAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasMidpointRoundingAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasMidpointRoundingAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseAnOverloadThatHasMidpointRoundingAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
@@ -1,7 +1,4 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseArrayEmptyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseArrayEmptyAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseArrayEmptyAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseAttributeIsDefinedAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseAwaitInsteadOfReturningTaskAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
@@ -1,7 +1,4 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class UseContainsKeyInsteadOfTryGetValueAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public class UseDateTimeUnixEpochAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseEqualsMethodInsteadOfOperatorAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseEqualsMethodInsteadOfOperatorAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public class UseEqualsMethodInsteadOfOperatorAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseEventArgsEmptyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseEventArgsEmptyAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseEventArgsEmptyAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseEventHandlerOfTAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseEventHandlerOfTAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseEventHandlerOfTAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseExclusiveOrOperatorAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseExclusiveOrOperatorAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseExclusiveOrOperatorAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseGuidEmptyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseGuidEmptyAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseGuidEmptyAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseHasFlagMethodAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseIFormatProviderAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseInKeywordForInParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseInKeywordForInParameterAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseInKeywordForInParameterAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseInlineArrayInsteadOfFixedBufferAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseInlineArrayInsteadOfFixedBufferAnalyzerTests.cs
@@ -1,7 +1,4 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
 using Microsoft.CodeAnalysis.CSharp;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests.cs
@@ -1,8 +1,4 @@
-﻿using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
-namespace Meziantou.Analyzer.Test.Rules;
+﻿namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class UseIsPatternInsteadOfSequenceEqualAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseJSRuntimeInvokeVoidAsyncWhenReturnValueIsNotUsedTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseJSRuntimeInvokeVoidAsyncWhenReturnValueIsNotUsedTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public class UseJSRuntimeInvokeVoidAsyncWhenReturnValueIsNotUsedTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseLangwordInXmlCommentAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseLangwordInXmlCommentAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class UseLangwordInXmlCommentAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseLazyInitializerEnsureInitializeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseLazyInitializerEnsureInitializeAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseLazyInitializerEnsureInitializeAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseMultiLineXmlCommentSyntaxAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseMultiLineXmlCommentSyntaxAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseMultiLineXmlCommentSyntaxAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseOperatingSystemInsteadOfRuntimeInformationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseOperatingSystemInsteadOfRuntimeInformationAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public class UseOperatingSystemInsteadOfRuntimeInformationAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerHasValueTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerHasValueTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerHasValueTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseReadOnlyStructForRefReadOnlyParametersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseReadOnlyStructForRefReadOnlyParametersAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public class UseReadOnlyStructForRefReadOnlyParametersAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseRegexOptionsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public class UseRegexSourceGeneratorAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexTimeoutAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexTimeoutAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseRegexTimeoutAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseStringComparerAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerNonCultureSensitiveTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerNonCultureSensitiveTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseStringComparisonAnalyzerNonCultureSensitiveTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseStringComparisonAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringCreateInsteadOfFormattableStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringCreateInsteadOfFormattableStringAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseStringCreateInsteadOfFormattableStringAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseStringEqualsAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsInsteadOfIsPatternAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsInsteadOfIsPatternAnalyzerTests.cs
@@ -1,6 +1,4 @@
-using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Rules;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStructLayoutAttributeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStructLayoutAttributeAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseStructLayoutAttributeAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public sealed class UseSystemThreadingLockInsteadOfObjectAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTaskUnwrapAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTaskUnwrapAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseTaskUnwrapAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTimeProviderInsteadOfInterfaceAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTimeProviderInsteadOfInterfaceAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseTimeProviderInsteadOfInterfaceAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTimeSpanZeroAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTimeSpanZeroAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using TestHelper;
-using Xunit;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseTimeSpanZeroAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ValidateArgumentsCorrectlyAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateUnsafeAccessorAttributeUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateUnsafeAccessorAttributeUsageAnalyzerTests.cs
@@ -1,7 +1,3 @@
-using Meziantou.Analyzer.Rules;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
-
 namespace Meziantou.Analyzer.Test.Rules;
 public class ValidateUnsafeAccessorAttributeUsageAnalyzerTests
 {

--- a/tests/Meziantou.Analyzer.Test/Suppressors/CA1507SerializationPropertyNameSuppressorTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Suppressors/CA1507SerializationPropertyNameSuppressorTests.cs
@@ -1,7 +1,5 @@
 #if ROSLYN_4_10_OR_GREATER
 using Meziantou.Analyzer.Suppressors;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Suppressors;
 public sealed class CA1507SerializationPropertyNameSuppressorTests

--- a/tests/Meziantou.Analyzer.Test/Suppressors/CA1822DecoratedMethodSuppressorTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Suppressors/CA1822DecoratedMethodSuppressorTests.cs
@@ -1,7 +1,5 @@
 #if ROSLYN_4_10_OR_GREATER
 using Meziantou.Analyzer.Suppressors;
-using Meziantou.Analyzer.Test.Helpers;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Suppressors;
 public sealed class CA1822DecoratedMethodSuppressorTests

--- a/tests/Meziantou.Analyzer.Test/Suppressors/IDE0058SuppressorTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Suppressors/IDE0058SuppressorTests.cs
@@ -1,7 +1,6 @@
 #if ROSLYN_4_10_OR_GREATER
 using Meziantou.Analyzer.Suppressors;
 using Microsoft.CodeAnalysis;
-using TestHelper;
 
 namespace Meziantou.Analyzer.Test.Suppressors;
 public sealed class IDE0058SuppressorTests


### PR DESCRIPTION
The same namespaces were repeated in almost every file of the analyzer, the code fixers and the test projects. They are now declared once per project, as `Using` items in the `Directory.Build.props` of the folder, so that all the Roslyn versions get them.

## Global namespaces per project

**`Meziantou.Analyzer`** (213 files) — the namespaces used by 49% to 90% of the files:

| Namespace | Files that had it |
| --- | --- |
| `Microsoft.CodeAnalysis` | 192 (90%) |
| `Meziantou.Framework.Roslyn` | 174 (81%) |
| `Microsoft.CodeAnalysis.Diagnostics` | 172 (80%) |
| `System.Collections.Immutable` | 170 (79%) |
| `Microsoft.CodeAnalysis.Operations` | 115 (53%) |
| `Meziantou.Analyzer.Internals` | 106 (49%) |

**`Meziantou.Analyzer.CodeFixers`** (113 files) — same list without `Microsoft.CodeAnalysis.Diagnostics`, which is unused there, plus:

| Namespace | Files that had it |
| --- | --- |
| `Microsoft.CodeAnalysis.CodeFixes` | 108 (95%) |
| `System.Composition` | 106 (93%) |
| `Microsoft.CodeAnalysis.CodeActions` | 107 (94%) |
| `Microsoft.CodeAnalysis.Editing` | 98 (86%) |
| `Microsoft.CodeAnalysis.CSharp.Syntax` | 96 (84%) |
| `Microsoft.CodeAnalysis.CSharp` | 65 (57%) |

**`Meziantou.Analyzer.Test`** (201 files):

| Namespace | Files that had it |
| --- | --- |
| `TestHelper` | 189 (94%) |
| `Meziantou.Analyzer.Rules` | 187 (93%) |
| `Meziantou.Analyzer.Test.Helpers` | 84 (41%) |

The remaining namespaces were used by less than a third of the files and are left as-is. `using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;` (28% of the code fixers) is also left as-is: making the `SyntaxFactory` members visible everywhere is more likely to change overload resolution than to help.

## Notes for the reviewer

- The files shared by `Meziantou.Analyzer` and `Meziantou.Analyzer.CodeFixers` (`RuleIdentifiers.cs`, `Internals/*.cs`, `Rules/*Common.cs`, ...) only lost the using directives that are global in **both** projects, so they keep compiling in the two projects.
- The using directives that duplicate the implicit global usings of the SDK (`System`, `System.Linq`, `Xunit`, ...) are removed as well: 35 of them, in 30 files.
- Only the using directives at the top of the files are removed, so the code snippets of the tests are untouched.
- The declarations are `Using` items in the `Directory.Build.props` of each folder rather than a `GlobalUsings.cs` file, so that they follow the same rule as the rest of the configuration: every Roslyn version of the folder gets them.

## Validation

- `dotnet build`: succeeds for all the Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9), no new warning.
- `dotnet test`: 18012 tests pass, 0 failed, 0 skipped.
- `dotnet run --project src/DocumentationGenerator`: no change to the markdown files.
