### PR TITLE
Fix MA0073 code fixer producing uncompilable code for low-precedence operands

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidComparisonWithBoolConstantFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidComparisonWithBoolConstantFixer.cs
@@ -48,7 +48,10 @@ public sealed class AvoidComparisonWithBoolConstantFixer : CodeFixProvider
 
         if (logicalNotOperatorNeeded)
         {
-            nodeToKeep = PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, (ExpressionSyntax)nodeToKeep);
+            // The operand may bind less tightly than '!' (e.g. "o is string" or "a < b"), so it must be parenthesized.
+            // The Simplifier annotation removes the parentheses when they are redundant.
+            var operand = nodeToKeep is ParenthesizedExpressionSyntax parenthesizedExpression ? parenthesizedExpression : ((ExpressionSyntax)nodeToKeep).Parentheses();
+            nodeToKeep = PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, operand);
         }
 
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidComparisonWithBoolConstantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidComparisonWithBoolConstantAnalyzerTests.cs
@@ -79,6 +79,168 @@ public sealed class AvoidComparisonWithBoolConstantAnalyzerTests
               .ValidateAsync();
     }
 
+    [Fact]
+    public async Task IsPatternComparedWithFalse_ParenthesizesExpression()
+    {
+        var originalCode = """
+            class TestClass
+            {
+                void Test(object o)
+                {
+                    _ = o is string [|==|] false;
+                }
+            }
+            """;
+        var modifiedCode = """
+            class TestClass
+            {
+                void Test(object o)
+                {
+                    _ = !(o is string);
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ShouldFixCodeWith(modifiedCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task IsPatternComparedWithTrue_KeepsExpression()
+    {
+        var originalCode = """
+            class TestClass
+            {
+                void Test(object o)
+                {
+                    _ = o is string [|==|] true;
+                }
+            }
+            """;
+        var modifiedCode = """
+            class TestClass
+            {
+                void Test(object o)
+                {
+                    _ = o is string;
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ShouldFixCodeWith(modifiedCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task IsPatternNotEqualToTrue_ParenthesizesExpression()
+    {
+        var originalCode = """
+            class TestClass
+            {
+                void Test(object o)
+                {
+                    _ = o is string [|!=|] true;
+                }
+            }
+            """;
+        var modifiedCode = """
+            class TestClass
+            {
+                void Test(object o)
+                {
+                    _ = !(o is string);
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ShouldFixCodeWith(modifiedCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task IsPatternNotEqualToFalse_KeepsExpression()
+    {
+        var originalCode = """
+            class TestClass
+            {
+                void Test(object o)
+                {
+                    _ = o is string [|!=|] false;
+                }
+            }
+            """;
+        var modifiedCode = """
+            class TestClass
+            {
+                void Test(object o)
+                {
+                    _ = o is string;
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ShouldFixCodeWith(modifiedCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ComparisonComparedWithFalse_ParenthesizesExpression()
+    {
+        var originalCode = """
+            class TestClass
+            {
+                void Test(int a, int b)
+                {
+                    _ = a < b [|==|] false;
+                }
+            }
+            """;
+        var modifiedCode = """
+            class TestClass
+            {
+                void Test(int a, int b)
+                {
+                    _ = !(a < b);
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ShouldFixCodeWith(modifiedCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task ComparisonComparedWithTrue_KeepsExpression()
+    {
+        var originalCode = """
+            class TestClass
+            {
+                void Test(int a, int b)
+                {
+                    _ = a < b [|==|] true;
+                }
+            }
+            """;
+        var modifiedCode = """
+            class TestClass
+            {
+                void Test(int a, int b)
+                {
+                    _ = a < b;
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ShouldFixCodeWith(modifiedCode)
+              .ValidateAsync();
+    }
+
     [Theory]
     [InlineData("==", "true", null)]
     [InlineData("==", "false", "!")]


### PR DESCRIPTION
Fixes #1324

### Problem

`AvoidComparisonWithBoolConstantFixer` wrapped the kept operand in `PrefixUnaryExpression(LogicalNotExpression, ...)` without parenthesizing it. It only used the parent node when that parent was *already* a `ParenthesizedExpression`. When the operand binds less tightly than `!`, the resulting tree is structurally correct but serializes to text that re-parses differently:

```csharp
bool M(object o) => o is string == false;   // MA0073
```

was fixed to `!o is string`, which parses as `(!o) is string` and fails with `error CS0023: Operator '!' cannot be applied to operand of type 'object'`. `a < b == false` was fixed to `!a < b` and failed the same way.

### Change

The kept operand now goes through the existing `ParenthesesExtensions.Parentheses()` helper before being negated, unless it is already a `ParenthesizedExpressionSyntax`. The `Simplifier` annotation carried by the added parentheses removes them again where they are redundant, so `value == false` is still fixed to `!value` and the existing expectations are unchanged.

### Tests

Added six facts to `AvoidComparisonWithBoolConstantAnalyzerTests` covering `o is string` and `a < b` against `== true/false` and `!= true/false`. Verified they fail against the unmodified fixer (producing `!o is string` / `!a < b`) and pass with it. All 26 tests of the class pass on roslyn4.8, 4.14, 5.0, 5.6 and 5.9.

### Note for the reviewer

As mentioned in the issue, this class of defect is only caught by the `ShouldFixCodeWith` text comparison: `ApplyFix` in the test harness compiles the syntax tree rather than the final text, and the tree built by the fixer was valid. That harness limitation is tracked separately and is not addressed here.