### PR TITLE
Fix StackOverflow crash on cyclic local initializers (MA0091/MA0092/MA0093)

### DIFF
--- a/src/Meziantou.Analyzer/Rules/EventsShouldHaveProperArgumentsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventsShouldHaveProperArgumentsAnalyzer.cs
@@ -75,7 +75,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzer : DiagnosticAnalyzer
         if (instance is null)
             return;
 
-        var ev = FindEvent(instance);
+        var ev = FindEvent(instance, context.CancellationToken);
         if (ev is null)
             return;
 
@@ -119,15 +119,17 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzer : DiagnosticAnalyzer
         return value is IInstanceReferenceOperation;
     }
 
-    private static IEventSymbol? FindEvent(IOperation operation)
+    private static IEventSymbol? FindEvent(IOperation operation, CancellationToken cancellationToken)
     {
-        var eventFinder = new EventReferenceVisitor();
+        var eventFinder = new EventReferenceVisitor(cancellationToken);
         eventFinder.Visit(operation);
         return eventFinder.EventSymbol;
     }
 
-    private sealed class EventReferenceVisitor : OperationVisitor
+    private sealed class EventReferenceVisitor(CancellationToken cancellationToken) : OperationVisitor
     {
+        private readonly HashSet<ISymbol> _visitedLocals = new(SymbolEqualityComparer.Default);
+
         public IEventSymbol? EventSymbol { get; set; }
 
         public override void VisitEventReference(IEventReferenceOperation operation)
@@ -150,15 +152,20 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzer : DiagnosticAnalyzer
                 }
                 else if (symbol is ILocalSymbol localSymbol)
                 {
-                    FindFromLocalSymbol(semanticModel, localSymbol, CancellationToken.None);
+                    FindFromLocalSymbol(semanticModel, localSymbol);
                 }
             }
 
             base.VisitConditionalAccessInstance(operation);
         }
 
-        private void FindFromLocalSymbol(SemanticModel semanticModel, ILocalSymbol localSymbol, CancellationToken cancellationToken)
+        private void FindFromLocalSymbol(SemanticModel semanticModel, ILocalSymbol localSymbol)
         {
+            // The initializer of a local can reference the local itself or another local that references it back,
+            // so keep track of the visited locals to avoid an infinite recursion
+            if (!_visitedLocals.Add(localSymbol))
+                return;
+
             foreach (var symbolLocation in localSymbol.DeclaringSyntaxReferences)
             {
                 var variableDeclarator = symbolLocation.GetSyntax(cancellationToken) as Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax;
@@ -172,7 +179,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzer : DiagnosticAnalyzer
                     }
                     else if (initializerSymbol is ILocalSymbol initializerLocalSymbol)
                     {
-                        FindFromLocalSymbol(semanticModel, initializerLocalSymbol, cancellationToken);
+                        FindFromLocalSymbol(semanticModel, initializerLocalSymbol);
                     }
                 }
             }
@@ -182,7 +189,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzer : DiagnosticAnalyzer
         {
             if (operation.SemanticModel is not null)
             {
-                FindFromLocalSymbol(operation.SemanticModel, operation.Local, CancellationToken.None);
+                FindFromLocalSymbol(operation.SemanticModel, operation.Local);
             }
 
             base.VisitLocalReference(operation);

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
@@ -138,7 +138,7 @@ public sealed partial class ProjectBuilder
     private async Task<Diagnostic[]> GetSortedDiagnostics(IList<DiagnosticAnalyzer> analyzers)
     {
         var documents = await GetDocuments().ConfigureAwait(false);
-        return await GetSortedDiagnosticsFromDocuments(analyzers, documents, compileSolution: true).ConfigureAwait(false);
+        return await GetSortedDiagnosticsFromDocuments(analyzers, documents, compileSolution: IsValidCode).ConfigureAwait(false);
     }
 
     private async Task<Document[]> GetDocuments()

--- a/tests/Meziantou.Analyzer.Test/Rules/EventsShouldHaveProperArgumentsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EventsShouldHaveProperArgumentsAnalyzerTests.cs
@@ -312,4 +312,45 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzerTests
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task CyclicLocalInitializers()
+    {
+        const string SourceCode = """
+            using System;
+            class Test
+            {
+                void OnEvent()
+                {
+                    EventHandler a = b;
+                    EventHandler b = a;
+                    a.Invoke(this, EventArgs.Empty);
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .WithNoCompilation()
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task SelfReferencingLocalInitializer()
+    {
+        const string SourceCode = """
+            using System;
+            class Test
+            {
+                void OnEvent()
+                {
+                    EventHandler a = a;
+                    a.Invoke(this, EventArgs.Empty);
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .WithNoCompilation()
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
Fixes #1323

## What changed

`EventsShouldHaveProperArgumentsAnalyzer.EventReferenceVisitor.FindFromLocalSymbol` resolved a local's initializer and, when that initializer bound to another `ILocalSymbol`, called itself — with no visited set. Two locals whose initializers reference each other made the walk recurse until the process died:

```csharp
class C
{
    void M()
    {
        System.EventHandler a = b;
        System.EventHandler b = a;
        a.Invoke(this, System.EventArgs.Empty);
    }
}
```

`FindFromLocalSymbol` now tracks the visited locals in a `HashSet<ISymbol>` (with `SymbolEqualityComparer.Default`) held by the visitor instance and bails on re-entry.

The two hardcoded `CancellationToken.None` arguments are also gone: the visitor now takes the real `context.CancellationToken` through a primary constructor, so the token parameter disappears from the recursive method's signature. With a cycle present, cancellation was the only thing that could have stopped the walk.

## Why it matters

A `StackOverflowException` cannot be caught by Roslyn's analyzer host, so this was not a recoverable `AD0001` — the whole process died (VBCSCompiler, Visual Studio, Rider, OmniSharp). MA0091, MA0092 and MA0093 are all enabled by default at Warning.

The source that triggers it does not compile (CS0841, use before declaration), which is exactly the state of a file while it is being typed — and IDE live analysis runs continuously on erroneous compilations.

## Test infrastructure

`ProjectBuilder.IsValidCode`, set by `WithNoCompilation()`, was declared but never read: `GetSortedDiagnostics` hardcoded `compileSolution: true`, so no analyzer test could use non-compiling source (`Assert.Fail("The code doesn't compile.")`). It now passes `IsValidCode`, which is what makes the regression tests possible. No existing test used `WithNoCompilation()`, so nothing else changes behavior.

## Tests

Two regression tests: the mutual `a = b; b = a;` cycle from the issue, and a self-referencing `EventHandler a = a;`.

I confirmed the new test actually reproduces the bug — with the visited-set guard temporarily removed, the run died exactly as reported in the issue (`Test run summary: Zero tests ran`, exit code 7, `createdump`). Guard restored, it passes.

- 12/12 tests in `EventsShouldHaveProperArgumentsAnalyzerTests` pass on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9)
- Full suite on the default version: 3776/3776 passed
- `dotnet run --project src/DocumentationGenerator` produced no markdown changes
