### PR TITLE
Add a language attribute code fix and MA0218/MA0219 for XML comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0215](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0215.md)|Performance|Return the task instead of awaiting it|ℹ️|❌|✔️|❌|
 |[MA0216](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0216.md)|Design|Remove unnecessary closed modifier|ℹ️|✔️|❌|❌|
 |[MA0217](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0217.md)|Design|Use a static lambda|ℹ️|❌|✔️|❌|
+|[MA0218](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0218.md)|Design|The language attribute is empty|ℹ️|✔️|❌|❌|
+|[MA0219](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md)|Design|Set the language attribute in XML comment|👻|✔️|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -216,6 +216,8 @@
 |[MA0215](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0215.md)|Performance|Return the task instead of awaiting it|<span title='Info'>ℹ️</span>|❌|✔️|❌|
 |[MA0216](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0216.md)|Design|Remove unnecessary closed modifier|<span title='Info'>ℹ️</span>|✔️|❌|❌|
 |[MA0217](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0217.md)|Design|Use a static lambda|<span title='Info'>ℹ️</span>|❌|✔️|❌|
+|[MA0218](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0218.md)|Design|The language attribute is empty|<span title='Info'>ℹ️</span>|✔️|❌|❌|
+|[MA0219](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md)|Design|Set the language attribute in XML comment|<span title='Hidden'>👻</span>|✔️|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0154.md
+++ b/docs/Rules/MA0154.md
@@ -1,6 +1,6 @@
 # MA0154 - Use langword in XML comment
 <!-- sources -->
-Sources: [UseLangwordInXmlCommentAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs), [UseLangwordInXmlCommentFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentFixer.cs)
+Sources: [UseLangwordInXmlCommentAddLanguageAttributeFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentAddLanguageAttributeFixer.cs), [UseLangwordInXmlCommentAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs), [UseLangwordInXmlCommentFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentFixer.cs)
 <!-- sources -->
 
 Use `<see langword="keyword" />` instead of plain `<c>keyword</c>` or `<code>keyword</code>` in XML comments.
@@ -12,5 +12,13 @@ public class Sample { }
 
 // ok
 /// <summary>Sample <see langword="class" /> keyword</summary>
+public class Sample { }
+```
+
+If the content is not a C# keyword, you can add a `language` attribute to the element to indicate the language of the code. Any attribute on the element disables the rule.
+
+```c#
+// ok
+/// <summary>Sample <c language="json">null</c> value</summary>
 public class Sample { }
 ```

--- a/docs/Rules/MA0218.md
+++ b/docs/Rules/MA0218.md
@@ -1,0 +1,19 @@
+# MA0218 - The language attribute is empty
+<!-- sources -->
+Source: [UseLangwordInXmlCommentAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs)
+<!-- sources -->
+
+The `language` or `lang` attribute of a `<c>` or `<code>` element is set but has no value, so it doesn't document the language of the code.
+
+> **Note**
+> Setting the language of a code block in an XML comment is only a convention. It is not part of the XML documentation comments specification, so the attribute name (`language` or `lang`) and its values are not standardized, and tools may ignore them.
+
+````csharp
+// non-compliant
+/// <summary>Sample <c language="">{ "value": 1 }</c></summary>
+public class Sample { }
+
+// ok
+/// <summary>Sample <c language="json">{ "value": 1 }</c></summary>
+public class Sample { }
+````

--- a/docs/Rules/MA0219.md
+++ b/docs/Rules/MA0219.md
@@ -1,0 +1,23 @@
+# MA0219 - Set the language attribute in XML comment
+<!-- sources -->
+Sources: [UseLangwordInXmlCommentAddLanguageAttributeFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentAddLanguageAttributeFixer.cs), [UseLangwordInXmlCommentAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs)
+<!-- sources -->
+
+A `<c>` or `<code>` element doesn't indicate the language of the code it contains. Set the `language` (or `lang`) attribute so tools can highlight the code properly.
+
+> **Note**
+> Setting the language of a code block in an XML comment is only a convention. It is not part of the XML documentation comments specification, so the attribute name (`language` or `lang`) and its values are not standardized, and tools may ignore them.
+
+The rule is not reported when the element contains a single C# keyword, as [MA0154](MA0154.md) already suggests using `<see langword="..." />` in that case.
+
+````csharp
+// non-compliant
+/// <summary>Sample <c>{ "value": 1 }</c></summary>
+public class Sample { }
+
+// ok
+/// <summary>Sample <c language="json">{ "value": 1 }</c></summary>
+public class Sample { }
+````
+
+The default severity of this rule is hidden: it is not reported during the build, but the code fix is available in the IDE.

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentAddLanguageAttributeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentAddLanguageAttributeFixer.cs
@@ -1,0 +1,39 @@
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class UseLangwordInXmlCommentAddLanguageAttributeFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.UseLangwordInXmlComment, RuleIdentifiers.MissingLanguageAttributeInXmlComment);
+
+    public override FixAllProvider? GetFixAllProvider() => null;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true, findInsideTrivia: true);
+        if (nodeToFix is not XmlElementSyntax elementSyntax)
+            return;
+
+        if (elementSyntax.StartTag.Attributes.Count > 0)
+            return;
+
+        const string Title = "Add language attribute";
+        var codeAction = CodeAction.Create(
+            Title,
+            cancellationToken => Fix(context.Document, elementSyntax, cancellationToken),
+            equivalenceKey: Title);
+
+        context.RegisterCodeFix(codeAction, context.Diagnostics);
+    }
+
+    private static async Task<Document> Fix(Document document, XmlElementSyntax elementSyntax, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        var attribute = XmlTextAttribute("language").WithLeadingTrivia(Whitespace(" "));
+        editor.ReplaceNode(elementSyntax.StartTag, elementSyntax.StartTag.AddAttributes(attribute));
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -646,3 +646,9 @@ dotnet_diagnostic.MA0216.severity = error
 
 # MA0217: Use a static lambda
 dotnet_diagnostic.MA0217.severity = error
+
+# MA0218: The language attribute is empty
+dotnet_diagnostic.MA0218.severity = error
+
+# MA0219: Set the language attribute in XML comment
+dotnet_diagnostic.MA0219.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -646,3 +646,9 @@ dotnet_diagnostic.MA0216.severity = suggestion
 
 # MA0217: Use a static lambda
 dotnet_diagnostic.MA0217.severity = suggestion
+
+# MA0218: The language attribute is empty
+dotnet_diagnostic.MA0218.severity = suggestion
+
+# MA0219: Set the language attribute in XML comment
+dotnet_diagnostic.MA0219.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -646,3 +646,9 @@ dotnet_diagnostic.MA0216.severity = warning
 
 # MA0217: Use a static lambda
 dotnet_diagnostic.MA0217.severity = warning
+
+# MA0218: The language attribute is empty
+dotnet_diagnostic.MA0218.severity = warning
+
+# MA0219: Set the language attribute in XML comment
+dotnet_diagnostic.MA0219.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -646,3 +646,9 @@ dotnet_diagnostic.MA0216.severity = suggestion
 
 # MA0217: Use a static lambda
 dotnet_diagnostic.MA0217.severity = none
+
+# MA0218: The language attribute is empty
+dotnet_diagnostic.MA0218.severity = suggestion
+
+# MA0219: Set the language attribute in XML comment
+dotnet_diagnostic.MA0219.severity = silent

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -646,3 +646,9 @@ dotnet_diagnostic.MA0216.severity = none
 
 # MA0217: Use a static lambda
 dotnet_diagnostic.MA0217.severity = none
+
+# MA0218: The language attribute is empty
+dotnet_diagnostic.MA0218.severity = none
+
+# MA0219: Set the language attribute in XML comment
+dotnet_diagnostic.MA0219.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -217,6 +217,8 @@ internal static class RuleIdentifiers
     public const string ReturnTaskInsteadOfAwaitingIt = "MA0215";
     public const string RemoveUnnecessaryClosedModifier = "MA0216";
     public const string UseStaticLambda = "MA0217";
+    public const string EmptyLanguageAttributeInXmlComment = "MA0218";
+    public const string MissingLanguageAttributeInXmlComment = "MA0219";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
@@ -99,7 +99,27 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseLangwordInXmlComment));
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    private static readonly DiagnosticDescriptor EmptyLanguageAttributeRule = new(
+        RuleIdentifiers.EmptyLanguageAttributeInXmlComment,
+        title: "The language attribute is empty",
+        messageFormat: "The '{0}' attribute is empty",
+        RuleCategories.Design,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.EmptyLanguageAttributeInXmlComment));
+
+    private static readonly DiagnosticDescriptor MissingLanguageAttributeRule = new(
+        RuleIdentifiers.MissingLanguageAttributeInXmlComment,
+        title: "Set the language attribute in XML comment",
+        messageFormat: "Set the language attribute in XML comment",
+        RuleCategories.Design,
+        DiagnosticSeverity.Hidden,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.MissingLanguageAttributeInXmlComment));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule, EmptyLanguageAttributeRule, MissingLanguageAttributeRule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -150,15 +170,19 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
                         var elementName = elementSyntax.StartTag.Name.LocalName.Text;
                         if (string.Equals(elementName, "c", StringComparison.OrdinalIgnoreCase) || string.Equals(elementName, "code", StringComparison.OrdinalIgnoreCase))
                         {
-                            if (elementSyntax.StartTag.Attributes.Count > 0)
-                                continue;
-
-                            var item = elementSyntax.Content.SingleOrDefaultIfMultiple();
-                            if (item is XmlTextSyntax { TextTokens: [var codeText] } && CSharpKeywords.Contains(codeText.Text))
+                            if (elementSyntax.StartTag.Attributes.Count == 0)
                             {
-                                var properties = ImmutableDictionary<string, string?>.Empty.Add("keyword", codeText.Text);
-                                context.ReportDiagnostic(Rule, properties, elementSyntax);
+                                var item = elementSyntax.Content.SingleOrDefaultIfMultiple();
+                                if (item is XmlTextSyntax { TextTokens: [var codeText] } && CSharpKeywords.Contains(codeText.Text))
+                                {
+                                    // The langword attribute is the way to document a keyword, so the language is not needed
+                                    var properties = ImmutableDictionary<string, string?>.Empty.Add("keyword", codeText.Text);
+                                    context.ReportDiagnostic(Rule, properties, elementSyntax);
+                                    continue;
+                                }
                             }
+
+                            AnalyzeLanguageAttributes(context, elementSyntax);
                         }
                         else
                         {
@@ -172,6 +196,34 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
 
                 NodeQueuePool.Return(queue);
             }
+        }
+    }
+
+    private static void AnalyzeLanguageAttributes(SymbolAnalysisContext context, XmlElementSyntax elementSyntax)
+    {
+        var hasLanguageAttribute = false;
+        foreach (var attribute in elementSyntax.StartTag.Attributes)
+        {
+            var attributeName = attribute.Name.LocalName.Text;
+            if (string.Equals(attributeName, "langword", StringComparison.OrdinalIgnoreCase))
+            {
+                hasLanguageAttribute = true;
+                continue;
+            }
+
+            if (!string.Equals(attributeName, "lang", StringComparison.OrdinalIgnoreCase) && !string.Equals(attributeName, "language", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            hasLanguageAttribute = true;
+            if (attribute is XmlTextAttributeSyntax textAttribute && textAttribute.TextTokens.All(token => string.IsNullOrWhiteSpace(token.ValueText)))
+            {
+                context.ReportDiagnostic(EmptyLanguageAttributeRule, attribute, attributeName);
+            }
+        }
+
+        if (!hasLanguageAttribute)
+        {
+            context.ReportDiagnostic(MissingLanguageAttributeRule, elementSyntax);
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseLangwordInXmlCommentAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseLangwordInXmlCommentAnalyzerTests.cs
@@ -9,6 +9,21 @@ public sealed class UseLangwordInXmlCommentAnalyzerTests
             .WithTargetFramework(TargetFramework.NetLatest);
     }
 
+    private static ProjectBuilder CreateProjectBuilder(string ruleId)
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<UseLangwordInXmlCommentAnalyzer>(id: ruleId)
+            .WithTargetFramework(TargetFramework.NetLatest);
+    }
+
+    private static ProjectBuilder CreateProjectBuilderWithAddLanguageAttributeFixer()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<UseLangwordInXmlCommentAnalyzer>()
+            .WithCodeFixProvider<UseLangwordInXmlCommentAddLanguageAttributeFixer>()
+            .WithTargetFramework(TargetFramework.NetLatest);
+    }
+
     [Theory]
     [InlineData("[|<c>void</c>|]", "<see langword=\"void\"/>")]
     [InlineData("[|<code>void</code>|]", "<see langword=\"void\"/>")]
@@ -39,6 +54,101 @@ class Sample { }
 /// <summary>{{comment}}</summary>
 class Sample { }
 """)
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("[|<c>void</c>|]", "<c language=\"\">void</c>")]
+    [InlineData("[|<code>void</code>|]", "<code language=\"\">void</code>")]
+    public async Task AddLanguageAttribute(string comment, string fix)
+    {
+        await CreateProjectBuilderWithAddLanguageAttributeFixer()
+              .WithSourceCode($$"""
+/// <summary>{{comment}}</summary>
+class Sample { }
+""")
+              .ShouldFixCodeWith($$"""
+/// <summary>{{fix}}</summary>
+class Sample { }
+""")
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("""<c [|lang=""|]>test</c>""")]
+    [InlineData("""<c [|lang=" "|]>test</c>""")]
+    [InlineData("""<code [|language=""|]>test</code>""")]
+    [InlineData("""<c [|lang=""|]>void</c>""")]
+    public async Task EmptyLanguageAttribute(string comment)
+    {
+        await CreateProjectBuilder("MA0218")
+              .WithSourceCode($$"""
+/// <summary>{{comment}}</summary>
+class Sample { }
+""")
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("""<c lang="csharp">test</c>""")]
+    [InlineData("""<c language="json">test</c>""")]
+    [InlineData("<c>test</c>")]
+    public async Task EmptyLanguageAttribute_Valid(string comment)
+    {
+        await CreateProjectBuilder("MA0218")
+              .WithSourceCode($$"""
+/// <summary>{{comment}}</summary>
+class Sample { }
+""")
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("[|<c>test</c>|]")]
+    [InlineData("[|<code>test</code>|]")]
+    [InlineData("""[|<c title="sample">test</c>|]""")]
+    public async Task MissingLanguageAttribute(string comment)
+    {
+        await CreateProjectBuilder("MA0219")
+              .WithSourceCode($$"""
+/// <summary>{{comment}}</summary>
+class Sample { }
+""")
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("""<c lang="csharp">test</c>""")]
+    [InlineData("""<c language="">test</c>""")]
+    [InlineData("""<code language="json">test</code>""")]
+    [InlineData("""<c langword="null"></c>""")]
+    [InlineData("<c>void</c>")]
+    [InlineData("<see langword=\"null\"/>")]
+    public async Task MissingLanguageAttribute_Valid(string comment)
+    {
+        await CreateProjectBuilder("MA0219")
+              .WithSourceCode($$"""
+/// <summary>{{comment}}</summary>
+class Sample { }
+""")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MissingLanguageAttribute_Fix()
+    {
+        await new ProjectBuilder()
+              .WithAnalyzer<UseLangwordInXmlCommentAnalyzer>(id: "MA0219")
+              .WithCodeFixProvider<UseLangwordInXmlCommentAddLanguageAttributeFixer>()
+              .WithTargetFramework(TargetFramework.NetLatest)
+              .WithSourceCode(""""
+/// <summary>[|<c>test</c>|]</summary>
+class Sample { }
+"""")
+              .ShouldFixCodeWith(""""
+/// <summary><c language="">test</c></summary>
+class Sample { }
+"""")
               .ValidateAsync();
     }
 }


### PR DESCRIPTION
## What

Extends the MA0154 analyzer file with a second code fix and two new rules.

**New code fix for MA0154** — `UseLangwordInXmlCommentAddLanguageAttributeFixer`

`<c>void</c>` could only be fixed by replacing the element with `<see langword="void" />`. The new fix adds an empty `language` attribute instead (`<c language="">void</c>`), which is the right answer when the content is not meant to be a C# keyword. It intentionally does **not** support fix all (`GetFixAllProvider() => null`), since the user has to fill in the value.

**MA0218 — The language attribute is empty** (info, enabled by default)

Reports a `language`/`lang` attribute on `<c>`/`<code>` that has no value (whitespace-only counts as empty). The diagnostic is on the attribute itself. This is the follow-up to the new code fix, which produces `language=""`.

**MA0219 — Set the language attribute in XML comment** (hidden, enabled by default)

Reports a `<c>`/`<code>` element that has no `language`, `lang`, or `langword` attribute. Being hidden, it does not show up in the build, but the "Add language attribute" fix is offered in the IDE, and the severity can be raised via editorconfig.

## Notes for the reviewer

- **MA0219 does not fire when MA0154 does.** For a bare keyword such as `<c>void</c>`, MA0154 already suggests `<see langword="void" />`, so asking for a language attribute on the same span would be contradictory. The `continue` in the analyzer is what implements this.
- **Both attribute names are recognized.** `language` is what the code fix writes and what the rule titles/docs use, but `lang` is still detected by MA0218/MA0219 so existing comments are handled.
- The rule docs note that the language attribute is only a convention: it is not part of the XML documentation comments specification, and tools may ignore it.
- Generated files (`README.md`, `docs/README.md`, the five packed `.editorconfig`) were refreshed with `dotnet run --project src/DocumentationGenerator`, which re-runs clean.

## Validation

- `dotnet build` on the solution: 0 warnings, 0 errors.
- Full `Meziantou.Analyzer.Test.roslyn5.9` suite: 3791/3791 passing.
- `UseLangwordInXmlCommentAnalyzerTests` on roslyn5.9 and roslyn4.8: 26/26 each.