### PR TITLE
Report MA0192 when the compared flag is not a constant

### DIFF
--- a/docs/Rules/MA0192.md
+++ b/docs/Rules/MA0192.md
@@ -16,6 +16,13 @@ This rule reports patterns such as:
 - `(value & MyEnum.Flag1) is 0`
 - `(value & MyEnum.Flag1) is not 0`
 
+The compared flag doesn't have to be a constant. `(value & flags) == flags` is reported when both operands reference the same value, such as a parameter, a local variable, or a field:
+
+- `(value & flags) == flags`
+- `(value & flags) != flags`
+
+Expressions that may return a different value on each evaluation, such as properties, method calls, or `volatile` fields, are not reported.
+
 For comparisons against `0`, the enum member used in the bitwise `&` must be a single-bit value (for example `1`, `2`, `4`, `8`, ...). Combined values are ignored.
 
 Zero-valued enum members are not reported by this rule. They are covered by [MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md).

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseHasFlagMethodFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseHasFlagMethodFixer.cs
@@ -193,7 +193,7 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
         return null;
     }
 
-    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IFieldReferenceOperation? flagOperation, out bool comparedWithZero)
+    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IOperation? flagOperation, out bool comparedWithZero)
     {
         potentialFlag = potentialFlag.UnwrapImplicitConversions();
         comparedOperand = comparedOperand.UnwrapImplicitConversions();
@@ -217,6 +217,13 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
                 comparedWithZero = true;
                 return true;
             }
+        }
+
+        if (!potentialFlag.IsConstantZero() && UseHasFlagMethodCommon.AreEquivalentOperands(potentialFlag, comparedOperand))
+        {
+            flagOperation = comparedOperand;
+            comparedWithZero = false;
+            return true;
         }
 
         flagOperation = null;

--- a/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
@@ -304,7 +304,7 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
-    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IFieldReferenceOperation? flagOperation)
+    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IOperation? flagOperation)
     {
         potentialFlag = potentialFlag.UnwrapImplicitConversions();
         comparedOperand = comparedOperand.UnwrapImplicitConversions();
@@ -327,6 +327,12 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
                 flagOperation = firstFieldReference;
                 return true;
             }
+        }
+
+        if (!potentialFlag.IsConstantZero() && UseHasFlagMethodCommon.AreEquivalentOperands(potentialFlag, comparedOperand))
+        {
+            flagOperation = comparedOperand;
+            return true;
         }
 
         flagOperation = null;

--- a/src/Meziantou.Analyzer/Rules/UseHasFlagMethodCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseHasFlagMethodCommon.cs
@@ -1,0 +1,26 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class UseHasFlagMethodCommon
+{
+    /// <summary>
+    /// Determines if both operations reference the same value, so that evaluating them twice is equivalent to evaluating them once.
+    /// Only side-effect free references are supported (parameters, locals, fields), so that <c>(value &amp; flag) == flag</c> can safely be replaced by <c>value.HasFlag(flag)</c>.
+    /// </summary>
+    public static bool AreEquivalentOperands(IOperation? left, IOperation? right)
+    {
+        if (left is null || right is null)
+            return false;
+
+        left = left.UnwrapImplicitConversions();
+        right = right.UnwrapImplicitConversions();
+
+        return (left, right) switch
+        {
+            (IParameterReferenceOperation a, IParameterReferenceOperation b) => a.Parameter.IsEqualTo(b.Parameter),
+            (ILocalReferenceOperation a, ILocalReferenceOperation b) => a.Local.IsEqualTo(b.Local),
+            (IFieldReferenceOperation a, IFieldReferenceOperation b) => a.Field.IsEqualTo(b.Field) && !a.Field.IsVolatile && (a.Field.IsStatic || AreEquivalentOperands(a.Instance, b.Instance)),
+            (IInstanceReferenceOperation a, IInstanceReferenceOperation b) => a.ReferenceKind == b.ReferenceKind && a.Type.IsEqualTo(b.Type),
+            _ => false,
+        };
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
@@ -497,7 +497,7 @@ public sealed class UseHasFlagMethodAnalyzerTests
 
                 static class MyEnumExtensions
                 {
-                    public static bool HasFlags(this MyEnum value, MyEnum flags) => (value & flags) == flags;
+                    public static bool HasFlags(this MyEnum value, MyEnum flags) => {|MA0192:(value & flags) == flags|};
                 }
 
                 class Sample
@@ -604,4 +604,290 @@ public sealed class UseHasFlagMethodAnalyzerTests
             .ValidateAsync();
     }
 
+    [Fact]
+    public async Task ParameterFlag_ReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value, MyEnum comparand) => {|MA0192:(value & comparand) == comparand|};
+                }
+                """)
+            .ShouldFixCodeWith("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                    Flag2 = 2,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value, MyEnum comparand) => value.HasFlag(comparand);
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ParameterFlag_ReversedAndOperands_ReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value, MyEnum comparand) => {|MA0192:(comparand & value) == comparand|};
+                }
+                """)
+            .ShouldFixCodeWith("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value, MyEnum comparand) => value.HasFlag(comparand);
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ParameterFlag_NotEquals_ReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value, MyEnum comparand) => {|MA0192:(value & comparand) != comparand|};
+                }
+                """)
+            .ShouldFixCodeWith("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value, MyEnum comparand) => !value.HasFlag(comparand);
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task LocalFlag_ReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value)
+                    {
+                        var comparand = MyEnum.Flag1;
+                        return {|MA0192:(value & comparand) == comparand|};
+                    }
+                }
+                """)
+            .ShouldFixCodeWith("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value)
+                    {
+                        var comparand = MyEnum.Flag1;
+                        return value.HasFlag(comparand);
+                    }
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task FieldFlag_ReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    private MyEnum _comparand;
+
+                    bool M(MyEnum value) => {|MA0192:(value & _comparand) == this._comparand|};
+                }
+                """)
+            .ShouldFixCodeWith("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    private MyEnum _comparand;
+
+                    bool M(MyEnum value) => value.HasFlag(this._comparand);
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task DifferentParameters_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    bool M(MyEnum value, MyEnum comparand, MyEnum other) => (value & comparand) == other;
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task DifferentInstanceFields_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    private MyEnum _comparand;
+
+                    bool M(MyEnum value, Sample other) => (value & _comparand) == other._comparand;
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task VolatileFieldFlag_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    private volatile MyEnum _comparand;
+
+                    bool M(MyEnum value) => (value & _comparand) == _comparand;
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task PropertyFlag_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    private MyEnum Comparand => MyEnum.Flag1;
+
+                    bool M(MyEnum value) => (value & Comparand) == Comparand;
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MethodCallFlag_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .WithSourceCode("""
+                [System.Flags]
+                enum MyEnum
+                {
+                    None = 0,
+                    Flag1 = 1,
+                }
+
+                class Sample
+                {
+                    private MyEnum GetComparand() => MyEnum.Flag1;
+
+                    bool M(MyEnum value) => (value & GetComparand()) == GetComparand();
+                }
+                """)
+            .ValidateAsync();
+    }
 }


### PR DESCRIPTION
Fixes #1313

## What changed

MA0192 (*Use HasFlag instead of bitwise checks*) only recognized bitwise flag checks whose flag was a constant enum member. `(value & comparand) == comparand` was not reported when `comparand` was a parameter, a local variable, or a field.

- New shared helper `src/Meziantou.Analyzer/Rules/UseHasFlagMethodCommon.cs`: `AreEquivalentOperands` structurally compares two operations and accepts only side-effect free references — parameters, locals, non-volatile fields (with an equivalent instance), and `this`/`base`. It is picked up by the code fixers project through the existing `Rules/*Common.cs` glob, so the analyzer and the fixer stay in sync.
- `UseHasFlagMethodAnalyzer.TryGetEnumFlagReference` and `UseHasFlagMethodFixer.TryGetEnumFlagReference` now return `IOperation` instead of `IFieldReferenceOperation` and fall back to that equivalence check when the flag is not a constant enum member.
- Constant-zero operands are excluded from the new path so MA0192 does not overlap with MA0201 (*Do not use zero-valued enum flags in flag checks*).

The issue repro is now reported and fixed to `value.HasFlag(comparand)`, as are the reversed-operand (`(comparand & value) == comparand`) and `!=` variants.

## Why the restriction to side-effect free references

The code fix replaces two evaluations of the flag expression by a single one. Properties, method calls, and `volatile` fields may yield a different value on each evaluation, so they are not reported. Tests cover each of those cases.

## Note for reviewers

The existing test `HasFlagsExtensionZeroFlag_NoDiagnostic` contained `public static bool HasFlags(this MyEnum value, MyEnum flags) => (value & flags) == flags;`, which is exactly the pattern this change is meant to report, so that line now expects MA0192. The subject of that test (no MA0201 on `value.HasFlags(MyEnum.None)`) is unchanged.

## Verification

- Full test suite on the default Roslyn version: 3736 passed, 0 failed.
- The 33 `UseHasFlagMethodAnalyzerTests` pass on roslyn4.8, 4.14, 5.0, 5.6 and 5.9.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown change after updating `docs/Rules/MA0192.md`.