### PR TITLE
Make MA0071 linear in the length of an if/else-if chain

### DIFF
--- a/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidUsingRedundantElseAnalyzer.cs
@@ -23,70 +23,89 @@ public sealed partial class AvoidUsingRedundantElseAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSyntaxNodeAction(AnalyzeElseClause, SyntaxKind.ElseClause);
+        // Analyze the whole "if / else if / else" chain from the 'if' that starts it. Registering on the
+        // else clause instead means every clause re-analyzes the branches above it, which is quadratic in
+        // the length of the chain.
+        context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
     }
 
-    private static void AnalyzeElseClause(SyntaxNodeAnalysisContext context)
+    private static void AnalyzeIfStatement(SyntaxNodeAnalysisContext context)
     {
-        var elseClause = (ElseClauseSyntax)context.Node;
-        if (elseClause is null)
+        var ifStatement = (IfStatementSyntax)context.Node;
+
+        // Only the 'if' that starts the chain drives the analysis; the following ones are visited by the loop
+        if (ifStatement.Parent is ElseClauseSyntax { Parent: IfStatementSyntax })
             return;
 
-        if (elseClause.Parent is not IfStatementSyntax ifStatement)
-            return;
-
-        var thenStatement = ifStatement.Statement;
-        var elseStatement = elseClause.Statement;
-        if (thenStatement is null || elseStatement is null)
-            return;
-
-        // If the 'else' clause contains a "using statement local declaration" as direct child, return
-        // NOTE:
-        //  using var charEnumerator = "".GetEnumerator();          => LocalDeclarationStatementSyntax  (will return)
-        //  using (var charEnumerator = "".GetEnumerator()) { }     => UsingStatementSyntax             (will carry on)
-        var elseHasUsingStatementLocalDeclaration = AvoidUsingRedundantElseAnalyzerCommon.GetElseClauseChildren(elseClause)
-            .OfType<LocalDeclarationStatementSyntax>()
-            .Any(localDeclaration => localDeclaration.UsingKeyword.IsKind(SyntaxKind.UsingKeyword));
-        if (elseHasUsingStatementLocalDeclaration)
-            return;
-
-        // If there are conflicting local (variable or function) declarations in 'if' and 'else' blocks, return
-        var thenLocalIdentifiers = FindLocalIdentifiersIn(thenStatement);
-        var elseLocalIdentifiers = FindLocalIdentifiersIn(elseStatement);
-        if (thenLocalIdentifiers.Intersect(elseLocalIdentifiers, System.StringComparer.Ordinal).Any())
-            return;
-
-        var controlFlowAnalysis = context.SemanticModel.AnalyzeControlFlow(thenStatement);
-        if (controlFlowAnalysis is null || !controlFlowAnalysis.Succeeded)
-            return;
-
-        if (!AllPreviousBranchesJumpUnconditionally(context.SemanticModel, ifStatement))
-            return;
-
-        if (!controlFlowAnalysis.EndPointIsReachable)
-        {
-            context.ReportDiagnostic(Rule, elseClause.ElseKeyword);
-        }
-    }
-
-    private static bool AllPreviousBranchesJumpUnconditionally(SemanticModel semanticModel, IfStatementSyntax ifStatement)
-    {
         var currentIfStatement = ifStatement;
-        while (currentIfStatement.Parent is ElseClauseSyntax { Parent: IfStatementSyntax parentIfStatement })
+        while (true)
         {
-            var controlFlowAnalysis = semanticModel.AnalyzeControlFlow(parentIfStatement.Statement);
-            if (!IsUnreachableEndpoint(controlFlowAnalysis))
-                return false;
+            var elseClause = currentIfStatement.Else;
+            if (elseClause is null)
+                return;
 
-            currentIfStatement = parentIfStatement;
+            // A branch that does not jump unconditionally makes the 'else' of every following branch
+            // meaningful too, so there is nothing left to report in this chain
+            if (!IsUnreachableEndpoint(context.SemanticModel.AnalyzeControlFlow(currentIfStatement.Statement)))
+                return;
+
+            if (!HasUsingLocalDeclaration(elseClause) && !HasConflictingLocalIdentifiers(currentIfStatement.Statement, elseClause.Statement))
+            {
+                context.ReportDiagnostic(Rule, elseClause.ElseKeyword);
+            }
+
+            if (elseClause.Statement is not IfStatementSyntax nextIfStatement)
+                return;
+
+            currentIfStatement = nextIfStatement;
         }
-
-        return true;
     }
 
     private static bool IsUnreachableEndpoint(ControlFlowAnalysis? controlFlowAnalysis)
     {
         return controlFlowAnalysis is { Succeeded: true, EndPointIsReachable: false };
+    }
+
+    /// <summary>
+    /// Detects a "using statement local declaration" as a direct child of the else clause.
+    /// </summary>
+    /// <remarks>
+    /// <c>using var charEnumerator = "".GetEnumerator();</c> is a <see cref="LocalDeclarationStatementSyntax"/> (matches),
+    /// whereas <c>using (var charEnumerator = "".GetEnumerator()) { }</c> is a <see cref="UsingStatementSyntax"/> (does not match).
+    /// </remarks>
+    private static bool HasUsingLocalDeclaration(ElseClauseSyntax elseClause)
+    {
+        foreach (var child in AvoidUsingRedundantElseAnalyzerCommon.GetElseClauseChildren(elseClause))
+        {
+            if (child is LocalDeclarationStatementSyntax localDeclaration && localDeclaration.UsingKeyword.IsKind(SyntaxKind.UsingKeyword))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasConflictingLocalIdentifiers(SyntaxNode thenStatement, SyntaxNode elseStatement)
+    {
+        // In an "else if" chain the else statement holds every following branch, so walking it is expensive.
+        // The intersection is empty as soon as the 'then' branch declares nothing, which is the common case,
+        // so collect the 'then' identifiers first and only walk the else statement when one can collide.
+        HashSet<string>? thenLocalIdentifiers = null;
+        foreach (var identifier in FindLocalIdentifiersIn(thenStatement))
+        {
+            thenLocalIdentifiers ??= new HashSet<string>(System.StringComparer.Ordinal);
+            thenLocalIdentifiers.Add(identifier);
+        }
+
+        if (thenLocalIdentifiers is null)
+            return false;
+
+        foreach (var identifier in FindLocalIdentifiersIn(elseStatement))
+        {
+            if (thenLocalIdentifiers.Contains(identifier))
+                return true;
+        }
+
+        return false;
     }
 
     private static IEnumerable<string> FindLocalIdentifiersIn(SyntaxNode node)

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUsingRedundantElseAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUsingRedundantElseAnalyzerTests.cs
@@ -744,4 +744,81 @@ public sealed class AvoidUsingRedundantElseAnalyzerTests
                 .WithSourceCode(originalCode)
                 .ValidateAsync();
     }
+
+    [Fact]
+    public async Task Test_ElseIfChainWithBranchThatDoesNotJump_FollowingElsesNotReported()
+    {
+        var originalCode = """
+            class TestClass
+            {
+                int Test(int value)
+                {
+                    if (value == 0)
+                    {
+                        return 0;
+                    }
+                    [|else|] if (value == 1)
+                    {
+                        value++;
+                    }
+                    else if (value == 2)
+                    {
+                        return 2;
+                    }
+                    else
+                    {
+                        return -1;
+                    }
+
+                    return value;
+                }
+            }
+            """;
+        await CreateProjectBuilder()
+              .WithSourceCode(originalCode)
+              .ValidateAsync();
+    }
+
+    // The chain used to be analyzed once per else clause, each time re-analyzing every branch above it,
+    // which is quadratic: 1600 branches took more than 4 minutes. Keep the chain long enough that a
+    // reintroduction of that behavior is obvious in the duration of this test.
+    [Fact]
+    public async Task Test_LongElseIfChainWhereEveryBranchJumps_AllElsesReported()
+    {
+        const int BranchCount = 1000;
+
+        var sourceCode = new StringBuilder();
+        sourceCode.AppendLine("""
+            class TestClass
+            {
+                int Test(int value)
+                {
+                    if (value == 0)
+                    {
+                        return 0;
+                    }
+            """);
+
+        for (var i = 1; i < BranchCount; i++)
+        {
+            var branch = i.ToString(CultureInfo.InvariantCulture);
+            sourceCode.AppendLine("        [|else|] if (value == " + branch + ")");
+            sourceCode.AppendLine("        {");
+            sourceCode.AppendLine("            return " + branch + ";");
+            sourceCode.AppendLine("        }");
+        }
+
+        sourceCode.AppendLine("""
+                    [|else|]
+                    {
+                        return -1;
+                    }
+                }
+            }
+            """);
+
+        await CreateProjectBuilder()
+              .WithSourceCode(sourceCode.ToString())
+              .ValidateAsync();
+    }
 }


### PR DESCRIPTION
## Problem

`AvoidUsingRedundantElseAnalyzer` registers on `SyntaxKind.ElseClause`, so each clause of an `if / else if / … / else` chain re-analyzes the branches above it. Two independent sources of quadratic behavior:

- `AllPreviousBranchesJumpUnconditionally` walks **up** the ancestor chain calling `SemanticModel.AnalyzeControlFlow` once per ancestor. For branch *i* that is *i* calls, so O(N²) control-flow analyses over a chain of N branches. `AnalyzeControlFlow` is one of the more expensive `SemanticModel` APIs.
- `FindLocalIdentifiersIn(elseStatement)` walks the else statement, which in an `else if` chain **is** every following branch. `Intersect` builds its set from that sequence, so it is fully enumerated even when the `then` branch declares no local at all — which is the common case in a long chain.

MA0071 is enabled by default (Info), so every consumer runs it, and long `else if` chains are normal in generated parsers, state machines and dispatch code. Measured on `roslyn5.9`, time to analyze a single chain:

| branches | before |
|---|---|
| 200 | 3.1 s |
| 400 | 15.2 s |
| 800 | 77.5 s |
| 1600 | **284.6 s** |

Clean 4×-per-2× growth. That cost is paid on every build *and* on every keystroke-triggered IDE pass over the document.

## Fix

Register on `SyntaxKind.IfStatement` and analyze the whole chain once, from the `if` that starts it (the ones whose parent is an `ElseClauseSyntax` return immediately — the loop reaches them).

Walking **down** the chain gives each branch exactly one `AnalyzeControlFlow`, and the walk can stop at the first branch that does not jump unconditionally: reporting requires every previous branch to jump, so once that fails neither the current branch nor any following one can be reported. An `if` with no `else` exits after two syntax checks and does no semantic work at all.

The local-identifier comparison now builds the `HashSet` from the `then` branch and streams the else statement, so it exits at the first conflict and is skipped entirely when the `then` branch declares nothing.

**Behavior is unchanged.** All the conditions are pure predicates combined with `AND`; only their order and the traversal differ. The existing `Test_SeveralNestedIfElseBlocksWithIfsThatJump_AllProblematicElsesRemoved` and `Test_ElseIfChainWithReachablePreviousThenAndMethodInvocationCondition_NoDiagnosticReported` already cover the multi-diagnostic and early-exit paths, and pass unmodified.

| branches | before | after |
|---|---|---|
| 200 | 3.1 s | 0.61 s |
| 400 | 15.2 s | 0.75 s |
| 800 | 77.5 s | 1.13 s |
| 1600 | 284.6 s | **1.48 s** |

## Tests

- `Test_ElseIfChainWithBranchThatDoesNotJump_FollowingElsesNotReported` — pins that the walk stops at the first non-jumping branch: the first `else` is reported, the two after it are not.
- `Test_LongElseIfChainWhereEveryBranchJumps_AllElsesReported` — a generated 1000-branch chain asserting a diagnostic on every `else`. It runs in ~1.9 s here; reintroducing the quadratic behavior would take it to roughly two minutes, so a regression is obvious in the test duration. Happy to drop this one if you would rather not have a generated snippet in the suite.

29/29 MA0071 tests pass on all five Roslyn versions, and the full `roslyn5.9` suite passes (3837/3837). `DocumentationGenerator` reports no changes.
