### PR TITLE
Fix MA0028 code fixer producing uncompilable code (#1327)

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
@@ -46,6 +46,14 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
                 break;
 
             case OptimizeStringBuilderUsageData.SplitAddOperator:
+                var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                if (semanticModel?.GetOperation(nodeToFix, context.CancellationToken) is not IInvocationOperation { Arguments: [{ Value: IBinaryOperation binaryOperation }, ..] })
+                    return;
+
+                // "value" + charArray uses char[].ToString(), whereas Append(char[]) appends the content of the array
+                if (IsCharArray(binaryOperation.LeftOperand) || IsCharArray(binaryOperation.RightOperand))
+                    return;
+
                 context.RegisterCodeFix(CodeAction.Create(title, ct => SplitAddOperator(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
@@ -166,10 +174,36 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
         var binaryOperation = (IBinaryOperation)operation.Arguments[0].Value;
 
         var newExpression = generator.InvocationExpression(generator.MemberAccessExpression(operation.GetChildOperations().First().Syntax, "Append"), binaryOperation.LeftOperand.Syntax);
-        newExpression = generator.InvocationExpression(generator.MemberAccessExpression(newExpression, isAppendLine ? "AppendLine" : "Append"), binaryOperation.RightOperand.Syntax);
+        if (isAppendLine && !IsString(binaryOperation.RightOperand))
+        {
+            // AppendLine has no overload for the type of the operand, so the value must be appended before the line terminator
+            newExpression = generator.InvocationExpression(generator.MemberAccessExpression(newExpression, "Append"), binaryOperation.RightOperand.Syntax);
+            newExpression = generator.InvocationExpression(generator.MemberAccessExpression(newExpression, "AppendLine"));
+        }
+        else
+        {
+            newExpression = generator.InvocationExpression(generator.MemberAccessExpression(newExpression, isAppendLine ? "AppendLine" : "Append"), binaryOperation.RightOperand.Syntax);
+        }
 
         editor.ReplaceNode(nodeToFix, newExpression);
         return editor.GetChangedDocument();
+    }
+
+    private static bool IsString(IOperation operation)
+    {
+        // An operand of a string concatenation has no type when it is the 'null' or 'default' literal, in which case it is converted to string
+        return operation.Type is null || operation.Type.IsString();
+    }
+
+    private static bool IsCharArray(IOperation operation)
+    {
+        // A non-string operand of a string concatenation is implicitly converted to object
+        if (operation is IConversionOperation { IsImplicit: true, Type.SpecialType: SpecialType.System_Object } conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation.Type is IArrayTypeSymbol { Rank: 1, ElementType.SpecialType: SpecialType.System_Char };
     }
 
     private static async Task<Document> RemoveToString(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -543,6 +543,141 @@ class Test
     }
 
     [Fact]
+    public async Task AppendLine_StringAdd_NonStringRightOperand()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System.Text;
+                class Test
+                {
+                    void A(int count)
+                    {
+                        [|new StringBuilder().AppendLine("a" + count)|];
+                    }
+                }
+                """)
+              .ShouldFixCodeWith("""
+                using System.Text;
+                class Test
+                {
+                    void A(int count)
+                    {
+                        new StringBuilder().Append("a").Append(count).AppendLine();
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task Append_StringAdd_NonStringRightOperand()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System.Text;
+                class Test
+                {
+                    void A(int count)
+                    {
+                        [|new StringBuilder().Append("a" + count)|];
+                    }
+                }
+                """)
+              .ShouldFixCodeWith("""
+                using System.Text;
+                class Test
+                {
+                    void A(int count)
+                    {
+                        new StringBuilder().Append("a").Append(count);
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task AppendLine_StringAdd_NonStringLeftOperand()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System.Text;
+                class Test
+                {
+                    void A(int count, string suffix)
+                    {
+                        [|new StringBuilder().AppendLine(count + suffix)|];
+                    }
+                }
+                """)
+              .ShouldFixCodeWith("""
+                using System.Text;
+                class Test
+                {
+                    void A(int count, string suffix)
+                    {
+                        new StringBuilder().Append(count).AppendLine(suffix);
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task AppendLine_StringAdd_NullRightOperand()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System.Text;
+                class Test
+                {
+                    void A(string prefix)
+                    {
+                        [|new StringBuilder().AppendLine(prefix + null)|];
+                    }
+                }
+                """)
+              .ShouldFixCodeWith("""
+                using System.Text;
+                class Test
+                {
+                    void A(string prefix)
+                    {
+                        new StringBuilder().Append(prefix).AppendLine(null);
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task AppendLine_StringAdd_CharArrayOperand_NoCodeFix()
+    {
+        await CreateProjectBuilder()
+              .WithSourceCode("""
+                using System.Text;
+                class Test
+                {
+                    void A(char[] value)
+                    {
+                        [|new StringBuilder().AppendLine("a" + value)|];
+                    }
+                }
+                """)
+              .ShouldFixCodeWith("""
+                using System.Text;
+                class Test
+                {
+                    void A(char[] value)
+                    {
+                        new StringBuilder().AppendLine("a" + value);
+                    }
+                }
+                """)
+              .ValidateAsync();
+    }
+
+    [Fact]
     public async Task Append_ToString()
     {
         await CreateProjectBuilder()


### PR DESCRIPTION
Fixes #1327

## What changed

`OptimizeStringBuilderUsageFixer.SplitAddOperator` emitted `.Append(left).AppendLine(right)` whatever the type of the right operand. The analyzer reports `SplitAddOperator` as soon as the *result* of the `+` is a string, so the operands need not be strings, and `StringBuilder.AppendLine` only has the `()`, `(string)` and interpolated string handler overloads.

```csharp
sb.AppendLine("a" + count); // MA0028
```

was fixed to `sb.Append("a").AppendLine(count)`, which fails with `error CS1503: Argument 1: cannot convert from 'int' to 'string?'`.

The fixer now emits `.Append(left).Append(right).AppendLine()` when the target is `AppendLine` and the right operand is not a string.

## Notes for the reviewer

- An operand with no type is the `null` or `default` literal, which is converted to `string` in a concatenation. It keeps using `AppendLine(null)`, as `Append(null)` would be ambiguous between `Append(string)`, `Append(char[])` and `Append(object)`.
- The new shape would compile for a `char[]` operand while silently changing the behavior: `"a" + charArray` uses `char[].ToString()` (`"aSystem.Char[]"`) whereas `Append(char[])` appends the content of the array. The fix is no longer offered when an operand is a `char[]`, which also covers the `Append` case that had the same divergence. The diagnostic is still reported, only the code fix is not offered.
- Both checks are done in `RegisterCodeFixesAsync`, before registering the code fix.
- `docs/Rules/MA0028.md` only documents the `Append` example, which is unchanged, so the documentation generator produces no change.

## Tests

Five cases added to `OptimizeStringBuilderUsageAnalyzerTests`: non-string right operand for `AppendLine` and for `Append`, non-string left operand, `null` right operand, and the `char[]` operand for which no code fix is applied. The input `"a" + 10` was already in the `AppendLine_ReportDiagnostic` theory, but without `ShouldFixCodeWith`, so the broken output was never exercised.

- `OptimizeStringBuilderUsageAnalyzerTests`: 100/100 on roslyn4.8, roslyn4.14, roslyn5.0, roslyn5.6 and roslyn5.9
- `Meziantou.Analyzer.Test.roslyn5.9`: 3823/3823