### PR TITLE
Add a timeout to the NuGet package downloads of the tests

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs
@@ -16,6 +16,10 @@ namespace TestHelper;
 public sealed partial class ProjectBuilder
 {
     private static readonly ConcurrentDictionary<string, Lazy<Task<string[]>>> NuGetPackagesCache = new(StringComparer.Ordinal);
+
+    // HttpClient.Timeout does not apply to reading the response stream, so a stalled connection would hang forever.
+    // The result is shared by all the tests through NuGetPackagesCache, so it would hang the whole test run.
+    private static readonly TimeSpan NuGetDownloadTimeout = TimeSpan.FromSeconds(60);
     private readonly AnalyzerAssemblyLoader _analyzerAssemblyLoader = new();
 
     private int _diagnosticMessageIndex;
@@ -95,7 +99,7 @@ public sealed partial class ProjectBuilder
                 }
 
                 static bool IsLastAttempt(int attempt) => attempt >= MaxAttempts;
-                static bool IsTransientException(Exception exception) => exception is HttpRequestException or IOException or InvalidDataException;
+                static bool IsTransientException(Exception exception) => exception is HttpRequestException or IOException or InvalidDataException or OperationCanceledException or TimeoutException;
             }
 
             async Task DownloadPackage()
@@ -104,8 +108,23 @@ public sealed partial class ProjectBuilder
                 try
                 {
                     Directory.CreateDirectory(tempFolder);
-                    await using var stream = await SharedHttpClient.Instance.GetStreamAsync(new Uri($"https://www.nuget.org/api/v2/package/{packageName}/{version}")).ConfigureAwait(false);
-                    await using var zip = new ZipArchive(stream, ZipArchiveMode.Read);
+                    var url = new Uri($"https://www.nuget.org/api/v2/package/{packageName}/{version}");
+                    var content = new MemoryStream();
+                    using (var cts = new CancellationTokenSource(NuGetDownloadTimeout))
+                    {
+                        try
+                        {
+                            await using var stream = await SharedHttpClient.Instance.GetStreamAsync(url, cts.Token).ConfigureAwait(false);
+                            await stream.CopyToAsync(content, cts.Token).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException ex) when (cts.IsCancellationRequested)
+                        {
+                            throw new TimeoutException($"Downloading '{url}' timed out after {NuGetDownloadTimeout}", ex);
+                        }
+                    }
+
+                    content.Seek(0, SeekOrigin.Begin);
+                    await using var zip = new ZipArchive(content, ZipArchiveMode.Read);
 
                     foreach (var entry in zip.Entries.Where(file => includedPaths.Any(path => file.FullName.StartsWith(path, StringComparison.Ordinal))))
                     {


### PR DESCRIPTION
`GetNuGetReferences` in `tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.cs` downloaded the reference packages with `GetStreamAsync` and read the resulting stream through a `ZipArchive`. `HttpClient.Timeout` does not cover reading an unbuffered response stream, and neither `DownloadPackageWithRetries` nor `HttpRetryMessageHandler` could recover from a stalled read: they only react to exceptions and 5xx responses. A stalled connection therefore hung the download forever, and because the result is shared through the `NuGetPackagesCache` `Lazy<Task<string[]>>`, every test waiting on it hung too.

This happened on CI in [this run](https://github.com/meziantou/Meziantou.Analyzer/actions/runs/32314247691/job/96263276981): the `build_and_test (Meziantou.Analyzer.Test.roslyn5.6)` job ran 3629 tests successfully, then `RemoveEmptyStatementAnalyzerTests.ForStatement` (a 0.6s test) was still running after 13 minutes and the hang dump policy killed the run with exit code 7.

## Changes

- The package is now read into a buffer under a `CancellationTokenSource` timeout covering both the request and the stream read, and only then handed to the `ZipArchive`. As the archive is opened over a buffer, the per-entry extraction can no longer stall on the network either.
- The timeout is 60 seconds. With the existing 5-attempt retry loop, a fully stalled connection now fails after about 5 minutes instead of hanging forever, which is well inside the CI hang dump window.
- `IsTransientException` now also matches `OperationCanceledException` and `TimeoutException`, so the timeout feeds the existing retry loop instead of propagating. There is no outer cancellation token in this path, so this cannot swallow a legitimate cancellation.

## Testing

The local NuGet reference cache was moved aside so that the download path actually ran during the test runs.

- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn5.9.csproj`: 3663 passed, 0 failed, with a cold cache.
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn4.8.csproj`: 3533 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator`: exit code 0, no markdown change.