### PR TITLE
Do not report MA0028 for a ToString call passed to StringBuilder.Insert

### DIFF
--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
@@ -227,7 +227,11 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
             else if (value is IInvocationOperation invocationOperation)
             {
                 var targetMethod = invocationOperation.TargetMethod;
-                if (string.Equals(targetMethod.Name, "ToString", System.StringComparison.Ordinal))
+
+                // Insert is excluded: the overloads below are the ones of Append, and StringBuilder has no
+                // Insert counterpart for some of them (StringBuilder, ReadOnlyMemory<char>), so removing the
+                // ToString call would not always compile
+                if (methodName != "Insert" && string.Equals(targetMethod.Name, "ToString", System.StringComparison.Ordinal))
                 {
                     if (targetMethod.Parameters.Length == 0 && targetMethod.ReturnType.IsString())
                     {

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -231,6 +231,9 @@ class Test
     [InlineData(@"""a"" + 10")]
     [InlineData(@"10 + 20 + ""a""")]
     [InlineData(@"string.Format(""{0}"", 0)")]
+    // StringBuilder.Insert has no counterpart for some of the Append overloads, so the ToString call is kept
+    [InlineData(@"10.ToString()")]
+    [InlineData(@"new StringBuilder().ToString()")]
     public async Task Insert_NoDiagnostic(string text)
     {
         await CreateProjectBuilder()
@@ -240,22 +243,6 @@ class Test
     void A()
     {
         new StringBuilder().Insert(0, " + text + @");
-    }
-}")
-              .ValidateAsync();
-    }
-
-    [Theory]
-    [InlineData(@"10.ToString()")]
-    public async Task Insert_Diagnostic(string text)
-    {
-        await CreateProjectBuilder()
-              .WithSourceCode(@"using System.Text;
-class Test
-{
-    void A()
-    {
-        [|new StringBuilder().Insert(0, " + text + @")|];
     }
 }")
               .ValidateAsync();


### PR DESCRIPTION
Found by extending the test harness in #1353 to execute every registered code action — the very first run surfaced this.

## Problem

In `IsOptimizable`, the `ToString` branch does not exclude `Insert`, unlike the `string.Format` and `string.Join` branches immediately below it, which both start with `methodName != "Insert" &&`. So this is reported:

```csharp
new StringBuilder().Insert(0, 10.ToString());   // MA0028: Remove the ToString call
```

Applying the fix throws:

```
System.InvalidCastException : Unable to cast object of type 'LiteralOperation' to type 'IInvocationOperation'
   at OptimizeStringBuilderUsageFixer.RemoveToString(...) OptimizeStringBuilderUsageFixer.cs:220
```

`RemoveToString` reads `operation.Arguments[0].Value` and casts it to `IInvocationOperation`. For `Insert(int index, string value)` that argument is the **index**, not the value — the analyzer had looked at `Arguments[1]` (line 101).

## Why the argument index is not the whole story

Correcting the index would still leave two problems, which is why this excludes `Insert` rather than teaching the fixer about it:

1. `RemoveToString` builds `…Append(…)` from a hardcoded `"Append"` member name, so it would rewrite `sb.Insert(0, x.ToString())` into `sb.Append(x)` — dropping the insertion index and changing the method.
2. The analyzer gates on `_appendOverloadTypes`, the types that have an **`Append`** overload. `StringBuilder` and `ReadOnlyMemory<char>` are in that set and have no `Insert` counterpart, so `sb.Insert(0, otherBuilder.ToString())` would be "fixed" to `sb.Insert(0, otherBuilder)`, which does not compile.

So the `Insert` path is unsound independently of the crash. Excluding it fixes the analyzer's actual defect instead of papering over the exception.

**Tradeoff:** this gives up a real optimization — `sb.Insert(i, x.ToString())` → `sb.Insert(i, x)` is valid for the types that do have an `Insert` overload. Supporting it properly needs its own set of overload types and its own fix method; happy to do that instead if you would rather keep the diagnostic.

## Tests

`Insert_Diagnostic` had a single `[InlineData(@"10.ToString()")]`, so it is folded into `Insert_NoDiagnostic`, together with `new StringBuilder().ToString()` — the case that would have produced uncompilable code.

MA0028 keeps its other `Insert` coverage: `Insert_EmptyString` (remove the no-op call) and `Insert_OneCharString` (replace with the `char` overload, which asserts the fixed code). `Append_ToString` and `AppendLine_ToString` confirm the optimization is untouched where it is sound.

101/101 MA0028 tests pass on all five Roslyn versions; full `roslyn5.9` suite passes (3840/3840). `DocumentationGenerator` reports no changes.
