### PR TITLE
Give Meziantou.Framework.Roslyn its own auto-merged Renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,15 @@
       ],
       "groupName": "roslyn-analyzers",
       "separateMajorMinor": true
+    },
+    {
+      "matchPackageNames": [
+        "Meziantou.Framework.Roslyn"
+      ],
+      "groupName": "Meziantou.Framework.Roslyn",
+      "separateMajorMinor": false,
+      "automerge": true,
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## What changed

Added a dedicated `packageRules` entry for `Meziantou.Framework.Roslyn` in `renovate.json`:

```json
{
  "matchPackageNames": [
    "Meziantou.Framework.Roslyn"
  ],
  "groupName": "Meziantou.Framework.Roslyn",
  "separateMajorMinor": false,
  "automerge": true,
  "automergeType": "pr"
}
```

## Why

`Meziantou.Framework.Roslyn` provides the `ROSLYN_*_OR_GREATER` / `CSHARP*_OR_GREATER` constants used throughout the analyzers, so its updates are worth seeing on their own rather than bundled into a large batch. Before this change the catch-all rule (`matchPackageNames: ["/.*/"]`, `groupName: "all dependencies"`) swept it into the shared group.

The new rule is placed **after** the catch-all so its `groupName` wins (later `packageRules` override earlier ones). It is also independent of the `roslyn-analyzers` group, which only lists the `Microsoft.CodeAnalysis.*` packages.

`automerge: true` with `automergeType: "pr"` lets the PR merge itself once CI is green — which here means all the per-Roslyn-version test jobs from the `build_and_test` matrix.

`separateMajorMinor` is `false`, matching the repo-wide default, so a major bump does not get split into a separate PR.

## Notes for the reviewer

- The package is referenced from three files, all pinned to `1.0.3`, so a Renovate PR will touch all of them:
  - `src/Meziantou.Analyzer/Directory.Build.props`
  - `src/Meziantou.Analyzer.CodeFixers/Directory.Build.props`
  - `tests/Meziantou.Analyzer.Test/Directory.Build.props`
- Validated with `npx --package renovate -- renovate-config-validator renovate.json` → *Config validated successfully*.
- I could not inspect the shared `github>meziantou/renovate-config` preset. Presets are merged before the local `packageRules`, so this rule should take precedence, but automerge additionally depends on the repository's branch-protection / auto-merge settings on GitHub allowing it.