### PR TITLE
Fix MA0026 crash on an unterminated block comment (#1328)

### DIFF
--- a/src/Meziantou.Analyzer/Rules/FixToDoAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FixToDoAnalyzer.cs
@@ -41,7 +41,11 @@ public sealed class FixToDoAnalyzer : DiagnosticAnalyzer
             else if (node.IsKind(SyntaxKind.MultiLineCommentTrivia))
             {
                 var nodeText = node.ToString().AsSpan();
-                nodeText = nodeText[2..^2]; // Remove leading "/*" and trailing "*/"
+                nodeText = nodeText[2..]; // Remove leading "/*"
+                if (nodeText.EndsWith("*/".AsSpan(), StringComparison.Ordinal))
+                {
+                    nodeText = nodeText[..^2]; // Remove trailing "*/"
+                }
 
                 var startIndex = node.SpanStart + 2;
                 foreach (var line in nodeText.SplitLines())

--- a/tests/Meziantou.Analyzer.Test/Rules/FixToDoAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FixToDoAnalyzerTests.cs
@@ -56,6 +56,35 @@ public sealed class FixToDoAnalyzerTests
               .ValidateAsync();
     }
 
+    [Theory]
+    [InlineData("/*")]
+    [InlineData("/*a")]
+    [InlineData("/*/")]
+    [InlineData("/*ab")]
+    [InlineData("/*test")]
+    public async Task UnterminatedMultiLinesCommentWithoutTodo(string comment)
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(comment)
+              .WithNoCompilation()
+              .ValidateAsync();
+    }
+
+    [Theory]
+    [InlineData("/*[|TODO|]", "")]
+    [InlineData("/* [|TODO|]", "")]
+    [InlineData("/*[|TODO test|]", "test")]
+    [InlineData("/* [|TODO test|]", "test")]
+    [InlineData("/*\n* [|TODO test|]", "test")]
+    public async Task UnterminatedMultiLinesComment(string comment, string todo)
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode(comment)
+              .WithNoCompilation()
+              .ShouldReportDiagnosticWithMessage($"TODO {todo}")
+              .ValidateAsync();
+    }
+
     [Fact]
     public async Task MultiTodoComment()
     {


### PR DESCRIPTION
Fixes #1328

## What

`FixToDoAnalyzer` sliced multi-line comment trivia with `nodeText[2..^2]`, assuming the trivia is at least 4 characters long **and** terminated by `*/`. Roslyn still produces a `MultiLineCommentTrivia` for an unterminated comment, so `/*`, `/*a` and `/*/` made the analyzer throw `ArgumentOutOfRangeException`, surfaced as `AD0001`.

The trailing `*/` is now removed only when the text actually ends with it.

## Why

MA0026 is enabled by default at Warning, and the trigger is the ordinary act of typing `/*` at the end of a file: every keystroke until the closing `*/` produced an analyzer crash in the IDE. On a command-line build of a file that genuinely ends with `/*`, the rule was silently disabled for the whole compilation.

## Tests

10 new cases in `FixToDoAnalyzerTests`, using `WithNoCompilation()` since unterminated comments do not compile:

- the three repros from the issue plus the already-working `/*ab` / `/*test`;
- unterminated comments that do contain a TODO, so the diagnostic and its span are still correct without the closing `*/`.

Reverting only the analyzer change makes 8 of the 10 new cases fail; the two that still pass are `/*ab` and `/*test`, exactly the length >= 4 cases the issue notes were already fine.

## Verification

- `FixToDoAnalyzerTests` pass on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9), 33 tests each.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown change.