### PR TITLE
Name the expected rule in the tests that annotate diagnostics

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -146,23 +146,23 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests
     }
 
     [Theory]
-    [InlineData("abc[|{(sbyte)-1}|]")]
-    [InlineData("abc[|{(short)-1}|]")]
-    [InlineData("abc[|{(int)-1}|]")]
-    [InlineData("abc[|{(long)-1}|]")]
-    [InlineData("abc[|{(long?)-1}|]")]
-    [InlineData("abc[|{(float)-1}|]")]
-    [InlineData("abc[|{(double)-1}|]")]
-    [InlineData("abc[|{(decimal)-1}|]")]
-    [InlineData("abc[|{(float)0}|]")]
-    [InlineData("abc[|{(double)0}|]")]
-    [InlineData("abc[|{(decimal)0}|]")]
-    [InlineData("abc[|{(float)1}|]")]
-    [InlineData("abc[|{(double)1}|]")]
-    [InlineData("abc[|{(decimal)1}|]")]
-    [InlineData(@"test[|{new int[0].Min()}|]")]
-    [InlineData(@"test[|{System.Int128.One}|]")]
-    [InlineData(@"test[|{new System.DateOnly(2023,1,1)}|]")]
+    [InlineData("abc{|MA0076:{(sbyte)-1}|}")]
+    [InlineData("abc{|MA0076:{(short)-1}|}")]
+    [InlineData("abc{|MA0076:{(int)-1}|}")]
+    [InlineData("abc{|MA0076:{(long)-1}|}")]
+    [InlineData("abc{|MA0076:{(long?)-1}|}")]
+    [InlineData("abc{|MA0076:{(float)-1}|}")]
+    [InlineData("abc{|MA0076:{(double)-1}|}")]
+    [InlineData("abc{|MA0076:{(decimal)-1}|}")]
+    [InlineData("abc{|MA0076:{(float)0}|}")]
+    [InlineData("abc{|MA0076:{(double)0}|}")]
+    [InlineData("abc{|MA0076:{(decimal)0}|}")]
+    [InlineData("abc{|MA0076:{(float)1}|}")]
+    [InlineData("abc{|MA0076:{(double)1}|}")]
+    [InlineData("abc{|MA0076:{(decimal)1}|}")]
+    [InlineData(@"test{|MA0076:{new int[0].Min()}|}")]
+    [InlineData(@"test{|MA0076:{System.Int128.One}|}")]
+    [InlineData(@"test{|MA0076:{new System.DateOnly(2023,1,1)}|}")]
     public async Task InterpolatedStringDiagnostic(string content)
     {
         var sourceCode = @"using System.Linq;
@@ -183,7 +183,7 @@ class Test
 {
     void A(int value)
     {
-        _ = $"abc[|{value}|]";
+        _ = $"abc{|MA0076:{value}|}";
     }
 }
 """;
@@ -216,7 +216,7 @@ class Test
 {
     void A(int value)
     {
-        _ = $"abc[|{value}|]";
+        _ = $"abc{|MA0076:{value}|}";
     }
 }
 """;
@@ -350,7 +350,7 @@ class Test
         var sourceCode = """
             class Test
             {
-                void A() { var a = "abc" + $"[|{-1}|]"; }
+                void A() { var a = "abc" + $"{|MA0076:{-1}|}"; }
             }
             """;
         await CreateProjectBuilder()
@@ -378,7 +378,7 @@ class Test
         var sourceCode = """
             class Test
             {
-                void ToString() { var a = "abc" + $"[|{-1}|]"; }
+                void ToString() { var a = "abc" + $"{|MA0076:{-1}|}"; }
             }
             """;
         await CreateProjectBuilder()
@@ -393,7 +393,7 @@ class Test
         var sourceCode = """
             class Test
             {
-                string A() => [|new object().ToString()|];
+                string A() => {|MA0107:new object().ToString()|};
             }
             """;
         await CreateProjectBuilder()
@@ -412,7 +412,7 @@ class Test
                 void A()
                 {
                     var sample = new Sample();
-                    _ = $"Value: {[|sample|]}";
+                    _ = $"Value: {{|MA0107:sample|}}";
                 }
             }
             """;
@@ -580,7 +580,7 @@ class Test
 
     [Theory]
     [InlineData(""" $"abc{new System.DateTime()}" """)]
-    [InlineData(""" $"abc[|{new System.DateTime():a}|]" """)]
+    [InlineData(""" $"abc{|MA0076:{new System.DateTime():a}|}" """)]
     public async Task IgnoreTypeUsingAssemblyAttribute_WithFormat_DefaultFormatInvariant(string content)
     {
         var sourceCode = $$"""
@@ -600,8 +600,8 @@ class Test
     }
 
     [Theory]
-    [InlineData(""" $"abc[|{new System.DateTime()}|]" """)]
-    [InlineData(""" $"abc[|{new System.DateTime():a}|]" """)]
+    [InlineData(""" $"abc{|MA0076:{new System.DateTime()}|}" """)]
+    [InlineData(""" $"abc{|MA0076:{new System.DateTime():a}|}" """)]
     public async Task IgnoreTypeUsingAssemblyAttribute_WithFormat_DefaultFormatCultureSensitive(string content)
     {
         var sourceCode = $$"""
@@ -630,7 +630,7 @@ class Test
 {
     void A()
     {
-        _ = $"abc[|{new System.DateTime():other}|]";
+        _ = $"abc{|MA0076:{new System.DateTime():other}|}";
     }
 }
 """;
@@ -676,8 +676,8 @@ class Sample : System.IFormattable
                     _ = "abc" + Value;
                     _ = $"abc{Value}";
                     _ = Value.ToString();
-                    _ = "abc" + [|OtherValue|];
-                    _ = $"abc[|{OtherValue}|]";
+                    _ = "abc" + {|MA0075:OtherValue|};
+                    _ = $"abc{|MA0076:{OtherValue}|}";
                 }
 
                 [Meziantou.Analyzer.Annotations.CultureInsensitive]
@@ -741,8 +741,8 @@ class Sample : System.IFormattable
                 {
                     Write($"abc{value}");
                     Write("abc" + value);
-                    WriteOther($"abc[|{value}|]");
-                    WriteOther("abc" + [|value|]);
+                    WriteOther($"abc{|MA0076:{value}|}");
+                    WriteOther("abc" + {|MA0075:value|});
                 }
 
                 static void Write([Meziantou.Analyzer.Annotations.CultureInsensitive] string value) { }
@@ -793,7 +793,7 @@ class Sample : System.IFormattable
             {
                 void A(double value)
                 {
-                    Write(Identity($"abc[|{value}|]"));
+                    Write(Identity($"abc{|MA0076:{value}|}"));
                 }
 
                 static string Identity(string value) => value;
@@ -1056,7 +1056,7 @@ class Test
 {
     void A(object value)
     {
-        _ = $"Value: [|{value}|]";
+        _ = $"Value: {|MA0076:{value}|}";
     }
 }
 """;
@@ -1129,7 +1129,7 @@ class Test
 {
     void A(System.IFormattable value)
     {
-        _ = $"Value: [|{value}|]";
+        _ = $"Value: {|MA0076:{value}|}";
     }
 }
 """;
@@ -1204,7 +1204,7 @@ class Test
 {
     void A(Value value)
     {
-        _ = $"Value: [|{value}|]";
+        _ = $"Value: {|MA0076:{value}|}";
     }
 }
 
@@ -1622,7 +1622,7 @@ class Sample : System.IFormattable
             using System;
             class Test
             {
-                void A(Test value) { _ = $"abc[|{value?.Value}|]"; }
+                void A(Test value) { _ = $"abc{|MA0076:{value?.Value}|}"; }
 
                 DateTime Value { get; }
             }
@@ -1826,7 +1826,7 @@ class Test
 {
     void A(Sample value)
     {
-        _ = $"[|{value}|]";
+        _ = $"{|MA0076:{value}|}";
     }
 }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests.cs
@@ -14,7 +14,7 @@ public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests
     {
         var originalCode = """
             class BaseClass {}
-            class [|Test|] : BaseClass
+            class {|MA0077:Test|} : BaseClass
             {
                 public bool Equals(Test other) => throw null;
             }
@@ -36,7 +36,7 @@ public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests
     public async Task Test_StructImplementsNoInterfaceAndProvidesCompatibleEqualsMethod_DiagnosticIsReported()
     {
         var originalCode = """
-            struct [|Test|]     //  This comment stays
+            struct {|MA0077:Test|}     //  This comment stays
             {
                 public bool Equals(Test other) => throw null;
             }
@@ -74,7 +74,7 @@ ref struct Test
     public async Task RefStruct_CSharp13()
     {
         var originalCode = """
-ref struct [|Test|]
+ref struct {|MA0077:Test|}
 {
     public bool Equals(Test other) => throw null;
 }
@@ -91,7 +91,7 @@ ref struct [|Test|]
     public async Task Test_ClassImplementsSystemIEquatableWithTOfWrongTypeButProvidesCompatibleEqualsMethod_DiagnosticIsReported()
     {
         var originalCode = @"using System;
-class [|Test|] : IEquatable<string>
+class {|MA0077:Test|} : IEquatable<string>
 {
     public bool Equals(Test other) => throw null;
     public bool Equals(string other) => throw null;
@@ -112,7 +112,7 @@ class Test : IEquatable<string>, IEquatable<Test>
     public async Task Test_StructImplementsSystemIEquatableWithTOfWrongTypeButProvidesCompatibleEqualsMethod_DiagnosticIsReported()
     {
         var originalCode = @"using System;
-struct [|Test|] : IEquatable<string>
+struct {|MA0077:Test|} : IEquatable<string>
 {
     public bool Equals(Test other) => throw null;
     public bool Equals(string other) => throw null;
@@ -134,7 +134,7 @@ struct Test : IEquatable<string>, IEquatable<Test>
     {
         var originalCode = """
             interface IEquatable<T> { bool Equals(T other); }
-            class [|Test|] : IEquatable<Test>
+            class {|MA0077:Test|} : IEquatable<Test>
             {
                 public bool Equals(Test other) => throw null;
             }
@@ -157,7 +157,7 @@ struct Test : IEquatable<string>, IEquatable<Test>
     {
         var originalCode = """
             interface IEquatable<T> { bool Equals(T other); }
-            struct [|Test|] : IEquatable<Test>
+            struct {|MA0077:Test|} : IEquatable<Test>
             {
                 public bool Equals(Test other) => throw null;
             }
@@ -180,7 +180,7 @@ struct Test : IEquatable<string>, IEquatable<Test>
     {
         var originalCode = """
             #nullable enable
-            class [|Test|]
+            class {|MA0077:Test|}
             {
                 public bool Equals(Test? other) => throw null;
             }
@@ -203,7 +203,7 @@ struct Test : IEquatable<string>, IEquatable<Test>
     {
         var originalCode = """
             #nullable enable
-            class [|Test|]
+            class {|MA0077:Test|}
             {
                 public bool Equals(Test other) => throw null;
             }

--- a/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0094Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0094Tests.cs
@@ -15,7 +15,7 @@ public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0094Tests
         var originalCode = """
             using System;
 
-            class [|Test|] : IComparable<string>
+            class {|MA0094:Test|} : IComparable<string>
             {
                 public int CompareTo(string other) => throw null;
                 public int CompareTo(Test other) => throw null;
@@ -193,7 +193,7 @@ public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0094Tests
         var originalCode = """
             using System;
 
-            class [|Test|] : IComparable<string>
+            class {|MA0094:Test|} : IComparable<string>
             {
                 public int CompareTo(string other) => throw null;
                 public int CompareTo(Test other) => throw null;

--- a/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0095Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0095Tests.cs
@@ -15,7 +15,7 @@ public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0095Tests
         var originalCode = """
 using System;
 
-public sealed class [|TriggersMA0095AndCA1067|] : IEquatable<TriggersMA0095AndCA1067>
+public sealed class {|MA0095:TriggersMA0095AndCA1067|} : IEquatable<TriggersMA0095AndCA1067>
 {
     public bool Equals(TriggersMA0095AndCA1067? other) => true;
 }
@@ -125,7 +125,7 @@ public abstract class Base : IEquatable<Base>
     public override int GetHashCode() => 0;
 }
 
-public sealed class [|Derived|] : Base, IEquatable<Derived>
+public sealed class {|MA0095:Derived|} : Base, IEquatable<Derived>
 {
     public bool Equals(Derived? other) => true;
 }
@@ -142,7 +142,7 @@ public sealed class [|Derived|] : Base, IEquatable<Derived>
         var originalCode = """
 using System;
 
-public struct [|TestStruct|] : IEquatable<TestStruct>
+public struct {|MA0095:TestStruct|} : IEquatable<TestStruct>
 {
     public bool Equals(TestStruct other) => true;
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/EventsShouldHaveProperArgumentsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EventsShouldHaveProperArgumentsAnalyzerTests.cs
@@ -93,7 +93,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzerTests
 
                 void OnEvent()
                 {
-                    MyEvent.Invoke([|this|], EventArgs.Empty);
+                    MyEvent.Invoke({|MA0092:this|}, EventArgs.Empty);
                 }
             }
             """;
@@ -113,7 +113,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzerTests
 
                 void OnEvent()
                 {
-                    MyEvent.Invoke(this, [|null|]);
+                    MyEvent.Invoke(this, {|MA0093:null|});
                 }
             }
             """;
@@ -147,7 +147,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzerTests
 
                 void OnEvent()
                 {
-                    MyEvent.Invoke(this, e: [|null|]);
+                    MyEvent.Invoke(this, e: {|MA0093:null|});
                 }
             }
             """;
@@ -184,7 +184,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzerTests
                     var ev = MyEvent;
                     if (ev != null)
                     {
-                        ev.Invoke(this, [|null|]);
+                        ev.Invoke(this, {|MA0093:null|});
                     }
                 }
             }
@@ -227,7 +227,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzerTests
                     var ev = a;
                     if (ev != null)
                     {
-                        ev.Invoke(this, [|null|]);
+                        ev.Invoke(this, {|MA0093:null|});
                     }
                 }
             }
@@ -268,7 +268,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzerTests
                 void OnEvent()
                 {
                     var ev = MyEvent;
-                    ev?.Invoke(this, [|null|]);
+                    ev?.Invoke(this, {|MA0093:null|});
                 }
             }
             """;
@@ -304,7 +304,7 @@ public sealed class EventsShouldHaveProperArgumentsAnalyzerTests
 
                 void OnEvent()
                 {
-                    MyEvent?.Invoke(this, [|null|]);
+                    MyEvent?.Invoke(this, {|MA0093:null|});
                 }
             }
             """;

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
@@ -33,7 +33,7 @@ Name;System.Int32
 using Microsoft.Extensions.Logging;
 
 ILogger logger = null;
-logger.BeginScope([|"{Prop} {Name} {Name}"|], 1, 2, (int?)null);
+logger.BeginScope({|MA0135:"{Prop} {Name} {Name}"|}, 1, 2, (int?)null);
 """;
         await CreateProjectBuilder()
               .WithSourceCode(SourceCode)
@@ -414,7 +414,7 @@ Prop;System.Int32
 using Microsoft.Extensions.Logging;
 
 ILogger logger = null;
-logger.LogInformation([|"{Prop}"|], 2);
+logger.LogInformation({|MA0135:"{Prop}"|}, 2);
 logger.LogInformation("{Dummy}", 2);
 """;
         await CreateProjectBuilder()
@@ -568,7 +568,7 @@ using System.Runtime.CompilerServices;
 partial class LoggerExtensions
 {
     [LoggerMessage(10_004, LogLevel.Trace, "Test message with {Prop} and {Name}")]
-    static partial void LogTestMessage(ILogger logger, string [|Prop|], int Name);
+    static partial void LogTestMessage(ILogger logger, string {|MA0135:Prop|}, int Name);
 }
 """;
         await CreateProjectBuilder()

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzer_SerilogTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzer_SerilogTests.cs
@@ -15,7 +15,7 @@ public sealed class LoggerParameterTypeAnalyzer_SerilogTests
 using Serilog;
 
 Log.Information("{Prop}", 1);
-Log.Information("{Prop}", [|(int?)1|]);
+Log.Information("{Prop}", {|MA0139:(int?)1|});
 """;
         await CreateProjectBuilder()
               .WithSourceCode(SourceCode)
@@ -32,7 +32,7 @@ Prop;System.Int32
 using Serilog;
 
 Log.Information((System.Exception)null, "{Prop}", 1);
-Log.Information((System.Exception)null, "{Prop}", [|(int?)1|]);
+Log.Information((System.Exception)null, "{Prop}", {|MA0139:(int?)1|});
 """;
         await CreateProjectBuilder()
               .WithSourceCode(SourceCode)
@@ -215,7 +215,7 @@ Prop;System.Int32
         const string SourceCode = """
 using Serilog;
 
-Log.ForContext("Prop", [|""|]);
+Log.ForContext("Prop", {|MA0139:""|});
 """;
         await CreateProjectBuilder()
               .WithSourceCode(SourceCode)
@@ -247,7 +247,7 @@ Prop;System.Int32
         const string SourceCode = """
 using Serilog;
 
-Log.Logger.ForContext("Prop", [|""|]);
+Log.Logger.ForContext("Prop", {|MA0139:""|});
 """;
         await CreateProjectBuilder()
               .WithSourceCode(SourceCode)
@@ -279,7 +279,7 @@ Prop;System.Int32
         const string SourceCode = """
 using Serilog;
 
-Log.Logger.ForContext(Serilog.Events.LogEventLevel.Warning,"Prop", [|""|]);
+Log.Logger.ForContext(Serilog.Events.LogEventLevel.Warning,"Prop", {|MA0139:""|});
 """;
         await CreateProjectBuilder()
               .WithSourceCode(SourceCode)

--- a/tests/Meziantou.Analyzer.Test/Rules/ParameterAttributeForRazorComponentAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ParameterAttributeForRazorComponentAnalyzerTests.cs
@@ -106,7 +106,7 @@ using Microsoft.AspNetCore.Components;
 class Test
 {
     [Parameter, SupplyParameterFromQuery]
-    public int [|A|] { get; set; }
+    public int {|MA0122:A|} { get; set; }
 }
 """;
         await CreateProjectBuilder()
@@ -123,7 +123,7 @@ class Test
             class Test
             {
                 [EditorRequired]
-                public int [|A|] { get; set; }
+                public int {|MA0117:A|} { get; set; }
             }
             """;
         const string Fix = """
@@ -172,7 +172,7 @@ class Test
             {
                 [CascadingParameter]
                 [EditorRequired]
-                public int [|A|] { get; set; }
+                public int {|MA0117:A|} { get; set; }
 
                 public int B { get; set; }
             }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -117,7 +117,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
             {
                 public void A(System.Threading.CancellationToken cancellationToken)
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public void MethodWithCancellationToken() => throw null;
@@ -138,7 +138,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
             {
                 public static void A(HttpRequest request)
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public static string Value { get; }
@@ -165,7 +165,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
             {
                 public static void A(HttpRequest request)
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public static string Value { get; }
@@ -192,7 +192,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
             {
                 public static void A(HttpRequest request)
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public static string Value { get; }
@@ -220,7 +220,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
             {
                 public static void A(HttpRequest request)
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public static string Value { get; }
@@ -245,7 +245,7 @@ class Test
 {
     public static void A(HttpRequest request)
     {
-        [|MethodWithCancellationToken()|];
+        {|MA0040:MethodWithCancellationToken()|};
     }
 
     public static string Value { get; }
@@ -270,7 +270,7 @@ class Test
 {
     public static void A(HttpRequest request)
     {
-        [|MethodWithCancellationToken()|];
+        {|MA0040:MethodWithCancellationToken()|};
     }
 
     public static string Value { get; }
@@ -298,7 +298,7 @@ record struct HttpRequest
             {
                 public void A()
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public System.Threading.CancellationToken MyCancellationToken { get; }
@@ -358,7 +358,7 @@ record struct HttpRequest
             {
                 public void A()
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public System.Threading.CancellationToken MyCancellationToken { get; }
@@ -418,7 +418,7 @@ record struct HttpRequest
             {
                 public static void A()
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public static System.Threading.CancellationToken MyCancellationToken { get; }
@@ -452,7 +452,7 @@ record struct HttpRequest
                     }
 
                     System.Threading.CancellationToken a = default;
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                     System.Threading.CancellationToken unaccessible2 = default;
                 }
 
@@ -493,7 +493,7 @@ record struct HttpRequest
                 public static void A()
                 {
                     System.Threading.CancellationToken a = default;
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public static void MethodWithCancellationToken(int a = 0, System.Threading.CancellationToken cancellationToken = default) => throw null;
@@ -529,7 +529,7 @@ record struct HttpRequest
 
                 public void A()
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public static void MethodWithCancellationToken(System.Threading.CancellationToken cancellationToken = default) => throw null;
@@ -549,7 +549,7 @@ record struct HttpRequest
             {
                 public void A()
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 public static void MethodWithCancellationToken(System.Threading.CancellationToken cancellationToken = default) => throw null;
@@ -585,7 +585,7 @@ record struct Test
 
     public void A()
     {
-        [|MethodWithCancellationToken()|];
+        {|MA0040:MethodWithCancellationToken()|};
     }
 
     public static void MethodWithCancellationToken(System.Threading.CancellationToken cancellationToken = default) => throw null;
@@ -605,7 +605,7 @@ record struct Test(System.Threading.CancellationToken a)
 {
     public void A()
     {
-        [|MethodWithCancellationToken()|];
+        {|MA0040:MethodWithCancellationToken()|};
     }
 
     public static void MethodWithCancellationToken(System.Threading.CancellationToken cancellationToken = default) => throw null;
@@ -627,7 +627,7 @@ record struct Test(System.Threading.CancellationToken a)
 
                 void Sample()
                 {
-                    [|MethodWithCancellationToken()|];
+                    {|MA0040:MethodWithCancellationToken()|};
                 }
 
                 void MethodWithCancellationToken(System.Threading.CancellationToken cancellationToken = default) => throw null;
@@ -693,7 +693,7 @@ record struct Test(System.Threading.CancellationToken a)
                 public static async Task A()
                 {
                     var ct = new CancellationToken();
-                    await foreach (var item in [|AsyncEnumerable()|])
+                    await foreach (var item in {|MA0040:AsyncEnumerable()|})
                     {
                     }
                 }
@@ -747,7 +747,7 @@ record struct Test(System.Threading.CancellationToken a)
                 public static async Task A(IAsyncEnumerable<int> enumerable)
                 {
                     var ct = new CancellationToken();
-                    await foreach (var item in [|enumerable|])
+                    await foreach (var item in {|MA0079:enumerable|})
                     {
                     }
                 }
@@ -921,7 +921,7 @@ record struct Test(System.Threading.CancellationToken a)
             {
                 public static void A(CancellationToken cancellationToken = default)
                 {
-                    _ = new System.Action<CancellationToken>(static ct => [|A()|]);
+                    _ = new System.Action<CancellationToken>(static ct => {|MA0040:A()|});
                 }
             }
             """;
@@ -942,7 +942,7 @@ record struct Test(System.Threading.CancellationToken a)
                 {
                     _ = new System.Action<CancellationToken>(static ct1 =>
                     {
-                        _ = new System.Action<CancellationToken>(ct2 => [|A()|]);
+                        _ = new System.Action<CancellationToken>(ct2 => {|MA0040:A()|});
                     });
                 }
             }
@@ -962,7 +962,7 @@ record struct Test(System.Threading.CancellationToken a)
             {
                 public static void A(CancellationToken cancellationToken = default)
                 {
-                    _ = new System.Action<CancellationToken>(static delegate(CancellationToken ct) { [|A()|]; });
+                    _ = new System.Action<CancellationToken>(static delegate(CancellationToken ct) { {|MA0040:A()|}; });
                 }
             }
             """;
@@ -982,7 +982,7 @@ record struct Test(System.Threading.CancellationToken a)
                 public static void A(CancellationToken cancellationToken = default)
                 {
                     B(cancellationToken);
-                    static void B(CancellationToken ct) => [|A()|];
+                    static void B(CancellationToken ct) => {|MA0040:A()|};
                 }
             }
             """;
@@ -1007,7 +1007,7 @@ record struct Test(System.Threading.CancellationToken a)
                         CancellationToken ct2 = default;
                         void C()
                         {
-                            [|A()|];
+                            {|MA0040:A()|};
                         }
                     }
                 }
@@ -1053,7 +1053,7 @@ record struct Test(System.Threading.CancellationToken a)
                 public static void Test()
                 {
                     CancellationToken ct = default;
-                    [|A()|].WithCancellation(ct);
+                    {|MA0040:A()|}.WithCancellation(ct);
 
                     async IAsyncEnumerable<int> A([EnumeratorCancellation]CancellationToken cancellationToken = default)
                     {
@@ -1103,7 +1103,7 @@ record struct Test(System.Threading.CancellationToken a)
                 {
                     CancellationToken ct1 = default;
                     CancellationToken ct2 = default;
-                    [|A()|].WithCancellation(ct2);
+                    {|MA0040:A()|}.WithCancellation(ct2);
 
                     async IAsyncEnumerable<int> A([EnumeratorCancellation]CancellationToken cancellationToken = default)
                     {
@@ -1153,7 +1153,7 @@ record struct Test(System.Threading.CancellationToken a)
                 public static void Test()
                 {
                     CancellationToken ct = default;
-                    [|A()|].WithCancellation(ct);
+                    {|MA0040:A()|}.WithCancellation(ct);
 
                     async IAsyncEnumerable<int> A([EnumeratorCancellation]CancellationToken cancellationToken = default)
                     {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
@@ -81,7 +81,7 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzerTests
             {
                 void A(System.TimeProvider foo)
                 {
-                    [|System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero)|];
+                    {|MA0166:System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero)|};
                 }
             }
             """;
@@ -109,7 +109,7 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzerTests
             {
                 void A(Sample foo)
                 {
-                    [|System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero)|];
+                    {|MA0166:System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero)|};
                 }
 
                 class Sample { public System.TimeProvider A {get;} }
@@ -145,7 +145,7 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzerTests
 
                 void A(System.TimeProvider foo)
                 {
-                    [|Delay()|];
+                    {|MA0166:Delay()|};
                 }
             }
             """;
@@ -182,7 +182,7 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzerTests
 
                 void A(System.TimeProvider foo)
                 {
-                    [|Delay()|];
+                    {|MA0166:Delay()|};
                 }
             }
             """;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
@@ -59,7 +59,7 @@ class ClassTest
 {
    void Test()
    {
-       _ = [|{{code}}|];
+       _ = {|MA0114:{{code}}|};
    }
 }
 """;

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
@@ -36,7 +36,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
     public async Task NullCheckForNullableOfT_NotNull()
     {
         await CreateProjectBuilder()
-              .WithSourceCode("_ = [|(int?)0 != null|];")
+              .WithSourceCode("_ = {|MA0141:(int?)0 != null|};")
               .ShouldFixCodeWith("_ = (int?)0 is not null;")
               .ValidateAsync();
     }
@@ -63,7 +63,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
     public async Task NullCheckForObject_NotNull_NullFirst()
     {
         await CreateProjectBuilder()
-              .WithSourceCode("_ = [|null != new object()|];")
+              .WithSourceCode("_ = {|MA0141:null != new object()|};")
               .ShouldFixCodeWith("_ = new object() is not null;")
               .ValidateAsync();
     }
@@ -74,7 +74,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
         await CreateProjectBuilder()
               .WithSourceCode("""
                   string line;
-                  while ([|(line = null) != null|]) { }
+                  while ({|MA0141:(line = null) != null|}) { }
                   """)
               .ShouldFixCodeWith("""
                   string line;
@@ -129,8 +129,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
     public async Task EqualityComparison_String()
     {
         await CreateProjectBuilder()
-              .WithSourceCode($"""_ = [|(string)"dummy" == "dummy"|];""")
-              .ShouldFixCodeWith($"""_ = (string)"dummy" is "dummy";""")
+              .WithSourceCode("""_ = {|MA0148:(string)"dummy" == "dummy"|};""")
+              .ShouldFixCodeWith("""_ = (string)"dummy" is "dummy";""")
               .ValidateAsync();
     }
 
@@ -138,8 +138,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
     public async Task EqualityComparison_NullableInt32_Int32()
     {
         await CreateProjectBuilder()
-              .WithSourceCode($"_ = [|(int?)0 == 1|];")
-              .ShouldFixCodeWith($"_ = (int?)0 is 1;")
+              .WithSourceCode("_ = {|MA0148:(int?)0 == 1|};")
+              .ShouldFixCodeWith("_ = (int?)0 is 1;")
               .ValidateAsync();
     }
 
@@ -147,8 +147,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
     public async Task EqualityComparison_Enum()
     {
         await CreateProjectBuilder()
-              .WithSourceCode($"_ = [|(System.DayOfWeek)1 == System.DayOfWeek.Monday|];")
-              .ShouldFixCodeWith($"_ = (System.DayOfWeek)1 is System.DayOfWeek.Monday;")
+              .WithSourceCode("_ = {|MA0148:(System.DayOfWeek)1 == System.DayOfWeek.Monday|};")
+              .ShouldFixCodeWith("_ = (System.DayOfWeek)1 is System.DayOfWeek.Monday;")
               .ValidateAsync();
     }
 
@@ -156,8 +156,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
     public async Task EqualityComparison_NullableEnum()
     {
         await CreateProjectBuilder()
-              .WithSourceCode($"_ = [|(System.DayOfWeek?)1 == System.DayOfWeek.Monday|];")
-              .ShouldFixCodeWith($"_ = (System.DayOfWeek?)1 is System.DayOfWeek.Monday;")
+              .WithSourceCode("_ = {|MA0148:(System.DayOfWeek?)1 == System.DayOfWeek.Monday|};")
+              .ShouldFixCodeWith("_ = (System.DayOfWeek?)1 is System.DayOfWeek.Monday;")
               .ValidateAsync();
     }
 
@@ -167,7 +167,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
         await CreateProjectBuilder()
               .WithSourceCode("""
                   var value = 0;
-                  _ = [|value == 0|] || [|value == 1|];
+                  _ = {|MA0148:value == 0|} || {|MA0148:value == 1|};
                   """)
               .ShouldFixCodeWith("""
                   var value = 0;
@@ -182,7 +182,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
         await CreateProjectBuilder()
               .WithSourceCode("""
                   var value = 0;
-                  _ = [|value != 0|] && [|value != 1|];
+                  _ = {|MA0149:value != 0|} && {|MA0149:value != 1|};
                   """)
               .ShouldFixCodeWith("""
                   var value = 0;
@@ -198,7 +198,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
               .WithSourceCode("""
                   var value1 = 0;
                   var value2 = 0;
-                  _ = [|value1 == 0|] || [|value2 == 1|];
+                  _ = {|MA0148:value1 == 0|} || {|MA0148:value2 == 1|};
                   """)
               .ShouldFixCodeWith("""
                   var value1 = 0;
@@ -215,7 +215,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
               .WithSourceCode("""
                   var value1 = 0;
                   var value2 = 0;
-                  _ = [|value1 == 0|] || [|value2 == 1|] || [|value1 == 2|];
+                  _ = {|MA0148:value1 == 0|} || {|MA0148:value2 == 1|} || {|MA0148:value1 == 2|};
                   """)
               .ShouldFixCodeWith("""
                   var value1 = 0;
@@ -231,8 +231,8 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
         await CreateProjectBuilder()
               .WithSourceCode("""
                   var value = 0;
-                  _ = [|value == 0|] || [|value == 1|];
-                  _ = [|value != 2|] && [|value != 3|];
+                  _ = {|MA0148:value == 0|} || {|MA0148:value == 1|};
+                  _ = {|MA0149:value != 2|} && {|MA0149:value != 3|};
                   """)
               .ShouldBatchFixCodeWith("""
                   var value = 0;
@@ -297,7 +297,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
               .WithSourceCode("""
                   var number = 0;
                   Sample value = null;
-                  _ = [|number == 0|] || value == 0;
+                  _ = {|MA0148:number == 0|} || value == 0;
 
                   class Sample
                   {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
@@ -24,7 +24,7 @@ class TestClass
 {
     void Test()
     {
-        Regex.IsMatch(""test"", """ + regex + @""", " + (isValid ? "" : "[|") + options + (isValid ? "" : "|]") + @", default);
+        Regex.IsMatch(""test"", """ + regex + @""", " + (isValid ? "" : "{|MA0023:") + options + (isValid ? "" : "|}") + @", default);
     }
 }");
         await project.ValidateAsync();
@@ -40,7 +40,7 @@ class TestClass
                   {
                       void Test()
                       {
-                          Regex.IsMatch("test", "([a-z]+)", [|RegexOptions.None|], default);
+                          Regex.IsMatch("test", "([a-z]+)", {|MA0023:RegexOptions.None|}, default);
                       }
                   }
                   """)
@@ -72,7 +72,7 @@ class TestClass
 {
     void Test()
     {
-        new Regex(""" + regex + @""", " + (isValid ? "" : "[|") + options + (isValid ? "" : "|]") + @", default);
+        new Regex(""" + regex + @""", " + (isValid ? "" : "{|MA0023:") + options + (isValid ? "" : "|}") + @", default);
     }
 }");
 
@@ -112,7 +112,7 @@ partial class TestClass
               .WithSourceCode(@"using System.Text.RegularExpressions;
 partial class TestClass
 {
-    [[|GeneratedRegex(""" + regex + @""", " + options + @", 0)|]]
+    [{|MA0023:GeneratedRegex(""" + regex + @""", " + options + @", 0)|}]
     private static partial Regex Test();
 }
 partial class TestClass
@@ -135,7 +135,7 @@ partial class TestClass
                   using System.Text.RegularExpressions;
                   partial class TestClass
                   {
-                      [[|GeneratedRegex("([a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, 0)|]]
+                      [{|MA0023:GeneratedRegex("([a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, 0)|}]
                       private static partial Regex Test();
                   }
                   partial class TestClass
@@ -193,7 +193,7 @@ partial class TestClass
 
                   partial class TestClass
                   {
-                      [[|GeneratedRegex("([a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, 0)|]]
+                      [{|MA0023:GeneratedRegex("([a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, 0)|}]
                       private static partial Regex Test { get; }
                   }
                   partial class TestClass
@@ -217,7 +217,7 @@ partial class TestClass
 
                   partial class TestClass
                   {
-                      [[|GeneratedRegex("([a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, 0)|]]
+                      [{|MA0023:GeneratedRegex("([a-z]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, 0)|}]
                       private static partial Regex Test { get; }
                   }
                   partial class TestClass

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests.cs
@@ -42,7 +42,7 @@ public sealed class ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests
                 class Sample
                 {
                     [System.Runtime.CompilerServices.FixedAddressValueType]
-                    static [|string|] _field;
+                    static {|MA0208:string|} _field;
                 }
                 """)
             .ValidateAsync();
@@ -56,7 +56,7 @@ public sealed class ValidateFixedAddressValueTypeAttributeUsageAnalyzerTests
                 class Sample
                 {
                     [System.Runtime.CompilerServices.FixedAddressValueType]
-                    [|string|] {|MA0207:_field|};
+                    {|MA0208:string|} {|MA0207:_field|};
                 }
                 """)
             .ValidateAsync();

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateUnsafeAccessorAttributeUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateUnsafeAccessorAttributeUsageAnalyzerTests.cs
@@ -36,7 +36,7 @@ public class ValidateUnsafeAccessorAttributeUsageAnalyzerTests
                       {
                           // Local function name are mangle by the compiler, so the Name property is required
                           [UnsafeAccessor(UnsafeAccessorKind.Field)]
-                          extern static ref int [|B|](System.Version a);
+                          extern static ref int {|MA0146:B|}(System.Version a);
                       }
                   }
                   """)


### PR DESCRIPTION
`[|code|]` says "a diagnostic is reported here" without saying which one. For an analyzer that supports a single
rule that is unambiguous, but 15 test files use it with an analyzer that reports several rules, so the tests never
checked that the rule that fires is the one under test. `EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests`
could have been reporting MA0095 everywhere and still passed.

This replaces 125 of those annotations with the `{|ruleId:code|}` syntax the `ProjectBuilder` already supports,
naming the rule the test is about. 23 rules are covered: MA0023, MA0040, MA0075, MA0076, MA0077, MA0079, MA0092,
MA0093, MA0094, MA0095, MA0107, MA0114, MA0117, MA0122, MA0135, MA0139, MA0141, MA0146, MA0148, MA0149, MA0166,
MA0207 and MA0208.

The `[|code|]` annotations of the tests whose analyzer supports a single rule are left alone: there is nothing to
disambiguate there.

`UsePatternMatchingForEqualityComparisonsAnalyzerTests` also loses four `$` prefixes on interpolated strings that
interpolate nothing. They had to go for `{|` to be valid in the code under test, and the fixed code of the same
tests follows for consistency.

No production code is touched, and no test is added or removed.

### Verification

`Meziantou.Analyzer.Test.roslyn5.9`: 3840 tests, 0 failures.
