### PR TITLE
Add CultureInsensitiveAttribute to annotate culture-insensitive values

### DIFF
--- a/docs/CultureInsensitiveAttribute.md
+++ b/docs/CultureInsensitiveAttribute.md
@@ -1,6 +1,6 @@
 # CultureInsensitiveAttribute
 
-The `CultureInsensitiveAttribute` is used to mark the value of a member as culture-insensitive, even when the type of the value is culture-sensitive. This attribute can be used to suppress culture-related analyzer rules ([MA0011](Rules/MA0011.md), [MA0075](Rules/MA0075.md), [MA0076](Rules/MA0076.md)) for a specific method, property, field, or parameter.
+The `CultureInsensitiveAttribute` is used to mark the value of a property, a field, or a parameter as culture-insensitive, even when the type of the value is culture-sensitive. This attribute can be used to suppress culture-related analyzer rules ([MA0011](Rules/MA0011.md), [MA0075](Rules/MA0075.md), [MA0076](Rules/MA0076.md)) for that value.
 
 Use [CultureInsensitiveTypeAttribute](CultureInsensitiveTypeAttribute.md) when a whole type is culture-insensitive, and `CultureInsensitiveAttribute` when only some values of a culture-sensitive type are known to be culture-insensitive.
 
@@ -9,24 +9,6 @@ Use [CultureInsensitiveTypeAttribute](CultureInsensitiveTypeAttribute.md) when a
 The attribute is available through the [`Meziantou.Analyzer.Annotations`](https://www.nuget.org/packages/Meziantou.Analyzer.Annotations/) NuGet package.
 
 Alternatively, you can define the attribute in your own assembly instead of using the package. The analyzer only looks for the attribute by name and namespace, so you can copy the [attribute definition](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/CultureInsensitiveAttribute.cs) into your project.
-
-### Marking the Return Value of a Method
-
-```csharp
-using Meziantou.Analyzer.Annotations;
-
-class Sample
-{
-    [CultureInsensitive] // Equivalent to [return: CultureInsensitive]
-    public static double GetInvariantValue() => 0;
-
-    public static double GetValue() => 0;
-}
-
-// Usage
-_ = $"{Sample.GetInvariantValue()}";     // OK - The returned value is marked as culture-insensitive
-_ = "value: " + Sample.GetValue();       // Warning - MA0075
-```
 
 ### Marking a Property or a Field
 
@@ -40,11 +22,16 @@ class Sample
 
     [CultureInsensitive]
     public double Field;
+
+    public double OtherValue { get; set; }
 }
 
-// Usage - no warning
-_ = $"{sample.Value} {sample.Field}";
+// Usage
+_ = $"{sample.Value} {sample.Field}"; // OK - Both values are marked as culture-insensitive
+_ = "value: " + sample.OtherValue;    // Warning - MA0075
 ```
+
+Methods cannot be annotated: the attribute marks a value, not the way a method computes it. When a method returns a culture-insensitive value of a culture-sensitive type, mark the type with [CultureInsensitiveTypeAttribute](CultureInsensitiveTypeAttribute.md), or assign the result to an annotated property or field.
 
 ### Marking a Parameter
 
@@ -74,27 +61,21 @@ Only the closest argument is considered, so a value nested in another invocation
 
 ### Assembly-Level Annotation for External Members
 
-When you cannot modify the source member (e.g., third-party libraries), use the assembly-level attribute with the [XML documentation id](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#id-strings) of the member:
+When you cannot modify the source member (e.g., third-party libraries), use the assembly-level attribute with the [XML documentation id](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#id-strings) of the property or the field:
 
 ```csharp
 using Meziantou.Analyzer.Annotations;
 
-// Mark a single overload as culture-insensitive
-[assembly: CultureInsensitive("M:Sample.StringHelper.CreateInvariant(System.Double)")]
-
-// Omit the parameter list to mark all the overloads of a method
-[assembly: CultureInsensitive("M:Sample.StringHelper.CreateInvariant")]
-
-// Properties and fields are also supported
 [assembly: CultureInsensitive("P:Sample.StringHelper.InvariantValue")]
+[assembly: CultureInsensitive("F:Sample.StringHelper.InvariantField")]
 ```
 
 ## Constructors
 
 | Constructor | Description |
 |-------------|-------------|
-| `CultureInsensitive()` | Marks the value of the member on which the attribute is applied as culture-insensitive |
-| `CultureInsensitive(string xmlDocumentationId)` | Assembly-level: marks the value of the member matching the XML documentation id as culture-insensitive |
+| `CultureInsensitive()` | Marks the value of the property, the field, or the parameter on which the attribute is applied as culture-insensitive |
+| `CultureInsensitive(string xmlDocumentationId)` | Assembly-level: marks the value of the property or the field matching the XML documentation id as culture-insensitive |
 
 ## Related Rules
 

--- a/docs/CultureInsensitiveAttribute.md
+++ b/docs/CultureInsensitiveAttribute.md
@@ -1,0 +1,108 @@
+# CultureInsensitiveAttribute
+
+The `CultureInsensitiveAttribute` is used to mark the value of a member as culture-insensitive, even when the type of the value is culture-sensitive. This attribute can be used to suppress culture-related analyzer rules ([MA0011](Rules/MA0011.md), [MA0075](Rules/MA0075.md), [MA0076](Rules/MA0076.md)) for a specific method, property, field, or parameter.
+
+Use [CultureInsensitiveTypeAttribute](CultureInsensitiveTypeAttribute.md) when a whole type is culture-insensitive, and `CultureInsensitiveAttribute` when only some values of a culture-sensitive type are known to be culture-insensitive.
+
+## Usage
+
+The attribute is available through the [`Meziantou.Analyzer.Annotations`](https://www.nuget.org/packages/Meziantou.Analyzer.Annotations/) NuGet package.
+
+Alternatively, you can define the attribute in your own assembly instead of using the package. The analyzer only looks for the attribute by name and namespace, so you can copy the [attribute definition](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/CultureInsensitiveAttribute.cs) into your project.
+
+### Marking the Return Value of a Method
+
+```csharp
+using Meziantou.Analyzer.Annotations;
+
+class Sample
+{
+    [CultureInsensitive] // Equivalent to [return: CultureInsensitive]
+    public static double GetInvariantValue() => 0;
+
+    public static double GetValue() => 0;
+}
+
+// Usage
+_ = $"{Sample.GetInvariantValue()}";     // OK - The returned value is marked as culture-insensitive
+_ = "value: " + Sample.GetValue();       // Warning - MA0075
+```
+
+### Marking a Property or a Field
+
+```csharp
+using Meziantou.Analyzer.Annotations;
+
+class Sample
+{
+    [CultureInsensitive]
+    public double Value { get; set; }
+
+    [CultureInsensitive]
+    public double Field;
+}
+
+// Usage - no warning
+_ = $"{sample.Value} {sample.Field}";
+```
+
+### Marking a Parameter
+
+A parameter marked with the attribute is culture-insensitive in both directions: reading it in the method does not report a diagnostic, and [MA0075](Rules/MA0075.md) and [MA0076](Rules/MA0076.md) are not reported for the arguments provided by the callers. The latter is useful for a method that formats its argument with a fixed culture, such as a wrapper around an interpolated string handler.
+
+```csharp
+using Meziantou.Analyzer.Annotations;
+
+class Sample
+{
+    public static void Write([CultureInsensitive] double value)
+    {
+        _ = $"{value}"; // OK - The parameter is marked as culture-insensitive
+    }
+
+    public static void Log([CultureInsensitive] string message) { }
+
+    public static string Format(string message) => message;
+}
+
+// Usage
+Sample.Log($"Value: {1.5}");         // OK - The argument is passed to a culture-insensitive parameter
+Sample.Log(Sample.Format($"{1.5}")); // Warning - The interpolated string is an argument of Format
+```
+
+Only the closest argument is considered, so a value nested in another invocation is still reported.
+
+### Assembly-Level Annotation for External Members
+
+When you cannot modify the source member (e.g., third-party libraries), use the assembly-level attribute with the [XML documentation id](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#id-strings) of the member:
+
+```csharp
+using Meziantou.Analyzer.Annotations;
+
+// Mark a single overload as culture-insensitive
+[assembly: CultureInsensitive("M:Sample.StringHelper.CreateInvariant(System.Double)")]
+
+// Omit the parameter list to mark all the overloads of a method
+[assembly: CultureInsensitive("M:Sample.StringHelper.CreateInvariant")]
+
+// Properties and fields are also supported
+[assembly: CultureInsensitive("P:Sample.StringHelper.InvariantValue")]
+```
+
+## Constructors
+
+| Constructor | Description |
+|-------------|-------------|
+| `CultureInsensitive()` | Marks the value of the member on which the attribute is applied as culture-insensitive |
+| `CultureInsensitive(string xmlDocumentationId)` | Assembly-level: marks the value of the member matching the XML documentation id as culture-insensitive |
+
+## Related Rules
+
+- [MA0011](Rules/MA0011.md) - IFormatProvider is missing
+- [MA0075](Rules/MA0075.md) - Do not use implicit culture-sensitive ToString
+- [MA0076](Rules/MA0076.md) - Do not use implicit culture-sensitive ToString in interpolated strings
+- [MA0185](Rules/MA0185.md) - Simplify string.Create when all parameters are culture invariant
+
+## Additional Information
+
+The attribute is marked with `[Conditional("MEZIANTOU_ANALYZER_ANNOTATIONS")]`, which means it is only compiled into your assembly when the `MEZIANTOU_ANALYZER_ANNOTATIONS` compilation symbol is defined. This keeps the attribute metadata in your assembly for use by analyzers without affecting runtime behavior.

--- a/docs/Rules/MA0011.md
+++ b/docs/Rules/MA0011.md
@@ -49,3 +49,5 @@ MA0011.treat_unsealed_types_as_culture_sensitive=false
 ````
 
 You can also annotate a type with `[Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute]` to disable the rule for this type. See [CultureInsensitiveTypeAttribute](../CultureInsensitiveTypeAttribute.md) for details and [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md) for installation options.
+
+You can annotate a method, a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to disable the rule for this value. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.

--- a/docs/Rules/MA0011.md
+++ b/docs/Rules/MA0011.md
@@ -50,4 +50,4 @@ MA0011.treat_unsealed_types_as_culture_sensitive=false
 
 You can also annotate a type with `[Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute]` to disable the rule for this type. See [CultureInsensitiveTypeAttribute](../CultureInsensitiveTypeAttribute.md) for details and [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md) for installation options.
 
-You can annotate a method, a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to disable the rule for this value. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.
+You can annotate a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to disable the rule for this value. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.

--- a/docs/Rules/MA0075.md
+++ b/docs/Rules/MA0075.md
@@ -52,3 +52,5 @@ MA0075.treat_unsealed_types_as_culture_sensitive=false
 ````
 
 You can also annotate a type with `[Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute]` to disable the rule for this type. See [CultureInsensitiveTypeAttribute](../CultureInsensitiveTypeAttribute.md) for details and [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md) for installation options.
+
+You can annotate a method, a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to disable the rule for this value. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.

--- a/docs/Rules/MA0075.md
+++ b/docs/Rules/MA0075.md
@@ -53,4 +53,4 @@ MA0075.treat_unsealed_types_as_culture_sensitive=false
 
 You can also annotate a type with `[Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute]` to disable the rule for this type. See [CultureInsensitiveTypeAttribute](../CultureInsensitiveTypeAttribute.md) for details and [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md) for installation options.
 
-You can annotate a method, a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to disable the rule for this value. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.
+You can annotate a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to disable the rule for this value. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.

--- a/docs/Rules/MA0076.md
+++ b/docs/Rules/MA0076.md
@@ -30,3 +30,5 @@ MA0076.treat_unsealed_types_as_culture_sensitive=false
 ````
 
 You can also annotate a type with `[Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute]` to disable the rule for this type. See [CultureInsensitiveTypeAttribute](../CultureInsensitiveTypeAttribute.md) for details and [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md) for installation options.
+
+You can annotate a method, a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to disable the rule for this value. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.

--- a/docs/Rules/MA0076.md
+++ b/docs/Rules/MA0076.md
@@ -31,4 +31,4 @@ MA0076.treat_unsealed_types_as_culture_sensitive=false
 
 You can also annotate a type with `[Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute]` to disable the rule for this type. See [CultureInsensitiveTypeAttribute](../CultureInsensitiveTypeAttribute.md) for details and [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md) for installation options.
 
-You can annotate a method, a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to disable the rule for this value. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.
+You can annotate a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to disable the rule for this value. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.

--- a/docs/Rules/MA0185.md
+++ b/docs/Rules/MA0185.md
@@ -34,7 +34,7 @@ The analyzer detects when all interpolated values are culture-invariant, such as
 
 You can annotate custom types with `[Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute]` to mark them as culture-insensitive and make additional `string.Create(CultureInfo.InvariantCulture, ...)` usages eligible for simplification. See [CultureInsensitiveTypeAttribute](../CultureInsensitiveTypeAttribute.md) for details and [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md) for installation options.
 
-You can also annotate a method, a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to mark its value as culture-insensitive. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.
+You can also annotate a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to mark its value as culture-insensitive. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.
 
 The analyzer will NOT suggest simplification when:
 - Any parameter is culture-sensitive (e.g., `double`, `DateTime` with culture-sensitive format)

--- a/docs/Rules/MA0185.md
+++ b/docs/Rules/MA0185.md
@@ -34,6 +34,8 @@ The analyzer detects when all interpolated values are culture-invariant, such as
 
 You can annotate custom types with `[Meziantou.Analyzer.Annotations.CultureInsensitiveTypeAttribute]` to mark them as culture-insensitive and make additional `string.Create(CultureInfo.InvariantCulture, ...)` usages eligible for simplification. See [CultureInsensitiveTypeAttribute](../CultureInsensitiveTypeAttribute.md) for details and [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md) for installation options.
 
+You can also annotate a method, a property, a field, or a parameter with `[Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute]` to mark its value as culture-insensitive. See [CultureInsensitiveAttribute](../CultureInsensitiveAttribute.md) for details.
+
 The analyzer will NOT suggest simplification when:
 - Any parameter is culture-sensitive (e.g., `double`, `DateTime` with culture-sensitive format)
 - A parameter is an opaque runtime type and `MA0185.treat_opaque_runtime_types_as_culture_sensitive` is enabled

--- a/src/Meziantou.Analyzer.Annotations/CultureInsensitiveAttribute.cs
+++ b/src/Meziantou.Analyzer.Annotations/CultureInsensitiveAttribute.cs
@@ -4,39 +4,38 @@
 namespace Meziantou.Analyzer.Annotations;
 
 /// <summary>
-/// Indicates that the value of a method return value, a property, a field, or a parameter is culture insensitive,
-/// even when its type is culture sensitive. This can be used to suppress rules such as <c>MA0011</c>, <c>MA0075</c>, <c>MA0076</c>.
-/// <para><code>[CultureInsensitive]string CreateInvariant() => "";</code></para>
-/// <para><code>[assembly: CultureInsensitive("M:Sample.StringHelper.CreateInvariant")]</code></para>
+/// Indicates that the value of a property, a field, or a parameter is culture insensitive, even when its type is
+/// culture sensitive. This can be used to suppress rules such as <c>MA0011</c>, <c>MA0075</c>, <c>MA0076</c>.
+/// <para><code>[CultureInsensitive]double Value { get; }</code></para>
+/// <para><code>[assembly: CultureInsensitive("P:Sample.StringHelper.InvariantValue")]</code></para>
 /// </summary>
 [System.Diagnostics.Conditional("MEZIANTOU_ANALYZER_ANNOTATIONS")]
-[System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.ReturnValue | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+[System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
 public sealed class CultureInsensitiveAttribute : System.Attribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CultureInsensitiveAttribute"/> class.
     /// </summary>
     /// <remarks>
-    /// This can be applied on a method, a property, a field, or a parameter to mark its value as culture insensitive.
+    /// This can be applied on a property, a field, or a parameter to mark its value as culture insensitive.
     /// </remarks>
     public CultureInsensitiveAttribute() { }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CultureInsensitiveAttribute"/> class with the specified XML documentation id.
     /// </summary>
-    /// <param name="xmlDocumentationId">The XML documentation id of the member to mark as culture insensitive, such as <c>M:System.Guid.ToString</c>.</param>
+    /// <param name="xmlDocumentationId">The XML documentation id of the property or the field to mark as culture insensitive, such as <c>P:System.DateTime.Now</c>.</param>
     /// <remarks>
-    /// This can be applied on an <see cref="System.Reflection.Assembly"/> to mark the value of a member of another assembly as culture insensitive.
-    /// When the id does not contain the parameter list of a method, all its overloads are marked as culture insensitive.
+    /// This can be applied on an <see cref="System.Reflection.Assembly"/> to mark the value of a property or a field of another assembly as culture insensitive.
     /// </remarks>
     public CultureInsensitiveAttribute(string xmlDocumentationId) => XmlDocumentationId = xmlDocumentationId;
 
     /// <summary>
-    /// Gets the XML documentation id of the member annotated at assembly level.
+    /// Gets the XML documentation id of the property or the field annotated at assembly level.
     /// </summary>
     /// <value>
-    /// The XML documentation id of the member annotated at assembly level, or <see langword="null"/> when the attribute
-    /// is applied to the member itself.
+    /// The XML documentation id of the property or the field annotated at assembly level, or <see langword="null"/> when
+    /// the attribute is applied to the member itself.
     /// </value>
     public string? XmlDocumentationId { get; }
 }

--- a/src/Meziantou.Analyzer.Annotations/CultureInsensitiveAttribute.cs
+++ b/src/Meziantou.Analyzer.Annotations/CultureInsensitiveAttribute.cs
@@ -1,0 +1,42 @@
+#pragma warning disable CS1591
+#pragma warning disable IDE0060
+
+namespace Meziantou.Analyzer.Annotations;
+
+/// <summary>
+/// Indicates that the value of a method return value, a property, a field, or a parameter is culture insensitive,
+/// even when its type is culture sensitive. This can be used to suppress rules such as <c>MA0011</c>, <c>MA0075</c>, <c>MA0076</c>.
+/// <para><code>[CultureInsensitive]string CreateInvariant() => "";</code></para>
+/// <para><code>[assembly: CultureInsensitive("M:Sample.StringHelper.CreateInvariant")]</code></para>
+/// </summary>
+[System.Diagnostics.Conditional("MEZIANTOU_ANALYZER_ANNOTATIONS")]
+[System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.ReturnValue | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+public sealed class CultureInsensitiveAttribute : System.Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CultureInsensitiveAttribute"/> class.
+    /// </summary>
+    /// <remarks>
+    /// This can be applied on a method, a property, a field, or a parameter to mark its value as culture insensitive.
+    /// </remarks>
+    public CultureInsensitiveAttribute() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CultureInsensitiveAttribute"/> class with the specified XML documentation id.
+    /// </summary>
+    /// <param name="xmlDocumentationId">The XML documentation id of the member to mark as culture insensitive, such as <c>M:System.Guid.ToString</c>.</param>
+    /// <remarks>
+    /// This can be applied on an <see cref="System.Reflection.Assembly"/> to mark the value of a member of another assembly as culture insensitive.
+    /// When the id does not contain the parameter list of a method, all its overloads are marked as culture insensitive.
+    /// </remarks>
+    public CultureInsensitiveAttribute(string xmlDocumentationId) => XmlDocumentationId = xmlDocumentationId;
+
+    /// <summary>
+    /// Gets the XML documentation id of the member annotated at assembly level.
+    /// </summary>
+    /// <value>
+    /// The XML documentation id of the member annotated at assembly level, or <see langword="null"/> when the attribute
+    /// is applied to the member itself.
+    /// </value>
+    public string? XmlDocumentationId { get; }
+}

--- a/src/Meziantou.Analyzer.Annotations/Meziantou.Analyzer.Annotations.csproj
+++ b/src/Meziantou.Analyzer.Annotations/Meziantou.Analyzer.Annotations.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <Description>Annotations to configure Meziantou.Analyzer</Description>
     <PackageTags>Meziantou.Analyzer, analyzers</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Meziantou.Analyzer.Annotations/README.md
+++ b/src/Meziantou.Analyzer.Annotations/README.md
@@ -20,6 +20,7 @@ If you want to keep these attributes in the metadata (for example, for reflectio
 | --- | --- | --- |
 | `DoNotIgnoreAttribute` | Marks a return value or `out` parameter as must-not-be-ignored. | [MA0060](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0060.md) |
 | `CultureInsensitiveTypeAttribute` | Marks a type (or a specific format) as culture-insensitive. | [MA0011](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0011.md), [MA0075](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0075.md), [MA0076](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0076.md), [MA0185](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0185.md) |
+| `CultureInsensitiveAttribute` | Marks the value of a method, a property, a field, or a parameter as culture-insensitive. | [MA0011](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0011.md), [MA0075](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0075.md), [MA0076](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0076.md), [MA0185](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0185.md) |
 | `NonAwaitableTypeAttribute` | Excludes await recommendations for specific types. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md), [MA0134](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md), [MA0137](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0137.md), [MA0138](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0138.md) |
 | `NonAsyncDisposableTypeAttribute` | Excludes `await using` recommendations for specific types. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md) |
 | `ExcludeFromBlockingCallAnalysisAttribute` | Excludes specific methods/properties from blocking-call diagnostics. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md) |
@@ -51,4 +52,32 @@ The match is exact-type only. Derived types are not excluded unless explicitly l
 
 ```csharp
 [assembly: Meziantou.Analyzer.Annotations.NonAsyncDisposableTypeAttribute(typeof(System.Data.Common.DbCommand))]
+```
+
+## CultureInsensitiveAttribute
+
+Use `CultureInsensitiveAttribute` to mark the value of a method, a property, a field, or a parameter as culture-insensitive, even when its type is culture-sensitive.
+
+```csharp
+class Sample
+{
+    [Meziantou.Analyzer.Annotations.CultureInsensitive]
+    public static double GetInvariantValue() => 0;
+}
+
+_ = $"{Sample.GetInvariantValue()}"; // No MA0076 diagnostic
+```
+
+A parameter marked with the attribute is culture-insensitive in both directions: reading it in the method does not report a diagnostic, and MA0075/MA0076 are not reported for the arguments provided by the callers.
+
+```csharp
+static void Log([Meziantou.Analyzer.Annotations.CultureInsensitive] string message) { }
+
+Log($"Value: {1.5}"); // No MA0076 diagnostic
+```
+
+Members of another assembly can be annotated at the assembly level using their XML documentation id. When the id does not contain the parameter list of a method, all its overloads are annotated.
+
+```csharp
+[assembly: Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute("M:Sample.GetInvariantValue")]
 ```

--- a/src/Meziantou.Analyzer.Annotations/README.md
+++ b/src/Meziantou.Analyzer.Annotations/README.md
@@ -20,7 +20,7 @@ If you want to keep these attributes in the metadata (for example, for reflectio
 | --- | --- | --- |
 | `DoNotIgnoreAttribute` | Marks a return value or `out` parameter as must-not-be-ignored. | [MA0060](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0060.md) |
 | `CultureInsensitiveTypeAttribute` | Marks a type (or a specific format) as culture-insensitive. | [MA0011](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0011.md), [MA0075](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0075.md), [MA0076](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0076.md), [MA0185](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0185.md) |
-| `CultureInsensitiveAttribute` | Marks the value of a method, a property, a field, or a parameter as culture-insensitive. | [MA0011](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0011.md), [MA0075](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0075.md), [MA0076](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0076.md), [MA0185](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0185.md) |
+| `CultureInsensitiveAttribute` | Marks the value of a property, a field, or a parameter as culture-insensitive. | [MA0011](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0011.md), [MA0075](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0075.md), [MA0076](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0076.md), [MA0185](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0185.md) |
 | `NonAwaitableTypeAttribute` | Excludes await recommendations for specific types. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md), [MA0134](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md), [MA0137](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0137.md), [MA0138](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0138.md) |
 | `NonAsyncDisposableTypeAttribute` | Excludes `await using` recommendations for specific types. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md) |
 | `ExcludeFromBlockingCallAnalysisAttribute` | Excludes specific methods/properties from blocking-call diagnostics. | [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md), [MA0045](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md) |
@@ -56,16 +56,16 @@ The match is exact-type only. Derived types are not excluded unless explicitly l
 
 ## CultureInsensitiveAttribute
 
-Use `CultureInsensitiveAttribute` to mark the value of a method, a property, a field, or a parameter as culture-insensitive, even when its type is culture-sensitive.
+Use `CultureInsensitiveAttribute` to mark the value of a property, a field, or a parameter as culture-insensitive, even when its type is culture-sensitive. Methods cannot be annotated: the attribute marks a value, not the way a method computes it.
 
 ```csharp
 class Sample
 {
     [Meziantou.Analyzer.Annotations.CultureInsensitive]
-    public static double GetInvariantValue() => 0;
+    public static double InvariantValue => 0;
 }
 
-_ = $"{Sample.GetInvariantValue()}"; // No MA0076 diagnostic
+_ = $"{Sample.InvariantValue}"; // No MA0076 diagnostic
 ```
 
 A parameter marked with the attribute is culture-insensitive in both directions: reading it in the method does not report a diagnostic, and MA0075/MA0076 are not reported for the arguments provided by the callers.
@@ -76,8 +76,8 @@ static void Log([Meziantou.Analyzer.Annotations.CultureInsensitive] string messa
 Log($"Value: {1.5}"); // No MA0076 diagnostic
 ```
 
-Members of another assembly can be annotated at the assembly level using their XML documentation id. When the id does not contain the parameter list of a method, all its overloads are annotated.
+Properties and fields of another assembly can be annotated at the assembly level using their XML documentation id.
 
 ```csharp
-[assembly: Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute("M:Sample.GetInvariantValue")]
+[assembly: Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute("P:Sample.InvariantValue")]
 ```

--- a/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
+++ b/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
@@ -25,6 +25,28 @@ internal static class AnnotationAttributes
         };
     }
 
+    public static bool IsCultureInsensitiveAttributeSymbol(ITypeSymbol? symbol)
+    {
+        // Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute
+        return symbol is INamedTypeSymbol
+        {
+            Name: "CultureInsensitiveAttribute",
+            ContainingSymbol: INamespaceSymbol
+            {
+                Name: "Annotations",
+                ContainingSymbol: INamespaceSymbol
+                {
+                    Name: "Analyzer",
+                    ContainingSymbol: INamespaceSymbol
+                    {
+                        Name: "Meziantou",
+                        ContainingSymbol: INamespaceSymbol { IsGlobalNamespace: true }
+                    }
+                }
+            }
+        };
+    }
+
     public static bool IsRequireNamedArgumentAttributeSymbol(ITypeSymbol? symbol)
     {
         // Meziantou.Analyzer.Annotations.RequireNamedArgumentAttribute        

--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -3,6 +3,7 @@ namespace Meziantou.Analyzer.Internals;
 internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
 {
     private readonly HashSet<ISymbol> _excludedMethods = CreateExcludedMethods(compilation);
+    private readonly HashSet<ISymbol> _cultureInsensitiveMembers = CreateCultureInsensitiveMembers(compilation);
 
     public INamedTypeSymbol? FormatProviderSymbol { get; } = compilation.GetBestTypeByMetadataName("System.IFormatProvider");
     public INamedTypeSymbol? CultureInfoSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Globalization.CultureInfo");
@@ -60,6 +61,95 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
         }
     }
 
+    private static HashSet<ISymbol> CreateCultureInsensitiveMembers(Compilation compilation)
+    {
+        var result = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        foreach (var attribute in compilation.Assembly.GetAttributes())
+        {
+            if (!AnnotationAttributes.IsCultureInsensitiveAttributeSymbol(attribute.AttributeClass))
+                continue;
+
+            if (attribute.ConstructorArguments is not [{ Kind: TypedConstantKind.Primitive, Value: string documentationId }])
+                continue;
+
+            foreach (var symbol in DocumentationCommentId.GetSymbolsForDeclarationId(documentationId, compilation))
+            {
+                result.Add(symbol);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Indicates whether the value of the operation is annotated with <c>Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute</c>,
+    /// which means the value is culture insensitive even when its type is culture sensitive.
+    /// </summary>
+    private bool IsAnnotatedAsCultureInsensitive(IOperation? operation)
+    {
+        if (operation is null)
+            return false;
+
+        return operation.UnwrapImplicitConversions() switch
+        {
+            IInvocationOperation invocation => IsAnnotatedAsCultureInsensitive(invocation.TargetMethod),
+            IParameterReferenceOperation parameterReference => IsAnnotatedAsCultureInsensitive(parameterReference.Parameter),
+            IMemberReferenceOperation memberReference => IsAnnotatedAsCultureInsensitive(memberReference.Member),
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Indicates whether the operation is part of an argument of a parameter annotated with
+    /// <c>Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute</c>, which means the value is formatted in a culture-insensitive way.
+    /// </summary>
+    public bool IsInCultureInsensitiveParameterContext(IOperation operation)
+    {
+        // Only consider the closest argument, so a value nested in another invocation is not impacted
+        for (var current = operation.Parent; current is not null; current = current.Parent)
+        {
+            if (current is not IArgumentOperation argument)
+                continue;
+
+            if (argument.Parameter is not null && IsAnnotatedAsCultureInsensitive(argument.Parameter))
+                return true;
+
+            // The compiler generates the calls to AppendFormatted, so continue with the parameter of the annotated method
+            if (argument.Parent is IInvocationOperation { Parent: IInterpolatedStringAppendOperation })
+                continue;
+
+            return false;
+        }
+
+        return false;
+    }
+
+    private bool IsAnnotatedAsCultureInsensitive(ISymbol symbol)
+    {
+        if (_cultureInsensitiveMembers.Count > 0 && (_cultureInsensitiveMembers.Contains(symbol) || _cultureInsensitiveMembers.Contains(symbol.OriginalDefinition)))
+            return true;
+
+        if (HasCultureInsensitiveAttribute(symbol.GetAttributes()))
+            return true;
+
+        if (symbol is IMethodSymbol method && HasCultureInsensitiveAttribute(method.GetReturnTypeAttributes()))
+            return true;
+
+        return false;
+
+        static bool HasCultureInsensitiveAttribute(ImmutableArray<AttributeData> attributes)
+        {
+            foreach (var attribute in attributes)
+            {
+                // The constructor with a documentation id only applies to assembly-level attributes
+                if (AnnotationAttributes.IsCultureInsensitiveAttributeSymbol(attribute.AttributeClass) && attribute.ConstructorArguments.IsEmpty)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
     private static bool MustUnwrapNullableOfT(CultureSensitiveOptions options)
     {
         return (options & CultureSensitiveOptions.UnwrapNullableOfT) == CultureSensitiveOptions.UnwrapNullableOfT;
@@ -94,6 +184,9 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
             operation = conversionOperand;
         }
 
+        if (IsAnnotatedAsCultureInsensitive(operation))
+            return CultureSensitivity.CultureInsensitive;
+
         if (operation is IInvocationOperation invocation)
         {
             if (_excludedMethods.Contains(invocation.TargetMethod))
@@ -105,6 +198,10 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
             var methodName = invocation.TargetMethod.Name;
             if (methodName is "ToString")
             {
+                // The formatted value is annotated, so the result does not depend on the culture
+                if (IsAnnotatedAsCultureInsensitive(invocation.Instance))
+                    return CultureSensitivity.CultureInsensitive;
+
                 // Try get the format. Most of ToString have only 1 string parameter to define the format
                 IOperation? format = null;
                 if (invocation.Arguments.Length > 0)
@@ -221,7 +318,12 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
             return Combine(GetCultureSensitivity(interpolatedStringAddition.Left, options), GetCultureSensitivity(interpolatedStringAddition.Right, options));
 
         if (operation is IInterpolationOperation content)
+        {
+            if (IsAnnotatedAsCultureInsensitive(content.Expression))
+                return CultureSensitivity.CultureInsensitive;
+
             return GetCultureSensitivity(content.Expression.Type, content.FormatString, content.Expression, options);
+        }
 
         if (operation is IInterpolatedStringTextOperation)
             return CultureSensitivity.CultureInsensitive;
@@ -230,6 +332,9 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
         {
             if (append.AppendCall is IInvocationOperation appendInvocation)
             {
+                if (appendInvocation.Arguments.Length > 0 && IsAnnotatedAsCultureInsensitive(appendInvocation.Arguments[0].Value))
+                    return CultureSensitivity.CultureInsensitive;
+
                 if (appendInvocation.Arguments.Length == 1)
                     return GetCultureSensitivity(appendInvocation.Arguments[0].Value.Type, format: null, instance: null, options);
 

--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -92,7 +92,6 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
 
         return operation.UnwrapImplicitConversions() switch
         {
-            IInvocationOperation invocation => IsAnnotatedAsCultureInsensitive(invocation.TargetMethod),
             IParameterReferenceOperation parameterReference => IsAnnotatedAsCultureInsensitive(parameterReference.Parameter),
             IMemberReferenceOperation memberReference => IsAnnotatedAsCultureInsensitive(memberReference.Member),
             _ => false,
@@ -130,9 +129,6 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
             return true;
 
         if (HasCultureInsensitiveAttribute(symbol.GetAttributes()))
-            return true;
-
-        if (symbol is IMethodSymbol method && HasCultureInsensitiveAttribute(method.GetReturnTypeAttributes()))
             return true;
 
         return false;

--- a/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
@@ -97,6 +97,9 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
             if (IsExcludedMethod(context, ExcludeToStringMethodsConfiguration, operation))
                 return;
 
+            if (_cultureSensitiveContext.IsInCultureInsensitiveParameterContext(operation))
+                return;
+
             if (ShouldReportCultureSensitiveOperand(context, StringConcatRule, operation.LeftOperand))
             {
                 context.ReportDiagnostic(StringConcatRule, operation.LeftOperand);
@@ -120,6 +123,9 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
                 return;
 
             if (_cultureSensitiveContext.IsInInterpolatedStringHandlerContext(operation))
+                return;
+
+            if (_cultureSensitiveContext.IsInCultureInsensitiveParameterContext(operation))
                 return;
 
             var options = GetOptions(context, StringInterpolationRule, operation);

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -629,69 +629,6 @@ class Sample : System.IFormattable
     }
 
     [Fact]
-    public async Task CultureInsensitiveAttribute_Method()
-    {
-        var sourceCode = """
-            class Test
-            {
-                void A()
-                {
-                    _ = "abc" + GetValue();
-                    _ = $"abc{GetValue()}";
-                    _ = GetValue().ToString();
-                }
-
-                [Meziantou.Analyzer.Annotations.CultureInsensitive]
-                double GetValue() => 0;
-            }
-            """;
-        await CreateProjectBuilder()
-              .WithSourceCode(sourceCode)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task CultureInsensitiveAttribute_ReturnValue()
-    {
-        var sourceCode = """
-            class Test
-            {
-                void A()
-                {
-                    _ = "abc" + GetValue();
-                    _ = $"abc{GetValue()}";
-                }
-
-                [return: Meziantou.Analyzer.Annotations.CultureInsensitive]
-                double GetValue() => 0;
-            }
-            """;
-        await CreateProjectBuilder()
-              .WithSourceCode(sourceCode)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task CultureInsensitiveAttribute_NotAnnotatedMethod()
-    {
-        var sourceCode = """
-            class Test
-            {
-                void A()
-                {
-                    _ = "abc" + [|GetValue()|];
-                    _ = $"abc[|{GetValue()}|]";
-                }
-
-                double GetValue() => 0;
-            }
-            """;
-        await CreateProjectBuilder()
-              .WithSourceCode(sourceCode)
-              .ValidateAsync();
-    }
-
-    [Fact]
     public async Task CultureInsensitiveAttribute_Property()
     {
         var sourceCode = """
@@ -701,10 +638,15 @@ class Sample : System.IFormattable
                 {
                     _ = "abc" + Value;
                     _ = $"abc{Value}";
+                    _ = Value.ToString();
+                    _ = "abc" + [|OtherValue|];
+                    _ = $"abc[|{OtherValue}|]";
                 }
 
                 [Meziantou.Analyzer.Annotations.CultureInsensitive]
                 double Value => 0;
+
+                double OtherValue => 0;
             }
             """;
         await CreateProjectBuilder()
@@ -830,41 +772,21 @@ class Sample : System.IFormattable
     public async Task CultureInsensitiveAttribute_AssemblyAttribute()
     {
         var sourceCode = """
-            [assembly: Meziantou.Analyzer.Annotations.CultureInsensitive("M:Test.GetValue")]
+            [assembly: Meziantou.Analyzer.Annotations.CultureInsensitive("P:Test.Value")]
+            [assembly: Meziantou.Analyzer.Annotations.CultureInsensitive("F:Test.Field")]
 
             class Test
             {
                 void A()
                 {
-                    _ = "abc" + GetValue();
-                    _ = "abc" + [|GetOtherValue()|];
+                    _ = "abc" + Value;
+                    _ = "abc" + Field;
+                    _ = "abc" + [|OtherValue|];
                 }
 
-                static double GetValue() => 0;
-                static double GetOtherValue() => 0;
-            }
-            """;
-        await CreateProjectBuilder()
-              .WithSourceCode(sourceCode)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task CultureInsensitiveAttribute_AssemblyAttribute_Overloads()
-    {
-        var sourceCode = """
-            [assembly: Meziantou.Analyzer.Annotations.CultureInsensitive("M:Test.GetValue(System.Int32)")]
-
-            class Test
-            {
-                void A()
-                {
-                    _ = "abc" + GetValue(0);
-                    _ = "abc" + [|GetValue()|];
-                }
-
-                static double GetValue() => 0;
-                static double GetValue(int value) => 0;
+                static double Value => 0;
+                static double Field;
+                static double OtherValue => 0;
             }
             """;
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -629,6 +629,250 @@ class Sample : System.IFormattable
     }
 
     [Fact]
+    public async Task CultureInsensitiveAttribute_Method()
+    {
+        var sourceCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = "abc" + GetValue();
+                    _ = $"abc{GetValue()}";
+                    _ = GetValue().ToString();
+                }
+
+                [Meziantou.Analyzer.Annotations.CultureInsensitive]
+                double GetValue() => 0;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_ReturnValue()
+    {
+        var sourceCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = "abc" + GetValue();
+                    _ = $"abc{GetValue()}";
+                }
+
+                [return: Meziantou.Analyzer.Annotations.CultureInsensitive]
+                double GetValue() => 0;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_NotAnnotatedMethod()
+    {
+        var sourceCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = "abc" + [|GetValue()|];
+                    _ = $"abc[|{GetValue()}|]";
+                }
+
+                double GetValue() => 0;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_Property()
+    {
+        var sourceCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = "abc" + Value;
+                    _ = $"abc{Value}";
+                }
+
+                [Meziantou.Analyzer.Annotations.CultureInsensitive]
+                double Value => 0;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_Field()
+    {
+        var sourceCode = """
+            class Test
+            {
+                [Meziantou.Analyzer.Annotations.CultureInsensitive]
+                double _value;
+
+                void A()
+                {
+                    _ = "abc" + _value;
+                    _ = $"abc{_value}";
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_Parameter()
+    {
+        var sourceCode = """
+            class Test
+            {
+                void A([Meziantou.Analyzer.Annotations.CultureInsensitive] double value, double other)
+                {
+                    _ = "abc" + value;
+                    _ = $"abc{value}";
+                    _ = "abc" + [|other|];
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_Parameter_Argument()
+    {
+        var sourceCode = """
+            class Test
+            {
+                void A(double value)
+                {
+                    Write($"abc{value}");
+                    Write("abc" + value);
+                    WriteOther($"abc[|{value}|]");
+                    WriteOther("abc" + [|value|]);
+                }
+
+                static void Write([Meziantou.Analyzer.Annotations.CultureInsensitive] string value) { }
+                static void WriteOther(string value) { }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_Parameter_InterpolatedStringHandlerArgument()
+    {
+        var sourceCode = """
+            using System.Runtime.CompilerServices;
+
+            class Test
+            {
+                void A(double value)
+                {
+                    Write($"abc{"x" + value}");
+                    WriteOther($"abc{"x" + [|value|]}");
+                }
+
+                static void Write([Meziantou.Analyzer.Annotations.CultureInsensitive] CustomHandler handler) { }
+                static void WriteOther(CustomHandler handler) { }
+            }
+
+            [InterpolatedStringHandler]
+            ref struct CustomHandler
+            {
+                public CustomHandler(int literalLength, int formattedCount) { }
+                public void AppendLiteral(string value) { }
+                public void AppendFormatted<T>(T value) { }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_Parameter_NestedArgument()
+    {
+        var sourceCode = """
+            class Test
+            {
+                void A(double value)
+                {
+                    Write(Identity($"abc[|{value}|]"));
+                }
+
+                static string Identity(string value) => value;
+                static void Write([Meziantou.Analyzer.Annotations.CultureInsensitive] string value) { }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_AssemblyAttribute()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Analyzer.Annotations.CultureInsensitive("M:Test.GetValue")]
+
+            class Test
+            {
+                void A()
+                {
+                    _ = "abc" + GetValue();
+                    _ = "abc" + [|GetOtherValue()|];
+                }
+
+                static double GetValue() => 0;
+                static double GetOtherValue() => 0;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_AssemblyAttribute_Overloads()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Analyzer.Annotations.CultureInsensitive("M:Test.GetValue(System.Int32)")]
+
+            class Test
+            {
+                void A()
+                {
+                    _ = "abc" + GetValue(0);
+                    _ = "abc" + [|GetValue()|];
+                }
+
+                static double GetValue() => 0;
+                static double GetValue(int value) => 0;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task CustomTypeImplementingIFormattable()
     {
         var sourceCode = """

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
@@ -644,6 +644,47 @@ class Value : IFormattable
     }
 
     [Fact]
+    public async Task StringCreateWithInvariantCulture_CultureInsensitiveAttribute_ShouldReport()
+    {
+        const string SourceCode = """
+using System;
+using System.Globalization;
+
+class TypeName
+{
+    public void Test()
+    {
+        _ = [|string.Create(CultureInfo.InvariantCulture, $"Value: {GetValue()}")|];
+    }
+
+    [Meziantou.Analyzer.Annotations.CultureInsensitive]
+    static double GetValue() => 0;
+}
+""";
+        const string Fix = """
+using System;
+using System.Globalization;
+
+class TypeName
+{
+    public void Test()
+    {
+        _ = $"Value: {GetValue()}";
+    }
+
+    [Meziantou.Analyzer.Annotations.CultureInsensitive]
+    static double GetValue() => 0;
+}
+""";
+        await CreateProjectBuilder()
+              .WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp10)
+              .WithTargetFramework(TargetFramework.Net6_0)
+              .WithSourceCode(SourceCode)
+              .ShouldFixCodeWith(Fix)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task StringCreateWithInvariantCulture_EmptyString_ShouldReport()
     {
         const string SourceCode = """

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
@@ -654,11 +654,11 @@ class TypeName
 {
     public void Test()
     {
-        _ = [|string.Create(CultureInfo.InvariantCulture, $"Value: {GetValue()}")|];
+        _ = [|string.Create(CultureInfo.InvariantCulture, $"Value: {Value}")|];
     }
 
     [Meziantou.Analyzer.Annotations.CultureInsensitive]
-    static double GetValue() => 0;
+    static double Value => 0;
 }
 """;
         const string Fix = """
@@ -669,11 +669,11 @@ class TypeName
 {
     public void Test()
     {
-        _ = $"Value: {GetValue()}";
+        _ = $"Value: {Value}";
     }
 
     [Meziantou.Analyzer.Annotations.CultureInsensitive]
-    static double GetValue() => 0;
+    static double Value => 0;
 }
 """;
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
@@ -364,6 +364,48 @@ _ = new System.DateTime().ToString(format: null);
     }
 
     [Fact]
+    public async Task CultureInsensitiveAttribute_Method()
+    {
+        var sourceCode = """
+            _ = Sample.GetInvariantValue("");
+            _ = [|Sample.GetValue("")|];
+
+            static class Sample
+            {
+                [Meziantou.Analyzer.Annotations.CultureInsensitive]
+                public static double GetInvariantValue(string value) => 0;
+                public static double GetInvariantValue(string value, System.IFormatProvider provider) => 0;
+
+                public static double GetValue(string value) => 0;
+                public static double GetValue(string value, System.IFormatProvider provider) => 0;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CultureInsensitiveAttribute_Property()
+    {
+        var sourceCode = """
+            _ = Sample.Value.ToString();
+            _ = [|Sample.OtherValue.ToString()|];
+
+            static class Sample
+            {
+                [Meziantou.Analyzer.Annotations.CultureInsensitive]
+                public static double Value => 0;
+
+                public static double OtherValue => 0;
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task ToString_IFormattable()
     {
         var sourceCode = """

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
@@ -364,38 +364,20 @@ _ = new System.DateTime().ToString(format: null);
     }
 
     [Fact]
-    public async Task CultureInsensitiveAttribute_Method()
-    {
-        var sourceCode = """
-            _ = Sample.GetInvariantValue("");
-            _ = [|Sample.GetValue("")|];
-
-            static class Sample
-            {
-                [Meziantou.Analyzer.Annotations.CultureInsensitive]
-                public static double GetInvariantValue(string value) => 0;
-                public static double GetInvariantValue(string value, System.IFormatProvider provider) => 0;
-
-                public static double GetValue(string value) => 0;
-                public static double GetValue(string value, System.IFormatProvider provider) => 0;
-            }
-            """;
-        await CreateProjectBuilder()
-              .WithSourceCode(sourceCode)
-              .ValidateAsync();
-    }
-
-    [Fact]
-    public async Task CultureInsensitiveAttribute_Property()
+    public async Task CultureInsensitiveAttribute_Member()
     {
         var sourceCode = """
             _ = Sample.Value.ToString();
+            _ = Sample.Field.ToString();
             _ = [|Sample.OtherValue.ToString()|];
 
             static class Sample
             {
                 [Meziantou.Analyzer.Annotations.CultureInsensitive]
                 public static double Value => 0;
+
+                [Meziantou.Analyzer.Annotations.CultureInsensitive]
+                public static double Field;
 
                 public static double OtherValue => 0;
             }


### PR DESCRIPTION
## What

Add `Meziantou.Analyzer.Annotations.CultureInsensitiveAttribute`. It marks the value of a property, a field, or a parameter as culture insensitive, even when its type is culture sensitive.

```csharp
class Sample
{
    [CultureInsensitive]
    public static double InvariantValue => 0;
}

_ = "value: " + Sample.InvariantValue;   // no MA0075
_ = $"{Sample.InvariantValue}";          // no MA0076
_ = Sample.InvariantValue.ToString();    // no MA0011
```

Methods and return values are deliberately not valid targets: the attribute marks a value, not the way a method computes it, and `[CultureInsensitive]` on a method would be ambiguous with "this method does not depend on the culture".

Properties and fields of another assembly are annotated at the assembly level with their XML documentation id, like `DoNotIgnoreAttribute` does.

```csharp
[assembly: CultureInsensitive("P:Sample.StringHelper.InvariantValue")]
[assembly: CultureInsensitive("F:Sample.StringHelper.InvariantField")]
```

A parameter is culture insensitive in both directions: reading it in the method is not reported, and MA0075/MA0076 are not reported for the arguments provided by the callers. This covers a method that formats its argument with a fixed culture, such as a wrapper around an interpolated string handler.

```csharp
static void Log([CultureInsensitive] string message) { }

Log($"Value: {1.5}");  // no MA0076
Log(Format($"{1.5}")); // MA0076, the interpolated string is an argument of Format
```

## Why

`CultureInsensitiveTypeAttribute` can only mark a whole type, so there was no way to opt out for a single member whose type is culture sensitive, nor for a wrapper method that formats its arguments with a fixed culture (#1316).

## Notes for the reviewer

- The annotation is resolved in `CultureSensitiveFormattingContext`, so it applies to MA0011, MA0075, MA0076 and MA0185. For MA0185 it enables the simplification, as the annotated value counts as invariant.
- Two paths lose the symbol before reaching `GetCultureSensitivity(IOperation)` and are handled separately: interpolation holes and `AppendFormatted` calls. The instance of a `ToString()` call is handled as well, so `invariantProperty.ToString()` is not reported.
- The call-site direction of a parameter annotation deliberately affects MA0075/MA0076 only. MA0011 flags how the argument was produced, which a parameter annotation cannot change, so `Log(double.Parse(text))` is still reported.
- `IsInCultureInsensitiveParameterContext` stops at the closest enclosing argument, so annotating a parameter never silences a value nested in another invocation. The arguments of the compiler-generated `AppendFormatted` calls are walked through, so a handler parameter behaves like any other parameter.
- The constructor taking a documentation id is for assembly-level annotations only: an attribute with constructor arguments is ignored when applied on a member.