### PR TITLE
Report MA0102 on the event instead of its accessors

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MakeMemberReadOnlyFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MakeMemberReadOnlyFixer.cs
@@ -38,7 +38,13 @@ public sealed class MakeMemberReadOnlyFixer : CodeFixProvider
             var method = (MethodDeclarationSyntax)nodeToFix;
             editor.ReplaceNode(method, method.WithModifiers(method.Modifiers.Add(SyntaxKind.ReadOnlyKeyword)).WithAdditionalAnnotations(Formatter.Annotation));
         }
-        else if (nodeToFix.IsKind(SyntaxKind.GetAccessorDeclaration) || nodeToFix.IsKind(SyntaxKind.SetAccessorDeclaration) || nodeToFix.IsKind(SyntaxKind.AddAccessorDeclaration) || nodeToFix.IsKind(SyntaxKind.RemoveAccessorDeclaration))
+        else if (nodeToFix.IsKind(SyntaxKind.EventDeclaration))
+        {
+            // 'readonly' cannot be applied to an event accessor, MA0102 reports the event itself
+            var eventDeclaration = (EventDeclarationSyntax)nodeToFix;
+            editor.ReplaceNode(eventDeclaration, eventDeclaration.WithModifiers(eventDeclaration.Modifiers.Add(SyntaxKind.ReadOnlyKeyword)).WithAdditionalAnnotations(Formatter.Annotation));
+        }
+        else if (nodeToFix.IsKind(SyntaxKind.GetAccessorDeclaration) || nodeToFix.IsKind(SyntaxKind.SetAccessorDeclaration))
         {
             var accessor = (AccessorDeclarationSyntax)nodeToFix;
             var addToAccessor = false;

--- a/src/Meziantou.Analyzer/Rules/MakeMemberReadOnlyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MakeMemberReadOnlyAnalyzer.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using Meziantou.Analyzer.Internals;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -29,6 +31,10 @@ public sealed class MakeMemberReadOnlyAnalyzer : DiagnosticAnalyzer
             if (!CouldBeReadOnly(symbol))
                 return;
 
+            // 'readonly' cannot be applied to an event accessor, only to the event itself, so the accessors are
+            // collected and the event is reported once every one of them can be readonly
+            var readOnlyEventAccessors = new ConcurrentDictionary<IEventSymbol, ConcurrentHashSet<IMethodSymbol>>(SymbolEqualityComparer.Default);
+
             ctx.RegisterOperationBlockStartAction(ctx =>
             {
                 if (!CouldBeReadOnly(ctx.OwningSymbol))
@@ -40,14 +46,44 @@ public sealed class MakeMemberReadOnlyAnalyzer : DiagnosticAnalyzer
                         return;
                 }
 
-                var analyzerContext = new AnalyzerContext();
+                var analyzerContext = new AnalyzerContext(readOnlyEventAccessors);
                 ctx.RegisterOperationAction(analyzerContext.AnalyzeBlock, OperationKind.Block);
                 ctx.RegisterOperationBlockEndAction(analyzerContext.AnalyzeEnd);
             });
+
+            ctx.RegisterSymbolEndAction(ctx => ReportEvents(ctx, readOnlyEventAccessors));
         }, SymbolKind.NamedType);
     }
 
-    private sealed class AnalyzerContext
+    private static void ReportEvents(SymbolAnalysisContext context, ConcurrentDictionary<IEventSymbol, ConcurrentHashSet<IMethodSymbol>> readOnlyEventAccessors)
+    {
+        foreach (var (eventSymbol, readOnlyAccessors) in readOnlyEventAccessors)
+        {
+            var accessorCount = 0;
+            if (eventSymbol.AddMethod is not null)
+            {
+                accessorCount++;
+            }
+
+            if (eventSymbol.RemoveMethod is not null)
+            {
+                accessorCount++;
+            }
+
+            if (readOnlyAccessors.Count != accessorCount)
+                continue;
+
+            foreach (var syntaxReference in eventSymbol.DeclaringSyntaxReferences)
+            {
+                if (syntaxReference.GetSyntax(context.CancellationToken) is EventDeclarationSyntax eventDeclaration)
+                {
+                    context.ReportDiagnostic(Rule, eventDeclaration.Identifier, [eventSymbol.Name]);
+                }
+            }
+        }
+    }
+
+    private sealed class AnalyzerContext(ConcurrentDictionary<IEventSymbol, ConcurrentHashSet<IMethodSymbol>> readOnlyEventAccessors)
     {
         private bool _canBeReadOnly = true;
 
@@ -82,12 +118,25 @@ public sealed class MakeMemberReadOnlyAnalyzer : DiagnosticAnalyzer
         {
             if (_canBeReadOnly)
             {
-                if (context.OwningSymbol is IMethodSymbol method && method.MethodKind is MethodKind.PropertyGet or MethodKind.PropertySet)
+                if (context.OwningSymbol is IMethodSymbol method)
                 {
-                    var parent = context.OperationBlocks.FirstOrDefault()?.Syntax.Parent;
-                    if (parent?.IsKind(SyntaxKind.PropertyDeclaration) == true)
+                    if (method.MethodKind is MethodKind.PropertyGet or MethodKind.PropertySet)
                     {
-                        context.ReportDiagnostic(Rule, ((PropertyDeclarationSyntax)parent).Identifier, context.OwningSymbol.Name);
+                        var parent = context.OperationBlocks.FirstOrDefault()?.Syntax.Parent;
+                        if (parent?.IsKind(SyntaxKind.PropertyDeclaration) == true)
+                        {
+                            context.ReportDiagnostic(Rule, ((PropertyDeclarationSyntax)parent).Identifier, context.OwningSymbol.Name);
+                            return;
+                        }
+                    }
+                    else if (method.MethodKind is MethodKind.EventAdd or MethodKind.EventRemove)
+                    {
+                        // The event is reported by ReportEvents once all its accessors can be readonly
+                        if (method.AssociatedSymbol is IEventSymbol eventSymbol)
+                        {
+                            readOnlyEventAccessors.GetOrAdd(eventSymbol, _ => []).Add(method);
+                        }
+
                         return;
                     }
                 }

--- a/tests/Meziantou.Analyzer.Test/Rules/MakeMemberReadOnlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MakeMemberReadOnlyAnalyzerTests.cs
@@ -507,10 +507,10 @@ public sealed class MakeMemberReadOnlyAnalyzerTests
         const string SourceCode = """
             struct Test
             {
-                public event System.Action<System.EventArgs> Event1
+                public event System.Action<System.EventArgs> [|Event1|]
                 {
-                    [|add|] { }
-                    [|remove|] { }
+                    add { }
+                    remove { }
                 }
             }
             """;
@@ -527,12 +527,54 @@ public sealed class MakeMemberReadOnlyAnalyzerTests
 
         await CreateProjectBuilder()
               .WithSourceCode(SourceCode)
-              .ShouldBatchFixCodeWith(CodeFix)
+              .ShouldFixCodeWith(CodeFix)
               .ValidateAsync();
     }
 
     [Fact]
-    public async Task CannotBeReadonly_CallNonReadOnlyMethod()
+    public async Task CannotBeReadOnly_EventWithOnlyOneReadOnlyAccessor()
+    {
+        // 'readonly' applies to both accessors of an event, so an event whose remove writes to a field cannot be
+        // made readonly, even though its add could
+        const string SourceCode = """
+            struct Test
+            {
+                int a;
+
+                public event System.Action<System.EventArgs> Event1
+                {
+                    add { }
+                    remove { a = 0; }
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CannotBeReadOnly_ReadOnlyEvent()
+    {
+        const string SourceCode = """
+            struct Test
+            {
+                public readonly event System.Action<System.EventArgs> Event1
+                {
+                    add { }
+                    remove { }
+                }
+            }
+            """;
+
+        await CreateProjectBuilder()
+              .WithSourceCode(SourceCode)
+              .ValidateAsync();
+    }
+
+    [Fact]
+    public async Task CannotBeReadOnly_CallNonReadOnlyMethod()
     {
         const string SourceCode = """
             struct Test

--- a/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
@@ -180,7 +180,9 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
 
     [Fact]
     public Task IAsyncEnumerableWithoutSuffix_CodeFix_AddsAsyncSuffix()
+        // MA0156 and MA0157 contradict each other, a project enables one of them, not both
         => CreateProjectBuilder()
+              .WithDefaultAnalyzerId("MA0156")
               .WithSourceCode("""
                  class TypeName
                  {
@@ -211,7 +213,9 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
 
     [Fact]
     public Task IAsyncEnumerableWithSuffix_CodeFix_RemovesAsyncSuffix()
+        // MA0156 and MA0157 contradict each other, a project enables one of them, not both
         => CreateProjectBuilder()
+              .WithDefaultAnalyzerId("MA0157")
               .WithSourceCode("""
                  class TypeName
                  {


### PR DESCRIPTION
### MA0102 reported event accessors, whose fix does not compile

`readonly` cannot be applied to an event accessor — `readonly add { }` is CS1609. But
[`MakeMemberReadOnlyAnalyzer`](src/Meziantou.Analyzer/Rules/MakeMemberReadOnlyAnalyzer.cs) reported each accessor
separately, and the fixer put the modifier on the accessor whenever the sibling accessor did not already have it,
which for an event is always. So `Add readonly` on

```c#
struct Test
{
    public event System.Action<System.EventArgs> Event1
    {
        add { }      // MA0102
        remove { }   // MA0102
    }
}
```

produced `readonly add { }`, which does not compile, and the analyzer kept reporting the accessor, so applying the
fix again appended another `readonly`. Only `Fix all occurrences` produced valid code, because it saw both
diagnostics at once and hoisted the modifier onto the event.

There is no fix for a single event accessor: `readonly` on an event covers both of them. So the analyzer now
collects the accessors that can be readonly per event and reports **the event** once every one of its accessors
qualifies, the way it already reports the property rather than the accessor for an expression-bodied property. The
fixer adds the modifier to the event declaration, and the incremental fix and the fix all now agree.

An event whose accessors do not all qualify is no longer reported at all — previously the fixable-looking accessor
was reported on its own, and taking that fix would have produced a `readonly` event with an accessor that writes to
a field. `CannotBeReadOnly_EventWithOnlyOneReadOnlyAccessor` covers that, and `CannotBeReadOnly_ReadOnlyEvent`
covers the already-readonly case.

`CanBeReadOnly_Event` moves from `ShouldBatchFixCodeWith` to `ShouldFixCodeWith`: the incremental fix produces the
right code now, and the test harness compiles the fixed code, so it is a regression test for the CS1609.

### MA0156 and MA0157 in the same test

The two rules contradict each other — "a method returning `IAsyncEnumerable<T>` must / must not use the `Async`
suffix". Both are `isEnabledByDefault: false` and a project enables one of them, but `WithAnalyzer<T>()` enables
every rule an analyzer supports, so the two code fixers fought over the same method: the fix for one produced code
the other reported. The two code fix tests now pin the rule they are about with `WithDefaultAnalyzerId`.

No production code changes for this one — it is a test that was configured in a way no real project can be.

### Verification

`Meziantou.Analyzer.Test.roslyn5.9`: 3842 tests, 0 failures (2 new).
`MakeMemberReadOnlyAnalyzerTests` + `MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests` also run
against roslyn4.8: 59 tests, 0 failures.
`dotnet run --project src/DocumentationGenerator` reports no change.

The MA0156/MA0157 half is unrelated to the MA0102 fix and can be split into its own PR if you prefer to review
them separately.
