### PR TITLE
Fix bare `#pragma warning disable` in AvoidUsingRedundantElseAnalyzer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,24 @@ jobs:
     - run: git status
       if: failure()
 
+  check_pragmas:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - name: Ensure no '#pragma warning disable' without a warning list
+      run: |
+        # A '#pragma warning disable' with no warning ID disables every warning until the end of the file
+        $barePragmas = @(Get-ChildItem -Recurse -Filter *.cs | Select-String -Pattern '^\s*#pragma\s+warning\s+disable\s*(//.*)?$')
+        if ($barePragmas.Count -gt 0) {
+          $barePragmas | ForEach-Object {
+            $path = (Resolve-Path -Relative -Path $_.Path) -replace '^\./', ''
+            Write-Host "::error file=$path,line=$($_.LineNumber)::'#pragma warning disable' without a warning list disables every warning until the end of the file. List the warnings to disable."
+          }
+          exit 1
+        }
+
+        Write-Host "No '#pragma warning disable' without a warning list"
+
   compute_package_version:
     runs-on: ubuntu-latest
     outputs:
@@ -238,7 +256,7 @@ jobs:
 
   deploy:
     runs-on: 'ubuntu-latest'
-    needs: [ check_documentation, validate_nuget, build_and_test ]
+    needs: [ check_documentation, check_pragmas, validate_nuget, build_and_test ]
     permissions:
       contents: read
       id-token: write

--- a/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
@@ -93,7 +93,7 @@ public sealed partial class AvoidUsingRedundantElseAnalyzer : DiagnosticAnalyzer
     {
         foreach (var child in node.DescendantNodes())
         {
-#pragma warning disable 
+#pragma warning disable IDE0010 // Add missing cases
             switch (child)
             {
                 case VariableDeclaratorSyntax variableDeclarator:


### PR DESCRIPTION
Fixes #1338

## What changed

**`src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs`** — the `#pragma warning disable` in `FindLocalIdentifiersIn` had no warning ID, so it disabled *every* warning from line 96 to the end of the file. The matching `#pragma warning restore IDE0010` only lifted IDE0010, so the blanket disable was never actually restored. The ID was lost in f8076852 ("Update .NET SDK 9.0", Nov 2024). Restored it to `#pragma warning disable IDE0010 // Add missing cases` so the suppression is scoped to the `switch` again (and dropped the trailing whitespace the bare pragma carried).

**`.github/workflows/ci.yml`** — new `check_pragmas` job that fails on any `#pragma warning disable` with an empty warning list, annotating the offending file and line. Added to `deploy`'s `needs` so it blocks publishing. This is the cheap recurrence guard suggested in the issue; nothing in the repo linted for bare pragmas before.

## Why it matters

This is analyzer source that runs inside every consumer's compiler. Nullable warnings, CA rules and the project's own dogfooded MA rules were all off for `FindLocalIdentifiersIn` — the helper deciding which identifiers MA0160 treats as captured. A regression there would have been flagged by neither the build nor CI.

## Verification

- All five analyzer projects (`roslyn4.8` → `roslyn5.9`) build with **0 warnings** — nothing was actually being hidden by the blanket disable, so no follow-up suppressions were needed.
- `AvoidUsingRedundantElseAnalyzerTests`: 27/27 passed on both `roslyn5.9` and `roslyn4.8`.
- The CI script was run locally under `pwsh` in both directions: clean on this branch (exit 0), and it correctly flags `AvoidUsingRedundantElseAnalyzer.cs:96` when the bare pragma is reintroduced (exit 1).
- `dotnet run --project src/DocumentationGenerator` exits 0 — no markdown changes.

## Note for the reviewer

The CI check is limited to bare `disable`, as the issue specified. A bare `#pragma warning restore` is also legal and can silently re-enable warnings suppressed by an enclosing region, but there are none in the repo today — happy to widen the check if you'd like it to cover those too.
