### PR TITLE
Add MA0217: Use a static lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0214](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0214.md)|Design|Use 'await' instead of returning the task|ℹ️|❌|✔️|❌|
 |[MA0215](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0215.md)|Performance|Return the task instead of awaiting it|ℹ️|❌|✔️|❌|
 |[MA0216](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0216.md)|Design|Remove unnecessary closed modifier|ℹ️|✔️|❌|❌|
+|[MA0217](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0217.md)|Design|Use a static lambda|ℹ️|❌|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -215,6 +215,7 @@
 |[MA0214](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0214.md)|Design|Use 'await' instead of returning the task|<span title='Info'>ℹ️</span>|❌|✔️|❌|
 |[MA0215](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0215.md)|Performance|Return the task instead of awaiting it|<span title='Info'>ℹ️</span>|❌|✔️|❌|
 |[MA0216](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0216.md)|Design|Remove unnecessary closed modifier|<span title='Info'>ℹ️</span>|✔️|❌|❌|
+|[MA0217](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0217.md)|Design|Use a static lambda|<span title='Info'>ℹ️</span>|❌|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0217.md
+++ b/docs/Rules/MA0217.md
@@ -1,0 +1,24 @@
+# MA0217 - Use a static lambda
+<!-- sources -->
+Sources: [UseStaticLambdaAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseStaticLambdaAnalyzer.cs), [UseStaticLambdaFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseStaticLambdaFixer.cs)
+<!-- sources -->
+
+A lambda that doesn't capture any variable, parameter, or `this` can be marked as `static`. The `static` modifier documents that the lambda doesn't depend on the enclosing context, and the compiler reports an error (`CS8820` / `CS8821`) if a capture is added later.
+
+The rule also applies to anonymous methods (`delegate { }`). It is reported only when the language version is C# 9 or greater, as this is the version that introduced static anonymous functions.
+
+This rule is disabled by default as adding the modifier on every lambda is often considered noisy.
+
+## Non-compliant code
+
+````c#
+List<int> list = [3, 1, 2];
+list.Sort((x, y) => x.CompareTo(y));
+````
+
+## Compliant code
+
+````c#
+List<int> list = [3, 1, 2];
+list.Sort(static (x, y) => x.CompareTo(y));
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStaticLambdaFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStaticLambdaFixer.cs
@@ -1,0 +1,48 @@
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class UseStaticLambdaFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.UseStaticLambda);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
+        if (nodeToFix is not AnonymousFunctionExpressionSyntax anonymousFunction)
+            return;
+
+        if (anonymousFunction.Modifiers.Any(SyntaxKind.StaticKeyword))
+            return;
+
+        var title = "Add static modifier";
+        var codeAction = CodeAction.Create(
+            title,
+            ct => AddStaticModifier(context.Document, anonymousFunction, ct),
+            equivalenceKey: title);
+
+        context.RegisterCodeFix(codeAction, context.Diagnostics);
+    }
+
+    private static async Task<Document> AddStaticModifier(Document document, AnonymousFunctionExpressionSyntax anonymousFunction, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        var staticToken = SyntaxFactory.Token(SyntaxKind.StaticKeyword).WithTrailingTrivia(SyntaxFactory.Space);
+
+        // The leading trivia must be moved to the new first token of the lambda
+        var leadingTrivia = anonymousFunction.GetLeadingTrivia();
+        var newNode = anonymousFunction
+            .WithoutLeadingTrivia()
+            .WithModifiers(anonymousFunction.Modifiers.Insert(0, staticToken))
+            .WithLeadingTrivia(leadingTrivia)
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        editor.ReplaceNode(anonymousFunction, newNode);
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -643,3 +643,6 @@ dotnet_diagnostic.MA0215.severity = error
 
 # MA0216: Remove unnecessary closed modifier
 dotnet_diagnostic.MA0216.severity = error
+
+# MA0217: Use a static lambda
+dotnet_diagnostic.MA0217.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -643,3 +643,6 @@ dotnet_diagnostic.MA0215.severity = suggestion
 
 # MA0216: Remove unnecessary closed modifier
 dotnet_diagnostic.MA0216.severity = suggestion
+
+# MA0217: Use a static lambda
+dotnet_diagnostic.MA0217.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -643,3 +643,6 @@ dotnet_diagnostic.MA0215.severity = warning
 
 # MA0216: Remove unnecessary closed modifier
 dotnet_diagnostic.MA0216.severity = warning
+
+# MA0217: Use a static lambda
+dotnet_diagnostic.MA0217.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -643,3 +643,6 @@ dotnet_diagnostic.MA0215.severity = none
 
 # MA0216: Remove unnecessary closed modifier
 dotnet_diagnostic.MA0216.severity = suggestion
+
+# MA0217: Use a static lambda
+dotnet_diagnostic.MA0217.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -643,3 +643,6 @@ dotnet_diagnostic.MA0215.severity = none
 
 # MA0216: Remove unnecessary closed modifier
 dotnet_diagnostic.MA0216.severity = none
+
+# MA0217: Use a static lambda
+dotnet_diagnostic.MA0217.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -216,6 +216,7 @@ internal static class RuleIdentifiers
     public const string UseAwaitInsteadOfReturningTask = "MA0214";
     public const string ReturnTaskInsteadOfAwaitingIt = "MA0215";
     public const string RemoveUnnecessaryClosedModifier = "MA0216";
+    public const string UseStaticLambda = "MA0217";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/UseStaticLambdaAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStaticLambdaAnalyzer.cs
@@ -1,0 +1,107 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseStaticLambdaAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.UseStaticLambda,
+        title: "Use a static lambda",
+        messageFormat: "Use a static lambda as it doesn't capture any state",
+        RuleCategories.Design,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseStaticLambda));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterOperationAction(AnalyzeAnonymousFunction, OperationKind.AnonymousFunction);
+    }
+
+    private static void AnalyzeAnonymousFunction(OperationAnalysisContext context)
+    {
+        var operation = (IAnonymousFunctionOperation)context.Operation;
+
+        // Query expressions generate anonymous functions whose syntax is not a lambda
+        if (operation.Syntax is not AnonymousFunctionExpressionSyntax syntax)
+            return;
+
+        if (syntax.Modifiers.Any(SyntaxKind.StaticKeyword))
+            return;
+
+        // static lambdas are available since C# 9
+        if (!syntax.GetCSharpLanguageVersion().IsCSharp9OrGreater())
+            return;
+
+        var semanticModel = operation.SemanticModel;
+        if (semanticModel is null)
+            return;
+
+        var dataFlow = semanticModel.AnalyzeDataFlow(syntax);
+        if (dataFlow is null || !dataFlow.Succeeded)
+            return;
+
+        // Variables declared inside the lambda can be captured by a nested lambda, which doesn't prevent the lambda from being static
+        foreach (var symbol in dataFlow.CapturedInside)
+        {
+            if (!IsDeclaredInside(symbol, syntax))
+                return;
+        }
+
+        // A static lambda cannot reference a local function declared outside of it (CS8820)
+        if (ReferencesLocalFunctionDeclaredOutside(operation, syntax))
+            return;
+
+        context.ReportDiagnostic(Rule, syntax);
+    }
+
+    private static bool ReferencesLocalFunctionDeclaredOutside(IOperation operation, SyntaxNode lambda)
+    {
+        var operations = new Queue<IOperation>();
+        operations.Enqueue(operation);
+
+        while (operations.Count > 0)
+        {
+            var op = operations.Dequeue();
+            foreach (var child in op.GetChildOperations())
+            {
+                operations.Enqueue(child);
+            }
+
+            var method = op switch
+            {
+                IInvocationOperation invocation => invocation.TargetMethod,
+                IMethodReferenceOperation methodReference => methodReference.Method,
+                _ => null,
+            };
+
+            if (method is { MethodKind: MethodKind.LocalFunction, IsStatic: false } && !IsDeclaredInside(method, lambda))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsDeclaredInside(ISymbol symbol, SyntaxNode lambda)
+    {
+        // "this" has no declaring syntax reference
+        if (symbol.DeclaringSyntaxReferences.Length is 0)
+            return false;
+
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            if (reference.SyntaxTree != lambda.SyntaxTree || !lambda.Span.Contains(reference.Span))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStaticLambdaAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStaticLambdaAnalyzerTests.cs
@@ -1,0 +1,553 @@
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class UseStaticLambdaAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<UseStaticLambdaAnalyzer>()
+            .WithCodeFixProvider<UseStaticLambdaFixer>()
+            .WithTargetFramework(TargetFramework.Net9_0);
+    }
+
+    [Fact]
+    public async Task LambdaWithoutCapture()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System.Collections.Generic;
+                  class C
+                  {
+                      void M(List<int> list) => list.Sort([|(x, y) => x.CompareTo(y)|]);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System.Collections.Generic;
+                  class C
+                  {
+                      void M(List<int> list) => list.Sort(static (x, y) => x.CompareTo(y));
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task SimpleLambdaWithoutCapture()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int, int>)([|x => x + 1|]);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int, int>)(static x => x + 1);
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task AnonymousMethodWithoutCapture()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int>)([|delegate { return 1; }|]);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int>)(static delegate { return 1; });
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task AsyncLambdaWithoutCapture()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  using System.Threading.Tasks;
+                  class C
+                  {
+                      void M() => _ = (Func<Task<int>>)([|async () => await Task.FromResult(1)|]);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  using System.Threading.Tasks;
+                  class C
+                  {
+                      void M() => _ = (Func<Task<int>>)(static async () => await Task.FromResult(1));
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MultilineLambdaKeepsIndentation()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System.Collections.Generic;
+                  class C
+                  {
+                      void M(List<int> list)
+                      {
+                          list.Sort(
+                              [|(x, y) => x.CompareTo(y)|]);
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System.Collections.Generic;
+                  class C
+                  {
+                      void M(List<int> list)
+                      {
+                          list.Sort(
+                              static (x, y) => x.CompareTo(y));
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LambdaInExpressionTree()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  using System.Linq.Expressions;
+                  class C
+                  {
+                      void M() => _ = (Expression<Func<int, int>>)([|x => x + 1|]);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  using System.Linq.Expressions;
+                  class C
+                  {
+                      void M() => _ = (Expression<Func<int, int>>)(static x => x + 1);
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LambdaUsingStaticMemberAndConstant()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      const int Constant = 1;
+                      static int Field;
+                      void M() => _ = (Func<int>)([|() => Field + Constant + Compute()|]);
+                      static int Compute() => 0;
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      const int Constant = 1;
+                      static int Field;
+                      void M() => _ = (Func<int>)(static () => Field + Constant + Compute());
+                      static int Compute() => 0;
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LambdaUsingNameofOfLocal()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M(int parameter) => _ = (Func<string>)([|() => nameof(parameter)|]);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void M(int parameter) => _ = (Func<string>)(static () => nameof(parameter));
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NestedLambdaCapturingLocalOfTheOuterLambda()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int, Func<int>>)([|x => { var y = x; return () => y; }|]);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int, Func<int>>)(static x => { var y = x; return () => y; });
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LambdaUsingStaticLocalFunction()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M()
+                      {
+                          static int Local() => 1;
+                          _ = (Func<int>)([|() => Local()|]);
+                      }
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void M()
+                      {
+                          static int Local() => 1;
+                          _ = (Func<int>)(static () => Local());
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LambdaDeclaringItsOwnLocalFunction()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int>)([|() => { int Local() => 1; return Local(); }|]);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int>)(static () => { int Local() => 1; return Local(); });
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task AlreadyStatic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System.Collections.Generic;
+                  class C
+                  {
+                      void M(List<int> list) => list.Sort(static (x, y) => x.CompareTo(y));
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CaptureLocalVariable()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M(int value) => _ = (Func<int>)(() => value);
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CaptureInstanceField()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      int _field;
+                      void M() => _ = (Func<int>)(() => _field);
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CaptureThisUsingInstanceMethod()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      int Compute() => 1;
+                      void M() => _ = (Func<int>)(() => Compute());
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CapturePrimaryConstructorParameter()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C(int value)
+                  {
+                      void M() => _ = (Func<int>)(() => value);
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NestedLambdaCapturingLocalOfTheEnclosingMethod()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M(int value) => _ = (Func<int, Func<int>>)(x => () => value);
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReferenceNonStaticLocalFunction()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M()
+                      {
+                          int Local() => 1;
+                          _ = (Func<int>)(() => Local());
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ReferenceNonStaticLocalFunctionAsMethodGroup()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M()
+                      {
+                          int Local() => 1;
+                          _ = (Func<Func<int>>)(() => Local);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task QueryExpression()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System.Collections.Generic;
+                  using System.Linq;
+                  class C
+                  {
+                      void M(IEnumerable<int> items) => _ = from item in items where item > 0 select item;
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LambdaCapturingRangeVariable()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  using System.Collections.Generic;
+                  using System.Linq;
+                  class C
+                  {
+                      void M(IEnumerable<int> items) => _ = from item in items select (Func<int>)(() => item);
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CSharp8()
+    {
+        await CreateProjectBuilder()
+              .WithLanguageVersion(LanguageVersion.CSharp8)
+              .WithSourceCode("""
+                  using System.Collections.Generic;
+                  class C
+                  {
+                      void M(List<int> list) => list.Sort((x, y) => x.CompareTo(y));
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LambdaWithAttribute()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int, int>)([|[Obsolete] (int x) => x|]);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void M() => _ = (Func<int, int>)([Obsolete] static (int x) => x);
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MultipleLambdasWithoutCapture()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M()
+                      {
+                          _ = (Func<int>)([|() => 1|]);
+                          _ = (Func<int>)([|() => 2|]);
+                      }
+                  }
+                  """)
+              .ShouldBatchFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void M()
+                      {
+                          _ = (Func<int>)(static () => 1);
+                          _ = (Func<int>)(static () => 2);
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task NestedLambdaInsideCapturingLambda()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      void M(int value) => _ = (Func<Func<int>>)(() => value > 0 ? [|() => 1|] : null);
+                  }
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  class C
+                  {
+                      void M(int value) => _ = (Func<Func<int>>)(() => value > 0 ? static () => 1 : null);
+                  }
+                  """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task TopLevelStatements()
+    {
+        await CreateProjectBuilder()
+              .WithOutputKind(Microsoft.CodeAnalysis.OutputKind.ConsoleApplication)
+              .WithSourceCode("""
+                  using System;
+                  var value = 1;
+                  _ = (Func<int>)([|() => 1|]);
+                  _ = (Func<int>)(() => value);
+                  """)
+              .ShouldFixCodeWith("""
+                  using System;
+                  var value = 1;
+                  _ = (Func<int>)(static () => 1);
+                  _ = (Func<int>)(() => value);
+                  """)
+              .ValidateAsync();
+    }
+
+#if CSHARP14_OR_GREATER
+    [Fact]
+    public async Task CaptureThisUsingFieldKeyword()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                  using System;
+                  class C
+                  {
+                      public int P
+                      {
+                          get
+                          {
+                              Func<int> f = () => field;
+                              return f();
+                          }
+                      }
+                  }
+                  """)
+              .ValidateAsync();
+    }
+#endif
+}


### PR DESCRIPTION
Closes #1312

Adds a new rule **MA0217 - Use a static lambda**, reported when a lambda or an anonymous method captures nothing and can therefore be marked `static`. Marking such a lambda `static` prevents accidentally capturing state later, as the compiler then reports CS8820/CS8821.

As discussed in the issue, the rule is **disabled by default** (`Info` severity, `isEnabledByDefault: false`) as adding the modifier on every lambda is often just noise. There is a code fix that adds the modifier.

## Detection

The analyzer runs on `OperationKind.AnonymousFunction` and skips:

- lambdas that already have the `static` modifier, and syntax trees whose language version is below C# 9 (static anonymous functions were introduced in C# 9)
- the anonymous functions generated by query expressions, as their syntax is not a lambda
- everything reported by `AnalyzeDataFlow(...).CapturedInside`: locals, parameters, primary constructor parameters, range variables and `this`. The symbols declared inside the lambda are excluded, as they can only be captured by a nested lambda, which doesn't prevent the outer lambda from being static.
- the lambdas that reference a non-static local function declared outside of them. This is not a capture for the data flow analysis, but the compiler rejects it (CS8820), so the operation tree is walked to detect the invocations and the method references, including the ones in nested lambdas and nested local functions.

The cases that are reported have been validated against the compiler: `nameof` of an outer local/parameter/instance field, static local function invocations, static fields and constants, expression trees, and `async` lambdas can all be `static`. The `field` keyword, `base.Member()`, implicit `this` and non-static local functions cannot, and are excluded.

The code fix inserts `static` first in the modifier list (so it produces `static async …`, and stays after the attribute lists) and moves the leading trivia to the new token so that the indentation of multi-line lambdas is preserved.

## Validation

- `dotnet build`: succeeds without any warning
- 27 new tests, run against Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9 (the `field` keyword test is guarded by `CSHARP14_OR_GREATER`)
- The full test suite of the default Roslyn version passes (3753 tests)
- `dotnet run --project src/DocumentationGenerator` has been run, and re-running it reports no additional change