### PR TITLE
Avoid the Sqlite data-flow analysis on every MA0042 invocation

### DIFF
--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -147,6 +147,12 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
         private INamedTypeSymbol? SqliteConnectionSymbol { get; }
         private INamedTypeSymbol? SqliteCommandSymbol { get; }
         private INamedTypeSymbol? SqliteDataReaderSymbol { get; }
+
+        /// <summary>
+        /// Indicates whether the compilation references <c>Microsoft.Data.Sqlite</c>. When it does not, the Sqlite special cases can never apply.
+        /// </summary>
+        private bool HasSqliteSymbols => SqliteConnectionSymbol is not null || SqliteCommandSymbol is not null || SqliteDataReaderSymbol is not null;
+
         private ISymbol[] ConsoleErrorAndOutSymbols { get; }
         private INamedTypeSymbol? CancellationTokenSymbol { get; }
         private INamedTypeSymbol? ObsoleteAttributeSymbol { get; }
@@ -186,19 +192,19 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             if (IsExcludedDiagnosticSymbol(targetMethod))
                 return;
 
-            var sqliteSpecialCasesEnabled = IsSqliteSpecialCasesEnabled(context, operation);
-            var isSqliteSpecialCaseMethod = IsSqliteSpecialCaseMethod(operation, context.CancellationToken);
-
             // The cache only contains methods with no async equivalent methods.
             // This optimizes the best-case scenario where code is correctly written according to this analyzer.
-            if (!isSqliteSpecialCaseMethod && _symbolsWithNoAsyncOverloads.Contains(targetMethod))
+            // Methods skipped because of the Sqlite special cases are never added to the cache, so a cache hit means
+            // the method has no async equivalent whatever the instance is.
+            if (_symbolsWithNoAsyncOverloads.Contains(targetMethod))
                 return;
 
+            var sqliteSpecialCasesEnabled = IsSqliteSpecialCasesEnabled(context, operation);
             if (HasAsyncEquivalent(operation, sqliteSpecialCasesEnabled, context.CancellationToken, out var diagnosticMessage))
             {
                 ReportDiagnosticIfNeeded(context, diagnosticMessage.CreateProperties(), operation, diagnosticMessage.DiagnosticMessage);
             }
-            else if (!isSqliteSpecialCaseMethod)
+            else if (!sqliteSpecialCasesEnabled || !IsSqliteSpecialCaseMethod(operation, context.CancellationToken))
             {
                 _symbolsWithNoAsyncOverloads.Add(targetMethod);
             }
@@ -479,8 +485,22 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             return type.IsEqualToAny(SqliteConnectionSymbol, SqliteCommandSymbol, SqliteDataReaderSymbol);
         }
 
+        /// <summary>
+        /// Indicates whether a value of the declared type <paramref name="type"/> could hold an instance of a Sqlite special-case type.
+        /// </summary>
+        private bool CanHoldSqliteSpecialCaseType(INamedTypeSymbol type)
+        {
+            return CanHold(SqliteConnectionSymbol, type) || CanHold(SqliteCommandSymbol, type) || CanHold(SqliteDataReaderSymbol, type);
+
+            static bool CanHold(INamedTypeSymbol? sqliteType, INamedTypeSymbol declaredType)
+                => sqliteType is not null && (sqliteType.InheritsFrom(declaredType) || sqliteType.Implements(declaredType));
+        }
+
         private bool IsSqliteSpecialCaseMethod(IInvocationOperation operation, CancellationToken cancellationToken)
         {
+            if (!HasSqliteSymbols)
+                return false;
+
             if (IsSqliteSpecialCaseType(operation.TargetMethod.ContainingType))
                 return true;
 
@@ -490,10 +510,21 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
             if (operation.TargetMethod.IsStatic)
                 return false;
 
-            if (operation.Instance?.GetActualType(cancellationToken) is not INamedTypeSymbol type)
+            if (operation.Instance is not { } instance)
                 return false;
 
-            return IsSqliteSpecialCaseType(type);
+            // The data flow analysis walks the whole syntax tree, so only run it when the declared type of the instance
+            // could actually hold a Sqlite instance.
+            if (instance.GetActualType(useDataFlowAnalysis: false, cancellationToken) is not INamedTypeSymbol declaredType)
+                return false;
+
+            if (IsSqliteSpecialCaseType(declaredType))
+                return true;
+
+            if (!CanHoldSqliteSpecialCaseType(declaredType))
+                return false;
+
+            return instance.GetActualType(cancellationToken) is INamedTypeSymbol type && IsSqliteSpecialCaseType(type);
         }
 
         private IMethodSymbol? FindPotentialAsyncEquivalent(IInvocationOperation operation, IMethodSymbol targetMethod, string methodName)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -2205,6 +2205,52 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     }
 
     [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1333")]
+    public async Task DbConnectionAssignedFromSqliteConnection_NoDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .WithSourceCode("""
+                using System.Data.Common;
+                using System.Threading.Tasks;
+                using Microsoft.Data.Sqlite;
+
+                class Test
+                {
+                    public async Task A()
+                    {
+                        DbConnection connection = new SqliteConnection();
+                        connection.Close();
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1333")]
+    public async Task DbConnectionNotAssignedFromSqliteConnection_Diagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithTargetFramework(TargetFramework.Net8_0)
+              .AddNuGetReference("Microsoft.Data.Sqlite.Core", "8.0.0", "lib/net8.0/")
+              .WithSourceCode("""
+                using System.Data.Common;
+                using System.Threading.Tasks;
+
+                class Test
+                {
+                    public async Task A(DbConnection connection)
+                    {
+                        [|connection.Close()|];
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task IAsyncEnumerable()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
Fixes #1333

## What changed

`AnalyzeInvocation` called `IsSqliteSpecialCaseMethod` unconditionally — before consulting its own negative cache, and ignoring the `enable_sqlite_special_cases` option computed on the line above. For any non-static, non-extension invocation that reached `operation.Instance?.GetActualType(cancellationToken)`, that ran the data-flow variant, which walks the **entire syntax tree** looking for assignments with a `GetOperation` call per assignment found. Nothing guarded against `SqliteConnectionSymbol` / `SqliteCommandSymbol` / `SqliteDataReaderSymbol` all being null, so it also ran in full in every project that does not reference `Microsoft.Data.Sqlite`.

Three changes in `DoNotUseBlockingCallInAsyncContextAnalyzer.cs`:

1. **Early return when Sqlite isn't referenced.** `IsSqliteSpecialCaseMethod` now returns immediately when all three Sqlite symbols are null. This alone removes the whole cost in projects without `Microsoft.Data.Sqlite`.

2. **Reordered `AnalyzeInvocation`.** The negative cache is consulted first, and the Sqlite check now only runs on the cache-miss + no-async-equivalent path, guarded by `sqliteSpecialCasesEnabled`.

3. **Declared-type pre-filter.** The data-flow variant of `GetActualType` now runs only when the receiver's declared type could actually hold a Sqlite instance (one of the Sqlite types inherits from or implements it).

## Why the reordering is safe

The cache lookup is now unconditional, where before a Sqlite special-case method bypassed it. An entry is only ever added when the method was *not* a Sqlite special case, so a cache hit means "no async equivalent regardless of the receiver" — the Sqlite branch of `HasAsyncEquivalent` would also have returned `false` at this site. Same outcome, no diagnostic.

The `!sqliteSpecialCasesEnabled || !IsSqliteSpecialCaseMethod(...)` short-circuit before adding to the cache is correct because when the option is off, `HasAsyncEquivalent` skips its Sqlite branch entirely — so a `false` result cannot have come from Sqlite special-casing and the method is legitimately cacheable.

## The tradeoff the issue raised

The issue noted that a receiver declared as `DbConnection` but assigned a `SqliteConnection` would stop being special-cased unless the `Db*` fallback is kept. It is kept: `DbConnection` and `IDbConnection` are a base class and an interface of `SqliteConnection`, so the pre-filter lets them through to the data-flow analysis. Only receivers whose declared type provably cannot hold a Sqlite instance skip the walk.

## Tests

Added two tests to `DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs`:

- `DbConnectionAssignedFromSqliteConnection_NoDiagnostic` — `DbConnection connection = new SqliteConnection(); connection.Close();` is still special-cased. There was no existing coverage of the data-flow path; every existing Sqlite test uses a directly-typed `SqliteConnection`/`SqliteCommand`/`SqliteDataReader` parameter, which is matched by the declared type without any data flow. I verified this test fails when the pre-filter is deliberately broken, so it isn't vacuous.
- `DbConnectionNotAssignedFromSqliteConnection_Diagnostic` — a plain `DbConnection` parameter still reports.

Full suite passes: 18,575 tests across roslyn4.8 / 4.14 / 5.0 / 5.6 / 5.9. `dotnet run --project src/DocumentationGenerator` produced no markdown changes (behavior is unchanged, so no rule documentation needed updating).

## Note on magnitude

As the issue says, the unconditional-ness is the confirmed part — I did not benchmark the before/after, so the size of the win is unquantified.