### PR TITLE
Compile the text produced by the fixer in the test harness

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
@@ -615,8 +615,18 @@ public sealed partial class ProjectBuilder
 
         if (mustCompile)
         {
+            // Compile the text the user actually gets, not the syntax tree built by the fixer. A tree can be
+            // structurally valid while its serialization re-parses differently (missing parentheses, missing
+            // separators, ...), so the text must be re-parsed before being compiled.
+            var solutionToCompile = solution;
+            foreach (var documentId in solution.GetChanges(document.Project.Solution).GetProjectChanges().SelectMany(projectChange => projectChange.GetChangedDocuments().Concat(projectChange.GetAddedDocuments())))
+            {
+                var text = await GetStringFromDocument(solution.GetDocument(documentId)!).ConfigureAwait(false);
+                solutionToCompile = solutionToCompile.WithDocumentText(documentId, SourceText.From(text, Encoding.UTF8));
+            }
+
             var options = new CSharpCompilationOptions(OutputKind, allowUnsafe: true, metadataImportOptions: MetadataImportOptions.All);
-            var project = solution.Projects.Single();
+            var project = solutionToCompile.Projects.Single();
             var compilation = (await project.GetCompilationAsync().ConfigureAwait(false))!.WithOptions(options);
 
             using var ms = new MemoryStream();
@@ -627,7 +637,7 @@ public sealed partial class ProjectBuilder
                 var firstDocument = project.Documents.FirstOrDefault();
                 if (firstDocument is not null)
                 {
-                    sourceCode = (await firstDocument.GetSyntaxRootAsync().ConfigureAwait(false))!.ToFullString();
+                    sourceCode = (await firstDocument.GetTextAsync().ConfigureAwait(false)).ToString();
                 }
 
                 Assert.Fail("The fixed code doesn't compile. " + string.Join(Environment.NewLine, result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)) + Environment.NewLine + sourceCode);

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilderValidationTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilderValidationTests.cs
@@ -1,0 +1,111 @@
+// The analyzer and the code fixers of this file are test helpers, not compiler extensions that ship to users, so
+// the analyzer authoring rules do not apply
+#pragma warning disable RS1038 // This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Meziantou.Analyzer.Test.Helpers;
+
+public sealed class ProjectBuilderValidationTests
+{
+    private const string SourceCode = """
+        class TestClass
+        {
+            bool Test(object o) => [|o is string|];
+        }
+        """;
+
+    [Fact]
+    public async Task VerifyFix_CompilesTheTextProducedByTheFixer()
+    {
+        // The fixer produces a valid tree ('!' applied to the is-expression), but its text is '!o is string',
+        // which re-parses as '(!o) is string' and does not compile
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => new ProjectBuilder()
+            .WithAnalyzer(new TypeCheckAnalyzer())
+            .WithCodeFixProvider(new NegateWithoutParenthesesFixer())
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith("""
+                class TestClass
+                {
+                    bool Test(object o) => !o is string;
+                }
+                """)
+            .ValidateAsync());
+
+        Assert.Contains("The fixed code doesn't compile.", exception.Message);
+    }
+
+    [Fact]
+    public async Task VerifyFix_DoesNotReportValidFix()
+    {
+        await new ProjectBuilder()
+            .WithAnalyzer(new TypeCheckAnalyzer())
+            .WithCodeFixProvider(new NegateWithParenthesesFixer())
+            .WithSourceCode(SourceCode)
+            .ShouldFixCodeWith("""
+                class TestClass
+                {
+                    bool Test(object o) => !(o is string);
+                }
+                """)
+            .ValidateAsync();
+    }
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class TypeCheckAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new("TEST0001", "Negate the type check", "Negate the type check", "Test", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(ctx => ctx.ReportDiagnostic(Diagnostic.Create(Rule, ctx.Node.GetLocation())), SyntaxKind.IsExpression);
+        }
+    }
+
+    private abstract class NegateFixer : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("TEST0001");
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        protected abstract ExpressionSyntax Negate(BinaryExpressionSyntax expression);
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root?.FindNode(context.Span, getInnermostNodeForTie: true) is not BinaryExpressionSyntax expression)
+                return;
+
+            context.RegisterCodeFix(CodeAction.Create("Negate", async ct =>
+            {
+                var editor = await DocumentEditor.CreateAsync(context.Document, ct).ConfigureAwait(false);
+                editor.ReplaceNode(expression, Negate(expression));
+                return editor.GetChangedDocument();
+            }, equivalenceKey: "Negate"), context.Diagnostics);
+        }
+    }
+
+    private sealed class NegateWithoutParenthesesFixer : NegateFixer
+    {
+        protected override ExpressionSyntax Negate(BinaryExpressionSyntax expression) =>
+            PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, expression);
+    }
+
+    private sealed class NegateWithParenthesesFixer : NegateFixer
+    {
+        protected override ExpressionSyntax Negate(BinaryExpressionSyntax expression) =>
+            PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, ParenthesizedExpression(expression.WithoutTrivia()));
+    }
+}


### PR DESCRIPTION
Fixes #1330

## Problem

`ApplyFix` called `compilation.Emit(...)` on the solution produced directly by the `CodeAction`, so it validated the **syntax tree** built by the fixer. The text compared against the expected fixed code is produced only afterwards, by `Simplifier.ReduceAsync` and `Formatter.Format` in `GetStringFromDocument` — and that text was never compiled.

Any fixer that builds a structurally valid tree whose *serialization* re-parses differently therefore passed. Operator-precedence and parenthesization bugs are the most common way a Roslyn fixer corrupts user code, and the harness was structurally blind to all of them across the 109 fixers.

## Change

`ApplyFix` now runs every document the code action changed or added through `GetStringFromDocument` and puts that text back into the solution with `WithDocumentText` before compiling. The trees that get compiled are the ones parsed from the text of the fix — the text the user actually gets. The failure message prints the document text rather than the raw syntax root.

A self-test for the harness is added in `ProjectBuilderValidationTests`, with a test-only analyzer on `is` expressions and two test-only fixers:

- `NegateWithoutParenthesesFixer` builds `!` applied to the is-expression — a valid tree whose text is `!o is string`, which re-parses as `(!o) is string` and does not compile. The test asserts the harness now fails with `The fixed code doesn't compile.`
- `NegateWithParenthesesFixer` is the correct version, and the test asserts a valid fix still passes.

I checked that the first test fails when `ApplyFix` is reverted to its previous behavior, so it genuinely guards the change.

## Notes for the reviewer

The issue expected this to surface more existing fixer bugs. It does not: all 18575 tests pass across the five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9). The MA0073 fixer bug used as the demonstration in the issue is not covered by any existing test case — no test compares an `is` expression with a bool constant — so it stays a live bug for its own issue rather than turning red here.

`dotnet run --project src/DocumentationGenerator` produced no markdown changes, as expected for a test-only change.