### PR TITLE
Fail the tests when an analyzer throws

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilder.Validation.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Meziantou.Analyzer.Internals;
@@ -375,10 +376,18 @@ public sealed partial class ProjectBuilder
                 ? analyzers.Select(analyzer => (DiagnosticAnalyzer)new GeneratedCodeAnalysisAnalyzer(analyzer, generatedCodeAnalysisFlags)).ToArray()
                 : analyzers;
 
+            // Report the exceptions thrown by the analyzers instead of letting Roslyn convert them to AD0001 diagnostics,
+            // as those diagnostics may be filtered out before the assertions
+            var analyzerExceptions = new ConcurrentBag<(DiagnosticAnalyzer Analyzer, Exception Exception)>();
             var compilationWithAnalyzers = compilation.WithAnalyzers(
                 ImmutableArray.CreateRange(effectiveAnalyzers),
-                new AnalyzerOptions(additionalFiles, analyzerOptionsProvider));
+                new CompilationWithAnalyzersOptions(
+                    new AnalyzerOptions(additionalFiles, analyzerOptionsProvider),
+                    onAnalyzerException: (exception, analyzer, _) => analyzerExceptions.Add((analyzer, exception)),
+                    concurrentAnalysis: true,
+                    logAnalyzerExecutionTime: false));
             var diags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(CancellationToken.None).ConfigureAwait(false);
+            AssertNoAnalyzerException(analyzerExceptions, diags);
             foreach (var diag in diags)
             {
                 if (diag.Location == Location.None || diag.Location.IsInMetadata || !diag.Location.IsInSource)
@@ -403,6 +412,21 @@ public sealed partial class ProjectBuilder
         var results = SortDiagnostics(diagnostics);
         diagnostics.Clear();
         return results;
+    }
+
+    private static void AssertNoAnalyzerException(IReadOnlyCollection<(DiagnosticAnalyzer Analyzer, Exception Exception)> analyzerExceptions, ImmutableArray<Diagnostic> diagnostics)
+    {
+        if (analyzerExceptions.Count > 0)
+        {
+            Assert.Fail("An analyzer threw an exception:\n\n" + string.Join("\n\n", analyzerExceptions.Select(item => item.Analyzer.GetType().FullName + ": " + item.Exception)));
+        }
+
+        // Safety net in case Roslyn reports the exception without calling the handler
+        var analyzerFailures = diagnostics.Where(diagnostic => diagnostic.Id is "AD0001").ToArray();
+        if (analyzerFailures.Length > 0)
+        {
+            Assert.Fail("An analyzer threw an exception:\n\n" + string.Join("\n\n", analyzerFailures.Select(diagnostic => diagnostic.GetMessage(CultureInfo.InvariantCulture))));
+        }
     }
 
     private static string FormatDiagnostics(IList<DiagnosticAnalyzer> analyzers, params Diagnostic[] diagnostics)

--- a/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilderValidationTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/ProjectBuilderValidationTests.cs
@@ -59,6 +59,39 @@ public sealed class ProjectBuilderValidationTests
             .ValidateAsync();
     }
 
+    [Fact]
+    public async Task VerifyDiagnostic_ReportsAnalyzerException()
+    {
+        // The exception is reported by Roslyn as an AD0001 diagnostic, which the default analyzer id would filter out
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => new ProjectBuilder()
+            .WithAnalyzer(new ThrowingAnalyzer(), id: "TEST0002")
+            .WithSourceCode("""
+                class TestClass
+                {
+                    bool Test(object o) => o is string;
+                }
+                """)
+            .ValidateAsync());
+
+        Assert.Contains("An analyzer threw an exception", exception.Message);
+        Assert.Contains(nameof(ThrowingAnalyzer), exception.Message);
+    }
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class ThrowingAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new("TEST0002", "Throw", "Throw", "Test", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(_ => throw new InvalidOperationException("Analyzer failure"), SyntaxKind.IsExpression);
+        }
+    }
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     private sealed class TypeCheckAnalyzer : DiagnosticAnalyzer
     {


### PR DESCRIPTION
Fixes #1331

## What changed

`VerifyDiagnosticResults` filters the actual diagnostics by the configured default rule id **before** counting them. Roslyn surfaces an analyzer exception as an `AD0001` diagnostic with `Location.None`: `GetSortedDiagnosticsFromDocuments` did add it to the list, and this filter then discarded it. In a test that expects zero diagnostics, expected and actual were both `0` and the test was green even though the analyzer threw.

The harness now passes `CompilationWithAnalyzersOptions` with an `onAnalyzerException` handler that records the exception, and `AssertNoAnalyzerException` fails right after `GetAnalyzerDiagnosticsAsync` — before the `DefaultAnalyzerId` filter, before sorting, and on the code fix paths too, as all of them go through `GetSortedDiagnosticsFromDocuments`. The failure message contains the analyzer type and the full exception with its stack trace, which is more actionable than the `AD0001` message. A check on the `AD0001` diagnostics remains as a safety net in case Roslyn ever reports a failure without invoking the handler.

`VerifyDiagnostic_ReportsAnalyzerException` covers it: an analyzer that throws, registered with `id:` so the `DefaultAnalyzerId` filtering is active, and no expected diagnostic — the exact shape that was silently green before.

## Verification

- `dotnet test --max-parallel-test-modules 2`: 18789 passed, 0 failed, for the 5 Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9). The `CompilationWithAnalyzersOptions` constructor overload works on 4.8.
- No pre-existing crash surfaced: the two issues filed alongside are already fixed on `main` (60df5ba, c6054ab).
- `dotnet run --project src/DocumentationGenerator` exits 0 and does not change any markdown file, as this is a test-only change.

## Not included: the same filter hiding a second rule

The issue also mentions that the `DefaultAnalyzerId` filter hides a wrong second rule from the multi-descriptor analyzers. Removing the filter breaks 27 tests on roslyn5.9: `OptimizeLinqUsageAnalyzer` (12), `UseStringComparisonAnalyzer` (5), `UseLangwordInXmlComment` (3), `ConcurrentDictionaryMustPreventClosureWhenAccessingTheKey` (3), and 4 others. Each one needs a decision on whether the second diagnostic is expected or a false positive, so this PR leaves it out rather than blanket-annotating them. Happy to do it in a follow-up.