### PR TITLE
Fix MA0075 false positive on Enum.ToString and handle conditional access

### DIFF
--- a/docs/Rules/MA0075.md
+++ b/docs/Rules/MA0075.md
@@ -15,7 +15,7 @@ _ = "abc" + -1.ToString(CultureInfo.InvariantCulture); // compliant
 
 A type is culture-sensitive when it implements `System.IFormattable` or `System.ISpanFormattable`, or exposes a provider-aware `ToString` overload. A type is culture-insensitive when it is known to be invariant, is marked with `CultureInsensitiveTypeAttribute`, or is sealed and does not support culture-aware formatting. Values typed as `object`, an interface, or an unconstrained type parameter are opaque runtime types. Non-sealed classes are tracked separately. These two categories are not reported by default; set `MA0075.treat_opaque_runtime_types_as_culture_sensitive` or `MA0075.treat_unsealed_types_as_culture_sensitive` to `true` to report them. A union type is culture-sensitive when at least one of its case types is culture-sensitive.<br/>
 Known culture-invariant types include:
-* Any enum
+* Any enum, including values typed as `System.Enum`
 * System.Byte
 * System.Char
 * System.Guid

--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -210,6 +210,10 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
             return CultureSensitivity.CultureSensitive;
         }
 
+        // "value?.ToString()" formats the value when it is not null, so the culture sensitivity is the one of the accessed value
+        if (operation is IConditionalAccessOperation conditionalAccess)
+            return GetCultureSensitivity(conditionalAccess.WhenNotNull, options);
+
         if (operation is IInterpolatedStringHandlerCreationOperation handler)
             return GetCultureSensitivity(handler.Content, options);
 
@@ -425,6 +429,11 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
             return GetCultureSensitivity(typeParameter, options);
 
         if (typeSymbol.IsEnum())
+            return CultureSensitivity.CultureInsensitive;
+
+        // The ToString overloads of an enum are declared on System.Enum, so the containing type of an invocation
+        // such as 'enumValue.ToString("G")' is System.Enum. They ignore the format provider, so they are culture-insensitive.
+        if (typeSymbol.IsEqualTo(EnumSymbol))
             return CultureSensitivity.CultureInsensitive;
 
         if (typeSymbol.SpecialType == SpecialType.System_Boolean)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -1220,6 +1220,215 @@ class Sample : System.IFormattable
               .ValidateAsync();
     }
 
+    [Theory]
+    [InlineData("value")]
+    [InlineData("value.ToString()")]
+    [InlineData("value.ToString(\"G\")")]
+    [InlineData("value.ToString(\"g\")")]
+    [InlineData("value.ToString(\"F\")")]
+    [InlineData("value.ToString(\"f\")")]
+    [InlineData("value.ToString(\"D\")")]
+    [InlineData("value.ToString(\"d\")")]
+    [InlineData("value.ToString(\"X\")")]
+    [InlineData("value.ToString(\"x\")")]
+    [InlineData("value.ToString(default(string))")]
+    [InlineData("value.ToString(format)")]
+    public async Task Concat_Enum_NoDiagnostic(string expression)
+    {
+        var sourceCode = $$"""
+            using System;
+            class Test
+            {
+                void A(StringComparison value, string format) { _ = "abc" + {{expression}}; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("value")]
+    [InlineData("value.ToString()")]
+    [InlineData("value?.ToString(\"G\")")]
+    [InlineData("value.Value.ToString(\"G\")")]
+    public async Task Concat_NullableEnum_NoDiagnostic(string expression)
+    {
+        var sourceCode = $$"""
+            using System;
+            class Test
+            {
+                void A(StringComparison? value) { _ = "abc" + {{expression}}; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("value.ToString()")]
+    [InlineData("value.ToString(\"G\")")]
+    public async Task Concat_SystemEnum_NoDiagnostic(string expression)
+    {
+        var sourceCode = $$"""
+            using System;
+            class Test
+            {
+                void A(Enum value) { _ = "abc" + {{expression}}; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("value.ToString(\"G\")")]
+    [InlineData("value.ToString(\"F\")")]
+    public async Task Concat_UserDefinedEnum_NoDiagnostic(string expression)
+    {
+        var sourceCode = $$"""
+            class Test
+            {
+                void A(Sample value) { _ = "abc" + {{expression}}; }
+            }
+
+            enum Sample { A }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("{value}")]
+    [InlineData("{value:G}")]
+    [InlineData("{value:F}")]
+    [InlineData("{value.ToString()}")]
+    [InlineData("{value.ToString(\"G\")}")]
+    public async Task InterpolatedString_Enum_NoDiagnostic(string content)
+    {
+        var sourceCode = $$"""
+            using System;
+            class Test
+            {
+                void A(StringComparison value) { _ = $"abc{{content}}"; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("value.ToString()")]
+    [InlineData("value.ToString(\"G\")")]
+    public async Task Concat_EnumInGenericMethod_NoDiagnostic(string expression)
+    {
+        var sourceCode = $$"""
+            using System;
+            class Test
+            {
+                void A<T>(T value) where T : struct, Enum { _ = "abc" + {{expression}}; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("value?.ToString()")]
+    [InlineData("value?.ToString(\"F\")")]
+    [InlineData("value?.ToString(format)")]
+    [InlineData("value?.Date.ToString(\"F\")")]
+    [InlineData("value?.Ticks.ToString()")]
+    public async Task Concat_ConditionalAccess_Diagnostic(string expression)
+    {
+        var sourceCode = $$"""
+            using System;
+            class Test
+            {
+                void A(DateTime? value, string format) { _ = "abc" + [|{{expression}}|]; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("value?.ToString(\"o\")")]
+    [InlineData("value?.ToString(System.Globalization.CultureInfo.InvariantCulture)")]
+    [InlineData("value?.Ticks.ToString(\"X\")")]
+    [InlineData("value?.Kind.ToString(\"G\")")]
+    public async Task Concat_ConditionalAccess_NoDiagnostic(string expression)
+    {
+        var sourceCode = $$"""
+            using System;
+            class Test
+            {
+                void A(DateTime? value) { _ = "abc" + {{expression}}; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_NestedConditionalAccess_Diagnostic()
+    {
+        const string SourceCode = """
+            using System;
+            class Test
+            {
+                void A(Test value) { _ = "abc" + [|value?.Child?.Value.ToString("F")|]; }
+
+                Test Child { get; }
+                DateTime Value { get; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Concat_ConditionalAccessToCultureSensitiveMember_Diagnostic()
+    {
+        const string SourceCode = """
+            using System;
+            class Test
+            {
+                void A(Test value) { _ = "abc" + [|value?.Value|]; }
+
+                DateTime Value { get; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InterpolatedString_ConditionalAccess_Diagnostic()
+    {
+        const string SourceCode = """
+            using System;
+            class Test
+            {
+                void A(Test value) { _ = $"abc[|{value?.Value}|]"; }
+
+                DateTime Value { get; }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
 #if ROSLYN_5_9_OR_GREATER
     private static ProjectBuilder CreateUnionProjectBuilder()
     {

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
@@ -714,4 +714,42 @@ class TypeName
               .ShouldFixCodeWith(Fix)
               .ValidateAsync();
     }
+
+    [Theory]
+    [InlineData("{value}")]
+    [InlineData("{value:G}")]
+    [InlineData("{value.ToString()}")]
+    [InlineData("{value.ToString(\"G\")}")]
+    public async Task StringCreateWithInvariantCulture_Enum_ShouldReport(string content)
+    {
+        var sourceCode = $$"""
+using System;
+using System.Globalization;
+
+class TypeName
+{
+    public void Test(StringComparison value)
+    {
+        var x = [|string.Create(CultureInfo.InvariantCulture, $"abc{{content}}")|];
+    }
+}
+""";
+
+        var fix = $$"""
+using System;
+using System.Globalization;
+
+class TypeName
+{
+    public void Test(StringComparison value)
+    {
+        var x = $"abc{{content}}";
+    }
+}
+""";
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ShouldFixCodeWith(fix)
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
Fixes #1310

## MA0075 vs MA0185 on enums

MA0075 reported `Do not use implicit culture-sensitive ToString` for `"abc" + enumValue.ToString("G")`, while MA0185 considered the very same value culture invariant.

The `ToString` overloads of an enum are declared on `System.Enum`, so `invocation.TargetMethod.ContainingType` is `System.Enum`. That type is a class, so `IsEnum()` returns `false`, and it implements `IFormattable`, so it was classified as culture sensitive. `System.Enum` ignores the format provider, so it is now part of the known culture-insensitive types.

Adding `System.Enum` to the type-level check rather than using `invocation.Instance?.Type` also covers values statically typed as `System.Enum` and type parameters constrained to `where T : struct, Enum`.

Note that the underlying gap is not new: it only became visible in #1273, which changed the string concatenation rule from analyzing only operands implicitly converted to `object` to analyzing every operand. Before that, a `string`-typed operand such as `enumValue.ToString("G")` was never analyzed at all.

## Conditional access

Found while investigating the above: `IConditionalAccessOperation` was not handled, so it fell through to the generic branch that uses the type of the whole expression. For `"abc" + dateTime?.ToString("F")` that type is `string`, so the rule never reported it. The culture sensitivity is now computed from `WhenNotNull`.

This only affects MA0075/MA0076. MA0185 reaches interpolation holes through `IInterpolatedStringAppendOperation`, which works off argument types, so its behavior is unchanged.

## Tests

- Enums: concat with every format (`G g F f D d X x`, `default(string)`, a non-constant `string format`), plain `ToString()`, implicit concat, nullable enums, `System.Enum`-typed values, user-defined enums, `where T : struct, Enum`, and the interpolated-string forms.
- Conditional access: `value?.ToString()`, `value?.ToString("F")`, `value?.ToString(format)`, `value?.Date.ToString("F")`, `value?.Ticks.ToString()`, nested `value?.Child?.Value.ToString("F")`, `value?.Value`, and the interpolated form are reported; `value?.ToString("o")`, `value?.ToString(CultureInfo.InvariantCulture)`, `value?.Ticks.ToString("X")` and `value?.Kind.ToString("G")` are not.
- MA0185 enum tests, so the two rules cannot drift apart again without a test failing.

`"abc" + value?.Ticks.ToString()` is reported on purpose: `Ticks` is a non-constant `long`, and MA0075 already treats non-constant signed integers as culture sensitive because of the negative sign.

## Note for the reviewer

`Enum.ToString("D")` on an *undefined* value of a signed enum formats the underlying integer with the current culture, so a negative value picks up the culture's negative sign. Treating `System.Enum` as unconditionally invariant ignores that. This is consistent with what MA0075 already did for `"abc" + enumValue` and with MA0185, but it is not literally always invariant.

## Validation

- `dotnet test --max-parallel-test-modules 2`: 18327 passed, 0 failed (all five Roslyn versions)
- `dotnet run --project src/DocumentationGenerator`: exit code 0, no generated markdown change