### PR TITLE
Fix MA0075 false positive on FormattableString.Invariant

### DIFF
--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -50,6 +50,9 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
         AddDocumentationId(result, compilation, "M:System.Convert.ToChar(System.Object)");
         AddDocumentationId(result, compilation, "M:System.Convert.ToBoolean(System.String)");
         AddDocumentationId(result, compilation, "M:System.Convert.ToBoolean(System.Object)");
+
+        // FormattableString.Invariant formats the FormattableString using CultureInfo.InvariantCulture
+        AddDocumentationId(result, compilation, "M:System.FormattableString.Invariant(System.FormattableString)");
         return result;
 
         static void AddDocumentationId(HashSet<ISymbol> result, Compilation compilation, string id)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -308,6 +308,43 @@ class Test
     }
 
     [Fact]
+    public async Task FormattableString_Invariant_StringConcat()
+    {
+        var sourceCode = """
+            class Test
+            {
+                void A(string b)
+                {
+                    _ = System.FormattableString.Invariant($"abc{1:N0}") + b;
+                    _ = b + System.FormattableString.Invariant($"abc{1:N0}");
+                    _ = System.FormattableString.Invariant($"abc{1:N0}") + System.FormattableString.Invariant($"abc{2:N0}");
+                    _ = (System.FormattableString.Invariant($"abc{1:N0}")) + b;
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task FormattableString_CurrentCulture_StringConcat()
+    {
+        var sourceCode = """
+            class Test
+            {
+                void A(string b)
+                {
+                    _ = [|System.FormattableString.CurrentCulture($"abc{1:N0}")|] + b;
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task StringConcatFormattableString()
     {
         var sourceCode = """


### PR DESCRIPTION
Fixes #1321

## Problem

Since 3.0.150 ([#1273](https://github.com/meziantou/Meziantou.Analyzer/pull/1273)), MA0075 reports `FormattableString.Invariant($"...")` when the result is used directly as an operand of a string concatenation:

```c#
_ = System.FormattableString.Invariant($"abc{1:N0}") + b; // MA0075
```

Storing the result in a local first was already accepted, so the inline form should be too.

## Cause

`CultureSensitiveFormattingContext.GetCultureSensitivity` calls `GetInterpolatedStringArgumentCultureSensitivity` for invocations, which treats *any* invocation with a `FormattableString` (or interpolated string handler) argument as producing the culture sensitivity of that argument, and returns before anything else is considered. For `Invariant($"abc{1:N0}")` the argument is culture sensitive, so the whole invocation was classified as culture sensitive — even though `Invariant` exists precisely to format that argument with `CultureInfo.InvariantCulture`.

## Fix

Add `System.FormattableString.Invariant(System.FormattableString)` to `CreateExcludedMethods`, which is consulted before the interpolated string argument path.

I used the excluded-methods list rather than skipping every method whose containing type is `System.FormattableString`, because `FormattableString.CurrentCulture` lives on the same type and is genuinely culture sensitive — it must keep being reported. `FormattableString.ToString(IFormatProvider)` and `string.Create(IFormatProvider, ...)`, also mentioned in the issue, were already covered by the existing `HasArgumentOfType(FormatProviderSymbol)` check, so they needed no change.

## Tests

- `FormattableString_Invariant_StringConcat` covers the four concatenation forms from the issue (left operand, right operand, both operands, parenthesized).
- `FormattableString_CurrentCulture_StringConcat` locks in that `FormattableString.CurrentCulture` is still reported.

## Verification

- Confirmed the new test fails on the unpatched analyzer and passes with the fix.
- Full test suite passes on roslyn5.9 (3774 tests) and roslyn4.8 (3643 tests).
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.