### PR TITLE
Fix MAS0004 stopping at the first unrelated CA1507 diagnostic

### DIFF
--- a/src/Meziantou.Analyzer/Suppressors/CA1507SerializationPropertyNameSuppressor.cs
+++ b/src/Meziantou.Analyzer/Suppressors/CA1507SerializationPropertyNameSuppressor.cs
@@ -15,22 +15,26 @@ public sealed class CA1507SerializationPropertyNameSuppressor : DiagnosticSuppre
 
     public override void ReportSuppressions(SuppressionAnalysisContext context)
     {
+        var jsonPropertyAttributeSymbol = context.Compilation.GetBestTypeByMetadataName("Newtonsoft.Json.JsonPropertyAttribute");
+        if (jsonPropertyAttributeSymbol is null)
+            return;
+
         foreach (var diagnostic in context.ReportedDiagnostics)
         {
             var node = diagnostic.FindNode(context.CancellationToken);
             if (node is null)
-                return;
+                continue;
 
             var parent = node.FirstAncestorOrSelf<AttributeSyntax>();
             if (parent is null)
-                return;
+                continue;
 
             var semanticModel = context.GetSemanticModel(node.SyntaxTree);
             var info = semanticModel.GetSymbolInfo(parent, context.CancellationToken);
             if (info.Symbol is not IMethodSymbol methodSymbol)
-                return;
+                continue;
 
-            if (methodSymbol.ContainingType.IsEqualTo(context.Compilation.GetBestTypeByMetadataName("Newtonsoft.Json.JsonPropertyAttribute")))
+            if (methodSymbol.ContainingType.IsEqualTo(jsonPropertyAttributeSymbol))
             {
                 var suppression = Suppression.Create(RuleJsonProperty, diagnostic);
                 context.ReportSuppression(suppression);

--- a/src/Meziantou.Analyzer/Suppressors/CA1507SerializationPropertyNameSuppressor.cs
+++ b/src/Meziantou.Analyzer/Suppressors/CA1507SerializationPropertyNameSuppressor.cs
@@ -17,7 +17,6 @@ public sealed class CA1507SerializationPropertyNameSuppressor : DiagnosticSuppre
     {
         // Resolved on the first diagnostic located in an attribute, so the symbol is not loaded when there is none
         INamedTypeSymbol? jsonPropertyAttributeSymbol = null;
-        var jsonPropertyAttributeSymbolResolved = false;
 
         foreach (var diagnostic in context.ReportedDiagnostics)
         {
@@ -34,14 +33,13 @@ public sealed class CA1507SerializationPropertyNameSuppressor : DiagnosticSuppre
             if (info.Symbol is not IMethodSymbol methodSymbol)
                 continue;
 
-            if (!jsonPropertyAttributeSymbolResolved)
-            {
-                jsonPropertyAttributeSymbol = context.Compilation.GetBestTypeByMetadataName("Newtonsoft.Json.JsonPropertyAttribute");
-                jsonPropertyAttributeSymbolResolved = true;
-            }
 
             if (jsonPropertyAttributeSymbol is null)
-                return;
+            {
+                jsonPropertyAttributeSymbol = context.Compilation.GetBestTypeByMetadataName("Newtonsoft.Json.JsonPropertyAttribute");
+                if (jsonPropertyAttributeSymbol is null)
+                    return;
+            }
 
             if (methodSymbol.ContainingType.IsEqualTo(jsonPropertyAttributeSymbol))
             {

--- a/src/Meziantou.Analyzer/Suppressors/CA1507SerializationPropertyNameSuppressor.cs
+++ b/src/Meziantou.Analyzer/Suppressors/CA1507SerializationPropertyNameSuppressor.cs
@@ -15,9 +15,9 @@ public sealed class CA1507SerializationPropertyNameSuppressor : DiagnosticSuppre
 
     public override void ReportSuppressions(SuppressionAnalysisContext context)
     {
-        var jsonPropertyAttributeSymbol = context.Compilation.GetBestTypeByMetadataName("Newtonsoft.Json.JsonPropertyAttribute");
-        if (jsonPropertyAttributeSymbol is null)
-            return;
+        // Resolved on the first diagnostic located in an attribute, so the symbol is not loaded when there is none
+        INamedTypeSymbol? jsonPropertyAttributeSymbol = null;
+        var jsonPropertyAttributeSymbolResolved = false;
 
         foreach (var diagnostic in context.ReportedDiagnostics)
         {
@@ -33,6 +33,15 @@ public sealed class CA1507SerializationPropertyNameSuppressor : DiagnosticSuppre
             var info = semanticModel.GetSymbolInfo(parent, context.CancellationToken);
             if (info.Symbol is not IMethodSymbol methodSymbol)
                 continue;
+
+            if (!jsonPropertyAttributeSymbolResolved)
+            {
+                jsonPropertyAttributeSymbol = context.Compilation.GetBestTypeByMetadataName("Newtonsoft.Json.JsonPropertyAttribute");
+                jsonPropertyAttributeSymbolResolved = true;
+            }
+
+            if (jsonPropertyAttributeSymbol is null)
+                return;
 
             if (methodSymbol.ContainingType.IsEqualTo(jsonPropertyAttributeSymbol))
             {

--- a/tests/Meziantou.Analyzer.Test/Suppressors/CA1507SerializationPropertyNameSuppressorTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Suppressors/CA1507SerializationPropertyNameSuppressorTests.cs
@@ -68,5 +68,22 @@ public sealed class CA1507SerializationPropertyNameSuppressorTests
                 """)
             .ValidateAsync();
     }
+
+    [Fact]
+    public async Task CA1507_NewtonsoftJson_JsonPropertyName_AfterAnUnrelatedDiagnostic()
+    {
+        await CreateProjectBuilder()
+            .AddNuGetReference("Newtonsoft.Json", "13.0.3", "lib/netstandard2.0/")
+            .WithSourceCode("""
+                internal class Test
+                {
+                    public void Foo(string name) => throw new System.ArgumentException("dummy", [|"name"|]);
+
+                    [Newtonsoft.Json.JsonProperty("Bar")]
+                    public int Bar { get; set; }
+                }
+                """)
+            .ValidateAsync();
+    }
 }
 #endif


### PR DESCRIPTION
Fixes #1337

## What changed

`CA1507SerializationPropertyNameSuppressor.ReportSuppressions` iterates `context.ReportedDiagnostics`, but the three "not applicable" guards used `return` instead of `continue`.

`ReportedDiagnostics` contains **every** CA1507 of the compilation, and the vast majority are not inside an attribute — so `node.FirstAncestorOrSelf<AttributeSyntax>()` was null and the method exited before ever reaching the `[Newtonsoft.Json.JsonProperty]` one. MAS0004 was effectively non-functional in any real project, and whether it worked at all depended on the ordering of `ReportedDiagnostics`, which is not guaranteed.

- The three `return` statements are now `continue`.
- `GetBestTypeByMetadataName("Newtonsoft.Json.JsonPropertyAttribute")` is hoisted out of the loop, with an early bail when Newtonsoft.Json is not referenced.

## Test

`CA1507_NewtonsoftJson_JsonPropertyName_AfterAnUnrelatedDiagnostic` puts two CA1507 diagnostics in one file with the attribute one second: the first stays reported, the second must be suppressed. The three existing tests each contained exactly one CA1507, which is why the bug was invisible to the suite.

## Notes for reviewers

- The new test was confirmed to fail against the pre-fix code (CA1507 reported on `"Bar"`) and to pass with the fix.
- Suppressor tests pass on roslyn4.14, 5.0, 5.6 and 5.9 (14/14 each). roslyn4.8 runs zero — all three suppressor test files are guarded by `#if ROSLYN_4_10_OR_GREATER`, which is pre-existing.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.
- The other two suppressors do not have this bug: `CA1822DecoratedMethodSuppressor` delegates the per-diagnostic work to a helper method, and `IDE0058Suppressor` already uses `continue`.