### PR TITLE
Fix the MA0090 code fixer deleting the enclosing else block

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveEmptyBlockFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveEmptyBlockFixer.cs
@@ -12,47 +12,40 @@ public sealed class RemoveEmptyBlockFixer : CodeFixProvider
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        if (nodeToFix is null)
-            return;
 
-        if (nodeToFix is ElseClauseSyntax || nodeToFix.AncestorsAndSelf().OfType<ElseClauseSyntax>().FirstOrDefault() is not null)
+        // The analyzer reports the diagnostic on the clause itself, so the node kind determines the fix.
+        // Walking up the ancestors would pick the enclosing else clause of a nested finally clause.
+        switch (root?.FindNode(context.Span, getInnermostNodeForTie: true))
         {
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    "Remove empty else block",
-                    ct => RemoveElseClause(context.Document, nodeToFix, ct),
-                    equivalenceKey: "Remove empty else block"),
-                context.Diagnostics);
-        }
-        else if (nodeToFix is FinallyClauseSyntax || nodeToFix.AncestorsAndSelf().OfType<FinallyClauseSyntax>().FirstOrDefault() is not null)
-        {
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    "Remove empty finally block",
-                    ct => RemoveFinallyClause(context.Document, nodeToFix, ct),
-                    equivalenceKey: "Remove empty finally block"),
-                context.Diagnostics);
+            case ElseClauseSyntax { Parent: IfStatementSyntax ifStatement }:
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        "Remove empty else block",
+                        ct => RemoveElseClause(context.Document, ifStatement, ct),
+                        equivalenceKey: "Remove empty else block"),
+                    context.Diagnostics);
+                break;
+
+            case FinallyClauseSyntax { Parent: TryStatementSyntax tryStatement }:
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        "Remove empty finally block",
+                        ct => RemoveFinallyClause(context.Document, tryStatement, ct),
+                        equivalenceKey: "Remove empty finally block"),
+                    context.Diagnostics);
+                break;
         }
     }
 
-    private static async Task<Document> RemoveElseClause(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static async Task<Document> RemoveElseClause(Document document, IfStatementSyntax ifStatement, CancellationToken cancellationToken)
     {
-        var elseClause = nodeToFix as ElseClauseSyntax ?? nodeToFix.AncestorsAndSelf().OfType<ElseClauseSyntax>().FirstOrDefault();
-        if (elseClause?.Parent is not IfStatementSyntax ifStatement)
-            return document;
-
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         editor.ReplaceNode(ifStatement, ifStatement.WithElse(null).WithAdditionalAnnotations(Formatter.Annotation));
         return editor.GetChangedDocument();
     }
 
-    private static async Task<Document> RemoveFinallyClause(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static async Task<Document> RemoveFinallyClause(Document document, TryStatementSyntax tryStatement, CancellationToken cancellationToken)
     {
-        var finallyClause = nodeToFix as FinallyClauseSyntax ?? nodeToFix.AncestorsAndSelf().OfType<FinallyClauseSyntax>().FirstOrDefault();
-        if (finallyClause?.Parent is not TryStatementSyntax tryStatement)
-            return document;
-
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         if (tryStatement.Catches.Count > 0)
         {

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveEmptyBlockAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveEmptyBlockAnalyzerTests.cs
@@ -333,4 +333,111 @@ public sealed class RemoveEmptyBlockAnalyzerTests
               .WithSourceCode(SourceCode)
               .ValidateAsync();
     }
+
+    [Fact]
+    public async Task EmptyFinallyBlockInsideElseBlock_CodeFix()
+    {
+        const string SourceCode = """
+            class Test
+            {
+                void Foo() => throw null;
+                void A(bool condition)
+                {
+                    if (condition)
+                    {
+                        Foo();
+                    }
+                    else
+                    {
+                        try
+                        {
+                            Foo();
+                        }
+                        [|finally
+                        {
+                        }|]
+                    }
+                }
+            }
+            """;
+
+        const string FixedCode = """
+            class Test
+            {
+                void Foo() => throw null;
+                void A(bool condition)
+                {
+                    if (condition)
+                    {
+                        Foo();
+                    }
+                    else
+                    {
+                        {
+                            Foo();
+                        }
+                    }
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ShouldFixCodeWith(FixedCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task EmptyElseBlockInsideFinallyBlock_CodeFix()
+    {
+        const string SourceCode = """
+            class Test
+            {
+                void Foo() => throw null;
+                void A(bool condition)
+                {
+                    try
+                    {
+                        Foo();
+                    }
+                    finally
+                    {
+                        if (condition)
+                        {
+                            Foo();
+                        }
+                        [|else
+                        {
+                        }|]
+                    }
+                }
+            }
+            """;
+
+        const string FixedCode = """
+            class Test
+            {
+                void Foo() => throw null;
+                void A(bool condition)
+                {
+                    try
+                    {
+                        Foo();
+                    }
+                    finally
+                    {
+                        if (condition)
+                        {
+                            Foo();
+                        }
+                    }
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ShouldFixCodeWith(FixedCode)
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
## Problem

`RemoveEmptyBlockFixer.RegisterCodeFixesAsync` tested for an `ElseClauseSyntax` anywhere in the **ancestors** of the reported node before testing for a `FinallyClauseSyntax`:

```csharp
if (nodeToFix is ElseClauseSyntax || nodeToFix.AncestorsAndSelf().OfType<ElseClauseSyntax>().FirstOrDefault() is not null)
```

When the empty block is a `finally` clause nested inside an `else` clause, that ancestor walk matches the enclosing `else`. The fixer then offers *"Remove empty else block"*, and `RemoveElseClause` walks back up to the same clause and does `ifStatement.WithElse(null)`.

Given this input, MA0090 is reported on the `finally` clause:

```csharp
if (condition)
{
    Foo();
}
else
{
    try
    {
        Foo();
    }
    finally
    {
    }
}
```

applying the offered fix produces:

```csharp
if (condition)
{
    Foo();
}
```

The entire `else` branch is gone, including the live `Foo()` call. The result still compiles, so neither the compiler nor code review flags it, and the loss only surfaces at runtime. MA0090 is enabled by default, and `GetFixAllProvider` returns `BatchFixer`, so *Fix all in solution* repeats it at every occurrence.

## Fix

The analyzer reports the diagnostic on the clause node itself (`RemoveEmptyBlockAnalyzer` registers on `SyntaxKind.FinallyClause` and `SyntaxKind.ElseClause` and reports on `context.Node`), so the node kind alone determines which fix applies. Match on it directly instead of walking the ancestors.

While there, this moves the `Parent` check to registration time, per the rule in `AGENTS.md`: the fix actions no longer have a path that returns the document unchanged.

## Tests

- `EmptyFinallyBlockInsideElseBlock_CodeFix` — the regression. Fails on `main` (the else branch is deleted), passes here.
- `EmptyElseBlockInsideFinallyBlock_CodeFix` — the symmetric shape, which was already correct; guards against the fix over-correcting.

Verified on all five Roslyn versions (14/14 each), and the full `roslyn5.9` suite passes (3837/3837). `DocumentationGenerator` reports no changes.
