### PR TITLE
Do not crash on an invalid regex in the .editorconfig (MA0003, MA0104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0217](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0217.md)|Design|Use a static lambda|ℹ️|❌|✔️|❌|
 |[MA0218](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0218.md)|Design|The language attribute is empty|ℹ️|✔️|❌|❌|
 |[MA0219](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md)|Design|Set the language attribute in XML comment|👻|✔️|✔️|❌|
+|[MA0220](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0220.md)|Design|The configured regular expression is not valid|⚠️|✔️|❌|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -218,6 +218,7 @@
 |[MA0217](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0217.md)|Design|Use a static lambda|<span title='Info'>ℹ️</span>|❌|✔️|❌|
 |[MA0218](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0218.md)|Design|The language attribute is empty|<span title='Info'>ℹ️</span>|✔️|❌|❌|
 |[MA0219](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md)|Design|Set the language attribute in XML comment|<span title='Hidden'>👻</span>|✔️|✔️|❌|
+|[MA0220](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0220.md)|Design|The configured regular expression is not valid|<span title='Warning'>⚠️</span>|✔️|❌|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0003.md
+++ b/docs/Rules/MA0003.md
@@ -35,6 +35,8 @@ MA0003.excluded_methods = M:A.B(System.Int32) | M:C.D()
 MA0003.excluded_methods_regex = Sample.*Test
 ````
 
+If `MA0003.excluded_methods_regex` is not a valid regular expression, no method is excluded and [MA0220](MA0220.md) is reported. No method is excluded either if the evaluation of the regular expression times out.
+
 You can annotate a parameter with `Meziantou.Analyzer.Annotations.RequireNamedArgumentAttribute`.
 To use this attribute, add the `Meziantou.Analyzer.Annotations` NuGet package (or copy the attribute source into your project). See [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md).
 

--- a/docs/Rules/MA0104.md
+++ b/docs/Rules/MA0104.md
@@ -16,6 +16,8 @@ MA0104.namespaces_regex = ^System($|\.)
 MA0104.use_preview_types = true # use types from preview versions of .NET
 ````
 
+If `MA0104.namespaces_regex` is not a valid regular expression, the default value (`^System($|\.)`) is used and [MA0220](MA0220.md) is reported.
+
 By default, the rule only applies to public types. Add the following line to the `.editorconfig` file to consider all types:
 
 ````

--- a/docs/Rules/MA0220.md
+++ b/docs/Rules/MA0220.md
@@ -1,0 +1,16 @@
+# MA0220 - The configured regular expression is not valid
+<!-- sources -->
+Source: [InvalidRegexConfigurationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InvalidRegexConfigurationAnalyzer.cs)
+<!-- sources -->
+
+Some rules can be configured with a regular expression in the `.editorconfig` file. When the value is not a valid regular expression, the option cannot be used, and the rule behaves as if the option was not set. This rule reports the invalid values, so a typo does not silently change the behavior of a rule.
+
+````
+# MA0220: The value of 'MA0104.namespaces_regex' is not a valid regular expression: Invalid pattern '[' at offset 1. Unterminated [] set.
+MA0104.namespaces_regex = [
+````
+
+The following options are validated by this rule:
+
+- [`MA0003.excluded_methods_regex`](MA0003.md)
+- [`MA0104.namespaces_regex`](MA0104.md)

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -652,3 +652,6 @@ dotnet_diagnostic.MA0218.severity = error
 
 # MA0219: Set the language attribute in XML comment
 dotnet_diagnostic.MA0219.severity = error
+
+# MA0220: The configured regular expression is not valid
+dotnet_diagnostic.MA0220.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -652,3 +652,6 @@ dotnet_diagnostic.MA0218.severity = suggestion
 
 # MA0219: Set the language attribute in XML comment
 dotnet_diagnostic.MA0219.severity = suggestion
+
+# MA0220: The configured regular expression is not valid
+dotnet_diagnostic.MA0220.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -652,3 +652,6 @@ dotnet_diagnostic.MA0218.severity = warning
 
 # MA0219: Set the language attribute in XML comment
 dotnet_diagnostic.MA0219.severity = warning
+
+# MA0220: The configured regular expression is not valid
+dotnet_diagnostic.MA0220.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -652,3 +652,6 @@ dotnet_diagnostic.MA0218.severity = suggestion
 
 # MA0219: Set the language attribute in XML comment
 dotnet_diagnostic.MA0219.severity = silent
+
+# MA0220: The configured regular expression is not valid
+dotnet_diagnostic.MA0220.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -652,3 +652,6 @@ dotnet_diagnostic.MA0218.severity = none
 
 # MA0219: Set the language attribute in XML comment
 dotnet_diagnostic.MA0219.severity = none
+
+# MA0220: The configured regular expression is not valid
+dotnet_diagnostic.MA0220.severity = none

--- a/src/Meziantou.Analyzer/Internals/RegexCache.cs
+++ b/src/Meziantou.Analyzer/Internals/RegexCache.cs
@@ -5,10 +5,71 @@ namespace Meziantou.Analyzer.Internals;
 
 internal static class RegexCache
 {
-    private static readonly ConcurrentDictionary<(string Pattern, RegexOptions Options, long TimeoutTicks), Regex> Cache = new();
+    // The patterns come from the configuration, so they can be invalid or subject to catastrophic backtracking.
+    // The timeout ensures a single pattern cannot hang the compilation.
+    private static readonly TimeSpan MatchTimeout = TimeSpan.FromSeconds(1);
+    private static readonly ConcurrentDictionary<(string Pattern, RegexOptions Options), (Regex? Regex, string? ErrorMessage)> Cache = new();
 
-    public static Regex GetOrCreate(string pattern, RegexOptions options, TimeSpan timeout)
+    /// <summary>
+    /// Gets a cached <see cref="Regex"/> for the pattern. Returns <see langword="false"/> when the pattern is invalid.
+    /// Invalid patterns are cached, so a pattern is parsed only once.
+    /// </summary>
+    public static bool TryGetOrCreate(string pattern, RegexOptions options, [NotNullWhen(true)] out Regex? regex)
     {
-        return Cache.GetOrAdd((pattern, options, timeout.Ticks), static key => new Regex(key.Pattern, key.Options, TimeSpan.FromTicks(key.TimeoutTicks)));
+        regex = GetOrCreate(pattern, options).Regex;
+        return regex is not null;
+    }
+
+    /// <summary>
+    /// Indicates whether the pattern is a valid regular expression. <paramref name="errorMessage"/> contains
+    /// the reason why the pattern is invalid.
+    /// </summary>
+    public static bool IsValidPattern(string pattern, RegexOptions options, [NotNullWhen(false)] out string? errorMessage)
+    {
+        var (regex, message) = GetOrCreate(pattern, options);
+        errorMessage = message;
+        return regex is not null;
+    }
+
+    /// <summary>
+    /// Indicates whether the pattern matches the input. Returns <paramref name="defaultValue"/> when the pattern
+    /// is invalid or when the evaluation times out.
+    /// </summary>
+    public static bool IsMatch(string pattern, RegexOptions options, string input, bool defaultValue)
+    {
+        if (!TryGetOrCreate(pattern, options, out var regex))
+            return defaultValue;
+
+        return IsMatch(regex, input, defaultValue);
+    }
+
+    /// <summary>
+    /// Indicates whether the regex matches the input. Returns <paramref name="defaultValue"/> when the evaluation times out.
+    /// </summary>
+    public static bool IsMatch(Regex regex, string input, bool defaultValue)
+    {
+        try
+        {
+            return regex.IsMatch(input);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return defaultValue;
+        }
+    }
+
+    private static (Regex? Regex, string? ErrorMessage) GetOrCreate(string pattern, RegexOptions options)
+    {
+        return Cache.GetOrAdd((pattern, options), static key =>
+        {
+            try
+            {
+                return (new Regex(key.Pattern, key.Options, MatchTimeout), null);
+            }
+            catch (ArgumentException ex)
+            {
+                return (null, ex.Message);
+            }
+        });
     }
 }

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -219,6 +219,7 @@ internal static class RuleIdentifiers
     public const string UseStaticLambda = "MA0217";
     public const string EmptyLanguageAttributeInXmlComment = "MA0218";
     public const string MissingLanguageAttributeInXmlComment = "MA0219";
+    public const string InvalidRegexConfiguration = "MA0220";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
@@ -18,8 +18,8 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
 
     private static readonly ConfigurationDefinition<bool> OnlyConsiderPublicSymbolsConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".only_consider_public_symbols", defaultValue: true);
     private static readonly ConfigurationDefinition<bool> UsePreviewTypesConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".use_preview_types", defaultValue: false);
-    private static readonly ConfigurationDefinition<string> NamespacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namespaces_regex", defaultValue: "^System($|\\.)");
-    private static readonly ConfigurationDefinition<string> LegacyNamepacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namepaces_regex", defaultValue: "^System($|\\.)") { IsHidden = true };
+    internal static readonly ConfigurationDefinition<string> NamespacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namespaces_regex", defaultValue: "^System($|\\.)");
+    internal static readonly ConfigurationDefinition<string> LegacyNamepacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namepaces_regex", defaultValue: "^System($|\\.)") { IsHidden = true };
 
     private static Dictionary<string, List<string>>? s_types;
     private static Dictionary<string, List<string>>? s_typesPreview;
@@ -53,22 +53,35 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
         var types = usePreviewTypes ? s_typesPreview : s_types;
         if (types!.TryGetValue(symbol.MetadataName, out var namespaces))
         {
-            var regex = context.Options.GetConfigurationValue(symbol, LegacyNamepacesRegexConfiguration);
-            if (context.Options.TryGetConfigurationValue(symbol, NamespacesRegexConfiguration, out var configuredRegex))
-            {
-                regex = configuredRegex;
-            }
+            var namespaceRegex = GetNamespacesRegex(context, symbol);
+            if (namespaceRegex is null)
+                return;
 
-            var namespaceRegex = RegexCache.GetOrCreate(regex, RegexOptions.None, Timeout.InfiniteTimeSpan);
             foreach (var ns in namespaces)
             {
-                if (namespaceRegex.IsMatch(ns))
+                if (RegexCache.IsMatch(namespaceRegex, ns, defaultValue: false))
                 {
                     context.ReportDiagnostic(Rule, symbol, symbol.MetadataName, ns);
                     return;
                 }
             }
         }
+    }
+
+    private static Regex? GetNamespacesRegex(SymbolAnalysisContext context, ISymbol symbol)
+    {
+        var pattern = context.Options.GetConfigurationValue(symbol, LegacyNamepacesRegexConfiguration);
+        if (context.Options.TryGetConfigurationValue(symbol, NamespacesRegexConfiguration, out var configuredPattern))
+        {
+            pattern = configuredPattern;
+        }
+
+        if (RegexCache.TryGetOrCreate(pattern, RegexOptions.None, out var regex))
+            return regex;
+
+        // The configured pattern is invalid, so fallback to the default pattern instead of failing the analysis
+        RegexCache.TryGetOrCreate(NamespacesRegexConfiguration.DefaultValue, RegexOptions.None, out regex);
+        return regex;
     }
 
     private static Dictionary<string, List<string>> LoadTypes(bool preview)

--- a/src/Meziantou.Analyzer/Rules/InvalidRegexConfigurationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InvalidRegexConfigurationAnalyzer.cs
@@ -1,0 +1,66 @@
+using System.Text.RegularExpressions;
+using Meziantou.Analyzer.Configurations;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidRegexConfigurationAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.InvalidRegexConfiguration,
+        title: "The configured regular expression is not valid",
+        messageFormat: "The value of '{0}' is not a valid regular expression: {1}",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InvalidRegexConfiguration));
+
+    /// <summary>
+    /// The options whose value must be a valid regular expression. The rules ignore an invalid value,
+    /// so this rule is the only way for the user to know the option is not applied.
+    /// </summary>
+    private static readonly ConfigurationDefinition<string>[] RegexConfigurations =
+    [
+        NamedParameterAnalyzer.ExcludedMethodsRegexConfiguration,
+        DotNotUseNameFromBCLAnalyzer.NamespacesRegexConfiguration,
+        DotNotUseNameFromBCLAnalyzer.LegacyNamepacesRegexConfiguration,
+    ];
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationAction(AnalyzeCompilation);
+    }
+
+    private static void AnalyzeCompilation(CompilationAnalysisContext context)
+    {
+        // The options can be different for each syntax tree, but a value must be reported only once
+        HashSet<(string Key, string Value)>? reportedValues = null;
+
+        foreach (var syntaxTree in context.Compilation.SyntaxTrees)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            var options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
+            foreach (var configuration in RegexConfigurations)
+            {
+                if (!options.TryGetValue(configuration.Key, out var value))
+                    continue;
+
+                reportedValues ??= [];
+                if (!reportedValues.Add((configuration.Key, value)))
+                    continue;
+
+                if (!RegexCache.IsValidPattern(value, RegexOptions.None, out var errorMessage))
+                {
+                    context.ReportDiagnostic(Rule, Location.None, configuration.Key, errorMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
@@ -22,7 +22,7 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseNamedParameter));
 
-    private static readonly ConfigurationDefinition<string> ExcludedMethodsRegexConfiguration = new(RuleIdentifiers.UseNamedParameter + ".excluded_methods_regex");
+    internal static readonly ConfigurationDefinition<string> ExcludedMethodsRegexConfiguration = new(RuleIdentifiers.UseNamedParameter + ".excluded_methods_regex");
     private static readonly ConfigurationDefinition<string> ExcludedMethodsConfiguration = new(RuleIdentifiers.UseNamedParameter + ".excluded_methods");
     private static readonly ConfigurationDefinition<string> MinimumMethodParametersConfiguration = new(RuleIdentifiers.UseNamedParameter + ".minimum_method_parameters", defaultValue: string.Empty);
     private static readonly ConfigurationDefinition<string> ExpressionKindsConfiguration = new(RuleIdentifiers.UseNamedParameter + ".expression_kinds", defaultValue: string.Empty);
@@ -278,12 +278,8 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
                         if (syntaxContext.Options.TryGetConfigurationValue(expression.SyntaxTree, ExcludedMethodsRegexConfiguration, out var excludedMethodsRegex))
                         {
                             var declarationId = DocumentationCommentId.CreateDeclarationId(invokedMethodSymbol);
-                            if (declarationId is not null)
-                            {
-                                var regex = RegexCache.GetOrCreate(excludedMethodsRegex, RegexOptions.Compiled, Timeout.InfiniteTimeSpan);
-                                if (regex.IsMatch(declarationId))
-                                    return;
-                            }
+                            if (declarationId is not null && RegexCache.IsMatch(excludedMethodsRegex, RegexOptions.None, declarationId, defaultValue: false))
+                                return;
                         }
 
                         if (syntaxContext.Options.TryGetConfigurationValue(expression.SyntaxTree, ExcludedMethodsConfiguration, out var excludedMethods))

--- a/tests/Meziantou.Analyzer.Test/Rules/DotNotUseNameFromBCLAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DotNotUseNameFromBCLAnalyzerTests.cs
@@ -76,4 +76,22 @@ public sealed class DotNotUseNameFromBCLAnalyzerTests
               .AddAnalyzerConfiguration("MA0104.namepaces_regex", "dummy")
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task InvalidRegex_UseDefaultRegex()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(@"public class [|Action|] { }")
+              .AddAnalyzerConfiguration("MA0104.namespaces_regex", "[")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InvalidRegex_UseDefaultRegex_OldConfigurationName()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(@"public class [|Action|] { }")
+              .AddAnalyzerConfiguration("MA0104.namepaces_regex", "[")
+              .ValidateAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/InvalidRegexConfigurationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InvalidRegexConfigurationAnalyzerTests.cs
@@ -1,0 +1,66 @@
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class InvalidRegexConfigurationAnalyzerTests
+{
+    private static ProjectBuilder CreateProjectBuilder()
+    {
+        return new ProjectBuilder()
+            .WithAnalyzer<InvalidRegexConfigurationAnalyzer>();
+    }
+
+    [Fact]
+    public async Task NoConfiguration_DoNotReportDiagnostic()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("class Test { }")
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("MA0003.excluded_methods_regex")]
+    [InlineData("MA0104.namespaces_regex")]
+    [InlineData("MA0104.namepaces_regex")]
+    public async Task ValidRegex_DoNotReportDiagnostic(string key)
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("class Test { }")
+              .AddAnalyzerConfiguration(key, "^System($|\\.)")
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("MA0003.excluded_methods_regex")]
+    [InlineData("MA0104.namespaces_regex")]
+    [InlineData("MA0104.namepaces_regex")]
+    public async Task InvalidRegex_ReportDiagnostic(string key)
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("class Test { }")
+              .AddAnalyzerConfiguration(key, "[")
+              .ShouldReportDiagnostic(new DiagnosticResult { Id = "MA0220" })
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task InvalidRegex_ReportDiagnosticOnlyOnceForMultipleFiles()
+    {
+        var builder = CreateProjectBuilder()
+              .WithSourceCode("class Test1 { }")
+              .AddAnalyzerConfiguration("MA0104.namespaces_regex", "[")
+              .ShouldReportDiagnostic(new DiagnosticResult { Id = "MA0220" });
+        builder.ApiReferences.Add("class Test2 { }");
+
+        await builder.ValidateAsync();
+    }
+
+    [Fact]
+    public async Task MultipleInvalidRegex_ReportOneDiagnosticPerConfiguration()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("class Test { }")
+              .AddAnalyzerConfiguration("MA0003.excluded_methods_regex", "[")
+              .AddAnalyzerConfiguration("MA0104.namespaces_regex", "(")
+              .ShouldReportDiagnostic(new DiagnosticResult { Id = "MA0220" }, new DiagnosticResult { Id = "MA0220" })
+              .ValidateAsync();
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -394,7 +394,29 @@ public sealed class NamedParameterAnalyzerTests
             """;
         await CreateProjectBuilder()
               .WithSourceCode(SourceCode)
+              .AddAnalyzerConfiguration("MA0003.expression_kinds", "numeric")
               .AddAnalyzerConfiguration("MA0003.excluded_methods_regex", "M[a-z][A-Z]ethod")
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Int32_ExcludedMethodWithInvalidRegex_ShouldReportDiagnostic()
+    {
+        const string SourceCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    MyMethod([|1|], [|1L|], [|3|]);
+                }
+
+                void MyMethod(int a, long b, short c) { }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .AddAnalyzerConfiguration("MA0003.expression_kinds", "numeric")
+              .AddAnalyzerConfiguration("MA0003.excluded_methods_regex", "[")
               .ValidateAsync();
     }
 


### PR DESCRIPTION
Fixes #1329

A regex coming from the `.editorconfig` was passed straight to `new Regex(...)`, with no `try`/`catch` and with `Timeout.InfiniteTimeSpan`. One typo in a shared `.editorconfig` (`MA0104.namespaces_regex = [`) crashed the analyzer with `AD0001` on every build, and a pattern with catastrophic backtracking would hang the compilation thread instead of failing.

## What changed

**`RegexCache`** now owns both concerns:

- The pattern is parsed once, `ArgumentException` is caught, and the failure (plus its message) is cached, so an invalid pattern never throws and is never re-parsed.
- A fixed 1 second match timeout replaces `Timeout.InfiniteTimeSpan`, and `IsMatch` catches `RegexMatchTimeoutException`, so a catastrophic pattern degrades to "no match" instead of hanging or crashing. `RegexOptions.NonBacktracking` was not an option: the analyzer also targets `netstandard2.0`.
- The timeout is no longer part of the cache key, since callers cannot choose it anymore.

**Call sites**

- `MA0104`: an invalid `namespaces_regex` (or the legacy `namepaces_regex`) falls back to the default `^System($|\.)`.
- `MA0003`: an invalid `excluded_methods_regex` excludes no method.
- `MA0003` no longer passes `RegexOptions.Compiled` for a pattern matched a handful of times per compilation: `RegexCache` is a process-lifetime static, so the compiled entries were pinning emitted IL that is never reclaimed. The cache is still unbounded, but it now only holds interpreted `Regex` objects keyed by the few patterns of an `.editorconfig`.

**New rule `MA0220` - The configured regular expression is not valid**

Silently ignoring the value would leave the user with a rule that does not behave as configured and no way to know why, so the invalid values are reported:

```
MA0220: The value of 'MA0104.namespaces_regex' is not a valid regular expression: Invalid pattern '[' at offset 1. Unterminated [] set.
```

It is a dedicated analyzer with a single `RegisterCompilationAction`, not a diagnostic reported by `MA0003`/`MA0104` themselves, because the error is not tied to a symbol or a node, reporting it from the rule analyzers would repeat it for every symbol or argument, and `MA0104` is disabled by default so its analyzer may never run. The action walks the syntax trees of the compilation (the options can differ per tree) and reports each distinct invalid `(key, value)` once. The keys come from the existing `ConfigurationDefinition` fields, now `internal` instead of `private`, so there is no second list of key names to keep in sync.

## Notes for the reviewer

- **The diagnostic has no location**, as `.editorconfig` is not part of the compilation. It shows as a project level warning, and it can be configured through `NoWarn` or a global AnalyzerConfig (which is what the packaged `configuration/*.editorconfig` files are), but not through a `[*.cs]` section.
- **Severity is `Warning`, enabled by default.** The issue suggested an informational diagnostic, but the closest precedent in the repository, `MA0125` (`LoggerParameterType_InvalidType`), is a default-on warning, and an `Info` diagnostic without a location is nearly invisible in a normal build. Happy to switch it to `Info`.
- **The rule is regex specific.** If one rule for any invalid option value is preferable, so future validations reuse it, only the title and the message need rewording: the `RegexConfigurations` array is already the extension point.
- The existing `Int32_ExcludedMethod_ShouldNotReportDiagnostic` test was passing vacuously (its source reported nothing under the default `expression_kinds`, so the exclusion regex was never exercised); it now sets `MA0003.expression_kinds = numeric`.

## Validation

- The three tests of the fix fail on the code before it and pass after it.
- `dotnet run --project src/DocumentationGenerator` reports no further change.
- `dotnet build`: 0 warnings. `dotnet test`: 18754 tests pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
