### PR TITLE
Fix MA0050 code fixer producing an extension local function (CS1106)

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateArgumentsCorrectlyFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateArgumentsCorrectlyFixer.cs
@@ -58,7 +58,7 @@ public sealed class ValidateArgumentsCorrectlyFixer : CodeFixProvider
         // Create local function
         var returnTypeSyntax = generator.TypeExpression(symbol.ReturnType);
         var localFunctionSyntaxNode = LocalFunctionStatement((TypeSyntax)returnTypeSyntax, symbol.Name);
-        localFunctionSyntaxNode = localFunctionSyntaxNode.WithParameterList(CopyParametersWithoutDefaultValues(methodSyntaxNode.ParameterList));
+        localFunctionSyntaxNode = localFunctionSyntaxNode.WithParameterList(CreateLocalFunctionParameterList(methodSyntaxNode.ParameterList));
         if (methodSyntaxNode.Modifiers.Any(m => m.IsKind(SyntaxKind.AsyncKeyword)))
         {
             localFunctionSyntaxNode = localFunctionSyntaxNode.AddModifiers(Token(SyntaxKind.AsyncKeyword));
@@ -95,9 +95,13 @@ public sealed class ValidateArgumentsCorrectlyFixer : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
-    private static ParameterListSyntax CopyParametersWithoutDefaultValues(ParameterListSyntax parameterListSyntax)
+    private static ParameterListSyntax CreateLocalFunctionParameterList(ParameterListSyntax parameterListSyntax)
     {
-        return ParameterList(SeparatedList(parameterListSyntax.Parameters.Select(p => p.WithDefault(null))));
+        // Default values are useless as the local function is always called with all the arguments.
+        // The "this" modifier must be removed as a local function cannot be an extension method (CS1106).
+        return ParameterList(SeparatedList(parameterListSyntax.Parameters.Select(p => p
+            .WithDefault(null)
+            .WithModifiers(TokenList(p.Modifiers.Where(modifier => !modifier.IsKind(SyntaxKind.ThisKeyword)))))));
     }
 
     private static ParameterListSyntax RemoveEnumeratorCancellationAttribute(ParameterListSyntax parameterListSyntax, SemanticModel semanticModel, CancellationToken cancellationToken)

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
@@ -465,4 +465,47 @@ class TypeName
               .ShouldFixCodeWith(CodeFix)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task ReportDiagnostic_ExtensionMethod()
+    {
+        const string SourceCode = """
+            using System;
+            using System.Collections.Generic;
+            static class TypeName
+            {
+                public static IEnumerable<int> [|A|](this string a)
+                {
+                    if (a is null)
+                        throw new ArgumentNullException(nameof(a));
+
+                    yield return 1;
+                }
+            }
+            """;
+
+        const string CodeFix = """
+            using System;
+            using System.Collections.Generic;
+            static class TypeName
+            {
+                public static IEnumerable<int> A(this string a)
+                {
+                    if (a is null)
+                        throw new ArgumentNullException(nameof(a));
+
+                    return A(a);
+                    IEnumerable<int> A(string a)
+                    {
+                        yield return 1;
+                    }
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ShouldFixCodeWith(CodeFix)
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
Fixes #1325

## What changed

`ValidateArgumentsCorrectlyFixer.CopyParametersWithoutDefaultValues` stripped default values but kept every parameter modifier when building the generated local function's parameter list — including `this`.

The analyzer accepts extension methods: its only parameter guard is `Parameters.All(p => p.RefKind == RefKind.None)`, and an extension receiver has `RefKind.None`. So applying the fix to an extension iterator method generated a local function declared as an extension method, which does not compile:

```
error CS1106: Extension method must be defined in a non-generic static class
```

The method now also removes the `this` modifier, and was renamed `CreateLocalFunctionParameterList` since it no longer only strips defaults.

## Why `params` and `scoped` are left alone

The issue suggested defensively stripping `params` and `scoped` as well. I did not:

- `params` is legal on a local function, and the forwarding call passes the array through directly, so keeping it is both valid and semantics-preserving.
- Stripping `scoped` would be a regression rather than a defense — passing a scoped argument to a non-scoped parameter is a ref-safety error. (Moot in practice, since iterator methods cannot have ref struct parameters.)

Only `this` is actually invalid on a local function, so only `this` is removed.

## Test

Added `ReportDiagnostic_ExtensionMethod` using the repro from the issue — there was no extension-method fixture in the existing tests.

I verified the test actually guards the regression: with the fixer reverted it fails (the harness compiles the fixer output, so CS1106 surfaces), and it passes with the fix in place.

## Verification

- All 17 tests of `ValidateArgumentsCorrectlyAnalyzerTests` pass on every supported Roslyn version (4.8, 4.14, 5.0, 5.6, 5.9).
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes, as expected for a code-fixer-only change.