### PR TITLE
Remove redundant .NET and language version settings in tests

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests.cs
@@ -445,7 +445,6 @@ public sealed class ArgumentExceptionShouldSpecifyArgumentNameAnalyzerTests
     public Task PrimaryConstructor()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             using System;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
@@ -301,7 +301,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task UnusedInternalRecord_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record {|MA0182:UnusedRecord|}
             {
@@ -316,7 +315,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task UnusedPrivateNestedRecord_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             public class OuterClass
             {
@@ -331,7 +329,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task UsedPrivateNestedRecord_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             public class OuterClass
             {
@@ -351,7 +348,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task UnusedInternalRecordStruct_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record struct {|MA0182:UnusedRecordStruct|}
             {
@@ -366,7 +362,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task UnusedPrivateNestedRecordStruct_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             public class OuterClass
             {
@@ -381,7 +376,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task UsedPrivateNestedRecordStruct_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             public class OuterClass
             {
@@ -445,7 +439,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordUsedInObjectCreation_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record UsedRecord(string Name);
 
@@ -465,7 +458,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordStructUsedInObjectCreation_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record struct UsedRecordStruct(string Name);
 
@@ -523,7 +515,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordUsedAsPropertyType_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record Settings(string Key, string Value);
 
@@ -540,7 +531,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordStructUsedAsParameterType_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record struct Point(int X, int Y);
 
@@ -583,7 +573,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordUsedInTypeOf_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
 
@@ -605,7 +594,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordStructUsedInArrayCreation_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
 
@@ -627,7 +615,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalCollectionUsedInCollectionExpression_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Collections;
@@ -665,7 +652,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task MultipleInternalTypes_SomeUsedSomeNot()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal class {|MA0182:UnusedClass|}
             {
@@ -1568,7 +1554,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordUsedInVariableDeclaration_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record Config(string Key);
 
@@ -1589,7 +1574,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordStructUsedInVariableDeclaration_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record struct Vector(double X, double Y);
 
@@ -1739,7 +1723,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordUsedInPatternMatching_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record Message(string Text);
 
@@ -1762,7 +1745,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalRecordStructUsedInPatternMatching_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record struct Coordinate(int X, int Y);
 
@@ -1843,7 +1825,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalClassWithDynamicallyAccessedMembersAttribute_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System.Diagnostics.CodeAnalysis;
 
@@ -1861,7 +1842,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task PrivateClassWithDynamicallyAccessedMembersAttribute_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System.Diagnostics.CodeAnalysis;
 
@@ -1882,7 +1862,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalStructWithDynamicallyAccessedMembersAttribute_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System.Diagnostics.CodeAnalysis;
 
@@ -2162,7 +2141,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task ClassWithModuleInitializerMethod_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
         test.TestCode = """
             using System.Runtime.CompilerServices;
 
@@ -2182,7 +2160,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task ClassWithModuleInitializerMethodAndOtherMembers_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
         test.TestCode = """
             using System.Runtime.CompilerServices;
 
@@ -2207,7 +2184,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task CodeFix_AddDynamicallyAccessedMembersAttribute_Class()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal class {|MA0182:UnusedClass|}
             {
@@ -2229,7 +2205,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task CodeFix_AddDynamicallyAccessedMembersAttribute_Struct()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal struct {|MA0182:UnusedStruct|}
             {
@@ -2251,7 +2226,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task CodeFix_AddDynamicallyAccessedMembersAttribute_Record()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             internal record {|MA0182:UnusedRecord|}(string Name);
             """;
@@ -2375,7 +2349,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task CodeFix_AddDynamicallyAccessedMembersAttribute_WithExistingAttributes()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/AwaitTaskBeforeDisposingResourcesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AwaitTaskBeforeDisposingResourcesAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.AwaitTaskBeforeDisposingResourcesAnalyzer>;
@@ -466,7 +465,6 @@ public sealed class AwaitTaskBeforeDisposingResourcesAnalyzerTests
     public Task ReturnInUsingStatement()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             class TestClass
             {
@@ -485,7 +483,6 @@ public sealed class AwaitTaskBeforeDisposingResourcesAnalyzerTests
     public Task UsingBlockBeforeAReturn()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             class TestClass
             {
@@ -507,7 +504,6 @@ public sealed class AwaitTaskBeforeDisposingResourcesAnalyzerTests
     public Task UsingBeforeAReturnWithLabel()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             class TestClass
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzerTests.cs
@@ -13,7 +13,6 @@ public sealed class BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzer
     {
         var test = new CodeFixTest();
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddAspNetCore();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         return test;
     }
 
@@ -172,7 +171,6 @@ public sealed class BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzer
     public Task InjectProperty_AspNetCore8_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddAspNetCore("8.0.0");
         test.TestCode = """
             using Microsoft.AspNetCore.Components;

--- a/tests/Meziantou.Analyzer.Test/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzerTests.cs
@@ -11,7 +11,8 @@ public sealed class BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzer
 {
     private static CodeFixTest CreateTest()
     {
-        var test = new CodeFixTest { ReferenceAssemblies = ReferenceAssemblies.Net.Net90.AddAspNetCore("9.0.0") };
+        var test = new CodeFixTest();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddAspNetCore();
         test.LanguageVersion = LanguageVersion.CSharp12;
         return test;
     }
@@ -153,7 +154,7 @@ public sealed class BlazorPropertyInjectionShouldUseConstructorInjectionAnalyzer
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddAspNetCore("8.0.0");
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddAspNetCore();
         test.TestCode = """
             using Microsoft.AspNetCore.Components;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
@@ -215,7 +215,6 @@ public sealed class ClassMustBeSealedAnalyzerTests
     public Task TopLevelStatement_9()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             System.Console.WriteLine();
@@ -398,7 +397,6 @@ public sealed class ClassMustBeSealedAnalyzerTests
     public Task TopLevelStatement_10()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             System.Console.WriteLine();

--- a/tests/Meziantou.Analyzer.Test/Rules/CommaAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/CommaAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.CommaAnalyzer,
     Meziantou.Analyzer.Rules.CommaFixer>;
@@ -458,7 +457,6 @@ public sealed class CommaAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.Latest;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             var a = new Sample(1, 2);
@@ -489,7 +487,6 @@ public sealed class CommaAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.Latest;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             var a = new Sample(1, 2);
@@ -510,7 +507,6 @@ public sealed class CommaAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.Latest;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             var a = new Sample(1, 2);

--- a/tests/Meziantou.Analyzer.Test/Rules/CommaAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/CommaAnalyzerTests.cs
@@ -230,7 +230,6 @@ public sealed class CommaAnalyzerTests
     public Task CollectionExpressionWithoutLeadingComma_ClosingBracketOnNextLine()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class TypeName
             {
@@ -265,7 +264,6 @@ public sealed class CommaAnalyzerTests
     public Task CollectionExpressionWithoutLeadingComma_ClosingBracketOnSameLine()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class TypeName
             {
@@ -285,7 +283,6 @@ public sealed class CommaAnalyzerTests
     public Task CollectionExpressionWithoutLeadingComma_ClosingBracketOnSameLine_WithPreviousValue()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class TypeName
             {
@@ -306,7 +303,6 @@ public sealed class CommaAnalyzerTests
     public Task CollectionExpressionWithoutLeadingComma_SpreadElementWithComment()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class TypeName
             {
@@ -341,7 +337,6 @@ public sealed class CommaAnalyzerTests
     public Task SwitchExpressionWithoutLeadingComma_CatchAll()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             class TypeName
             {
@@ -376,7 +371,6 @@ public sealed class CommaAnalyzerTests
     public Task SwitchExpressionWithoutLeadingComma_IgnoreCatchAll()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestState.SetConfiguration("MA0007.IgnoreCatchAllArm", "true");
         test.TestCode = """
             class TypeName
@@ -399,7 +393,6 @@ public sealed class CommaAnalyzerTests
     public Task SwitchExpressionWithoutLeadingComma()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             class TypeName
             {
@@ -434,7 +427,6 @@ public sealed class CommaAnalyzerTests
     public Task SwitchExpressionWithLeadingComma()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             class TypeName
             {
@@ -456,7 +448,6 @@ public sealed class CommaAnalyzerTests
     public Task WithExpressionWithoutLeadingComma()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.Latest;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             var a = new Sample(1, 2);
@@ -486,7 +477,6 @@ public sealed class CommaAnalyzerTests
     public Task WithExpressionWithLeadingComma()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.Latest;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             var a = new Sample(1, 2);
@@ -506,7 +496,6 @@ public sealed class CommaAnalyzerTests
     public Task WithExpressionWithoutLeadingCommaSingleLine()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.Latest;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             var a = new Sample(1, 2);
@@ -522,7 +511,6 @@ public sealed class CommaAnalyzerTests
     public Task PropertyPatternWithoutTrailingComma()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             class TypeName
             {
@@ -565,7 +553,6 @@ public sealed class CommaAnalyzerTests
     public Task PropertyPatternWithTrailingComma()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             class TypeName
             {
@@ -591,7 +578,6 @@ public sealed class CommaAnalyzerTests
     public Task PropertyPatternSingleLine()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             class TypeName
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0105.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0105.cs
@@ -12,7 +12,7 @@ public sealed class ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAna
     // This class covers MA0105 only, the way the original test filtered the diagnostics to that rule
     private static CodeFixTest CreateTest()
     {
-        var test = new CodeFixTest { ReferenceAssemblies = ReferenceAssemblies.Net.Net60 };
+        var test = new CodeFixTest();
         test.DisabledDiagnostics.Add(RuleIdentifiers.AvoidClosureWhenUsingConcurrentDictionaryByUsingFactoryArg);
         return test;
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0106.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests_MA0106.cs
@@ -12,7 +12,7 @@ public sealed class ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAna
     // This class covers MA0106 only, the way the original test filtered the diagnostics to that rule
     private static CodeFixTest CreateTest()
     {
-        var test = new CodeFixTest { ReferenceAssemblies = ReferenceAssemblies.Net.Net60 };
+        var test = new CodeFixTest();
         test.DisabledDiagnostics.Add(RuleIdentifiers.AvoidClosureWhenUsingConcurrentDictionary);
         return test;
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/DeclareTypesInNamespacesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DeclareTypesInNamespacesAnalyzerTests.cs
@@ -43,7 +43,6 @@ public sealed class DeclareTypesInNamespacesAnalyzerTests
     public Task TopLevelProgram_9()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             System.Console.WriteLine();
@@ -56,7 +55,6 @@ public sealed class DeclareTypesInNamespacesAnalyzerTests
     public Task TopLevelProgram_10()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             System.Console.WriteLine();
@@ -69,7 +67,6 @@ public sealed class DeclareTypesInNamespacesAnalyzerTests
     public Task TopLevelProgram_10_partial()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             System.Console.WriteLine();

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotDeclareStaticMembersOnGenericTypesTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotDeclareStaticMembersOnGenericTypesTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis.CSharp;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.DoNotDeclareStaticMembersOnGenericTypes>;
 
@@ -136,7 +135,6 @@ public sealed class DoNotDeclareStaticMembersOnGenericTypesTests
     public Task StaticAbstract()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """
             public interface IFactory<TSelf> where TSelf : IFactory<TSelf>
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotDeclareStaticMembersOnGenericTypesTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotDeclareStaticMembersOnGenericTypesTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.DoNotDeclareStaticMembersOnGenericTypes>;
 
@@ -138,7 +137,6 @@ public sealed class DoNotDeclareStaticMembersOnGenericTypesTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             public interface IFactory<TSelf> where TSelf : IFactory<TSelf>
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotLogClassifiedDataAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotLogClassifiedDataAnalyzerTests.cs
@@ -13,7 +13,7 @@ public sealed class DoNotLogClassifiedDataAnalyzerTests
     {
         var test = new AnalyzerTest();
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages([
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([
             new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", "8.0.0"),
             new PackageIdentity("Microsoft.Extensions.Compliance.Abstractions", "8.0.0"),
         ]);

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseAsyncVoidAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseAsyncVoidAnalyzerTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.DoNotUseAsyncVoidAnalyzer>;
 
@@ -6,7 +5,7 @@ namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class DoNotUseAsyncVoidAnalyzerTests
 {
-    private static AnalyzerTest CreateTest() => new() { ReferenceAssemblies = ReferenceAssemblies.Net.Net80 };
+    private static AnalyzerTest CreateTest() => new();
 
     [Fact]
     public Task Method_Void()

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -612,7 +612,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task ProcessWaitForExit_NET5()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
         test.TestCode = """
             using System.Threading.Tasks;
             using System.Diagnostics;
@@ -2095,7 +2094,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteConnection_CreateCommand_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using System.Threading.Tasks;
@@ -2118,7 +2116,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteConnection_Close_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using System.Threading.Tasks;
@@ -2141,7 +2138,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteCommand_Prepare_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using System.Threading.Tasks;
@@ -2164,7 +2160,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteConnection_CreateCommand_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
@@ -2188,7 +2183,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteConnection_Close_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
@@ -2212,7 +2206,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteCommand_Prepare_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
@@ -2236,7 +2229,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteDataReader_Read_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using System.Threading.Tasks;
@@ -2259,7 +2251,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteDataReader_Read_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
@@ -2283,7 +2274,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task DbConnectionAssignedFromSqliteConnection_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using System.Data.Common;
@@ -2308,7 +2298,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task DbConnectionNotAssignedFromSqliteConnection_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using System.Data.Common;
@@ -2330,7 +2319,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task IAsyncEnumerable()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Collections.Generic;
@@ -2354,7 +2342,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task IAsyncEnumerator()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Collections.Generic;
@@ -2378,7 +2365,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task AsyncMethodBuilder()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Collections.Generic;
@@ -2403,7 +2389,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task TaskYieldResult()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Threading;
@@ -2425,7 +2410,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task TopLevelStatement()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestState.OutputKind = OutputKind.WindowsApplication;
         test.TestCode = """
             {|MA0042:System.Threading.Thread.Sleep(1)|};
@@ -2438,7 +2422,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task TaskRunDelegate()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Collections.Generic;
@@ -2461,7 +2444,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task Moq_Raise()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Moq", "4.20.0")]);
         test.TestCode = """
             using System;
@@ -2484,7 +2466,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewMemoryStream()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             using var ms = new System.IO.MemoryStream();
@@ -2497,7 +2478,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_StreamSubclass_NoDisposeAsyncOverride_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.IO;
             using System.Threading.Tasks;
@@ -2534,7 +2514,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewStreamSubclass_WithDisposeAsyncOverride_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.IO;
             using System.Threading.Tasks;
@@ -2815,7 +2794,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbConnectionSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -2851,7 +2829,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbConnectionSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -2889,7 +2866,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbConnectionSubclass_NoDisposeAsyncOverride_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_db_special_cases", "false");
         test.TestCode = """
             using System.Data;
@@ -2928,7 +2904,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbConnectionSubclass_WithDisposeAsyncOverride_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -2965,7 +2940,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbConnectionSubclass_DisposeAsyncOverriddenInIntermediateBase_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3004,7 +2978,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbCommandSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3044,7 +3017,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbCommandSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3086,7 +3058,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbCommandSubclass_NoDisposeAsyncOverride_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_db_special_cases", "false");
         test.TestCode = """
             using System.Data;
@@ -3129,7 +3100,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbCommandSubclass_WithDisposeAsyncOverride_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3170,7 +3140,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbCommandSubclass_DisposeAsyncOverriddenInIntermediateBase_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3213,7 +3182,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbDataReaderSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Threading.Tasks;
@@ -3234,7 +3202,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbDataReaderSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Threading.Tasks;
@@ -3257,7 +3224,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbDataReaderSubclass_NoDisposeAsyncOverride_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_db_special_cases", "false");
         test.TestCode = """
             using System.Data;
@@ -3281,7 +3247,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbDataReaderSubclass_WithDisposeAsyncOverride_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System;
             using System.Collections;
@@ -3343,7 +3308,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbTransactionSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3373,7 +3337,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbTransactionSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3405,7 +3368,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbTransactionSubclass_NoDisposeAsyncOverride_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_db_special_cases", "false");
         test.TestCode = """
             using System.Data;
@@ -3438,7 +3400,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbTransactionSubclass_WithDisposeAsyncOverride_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3645,7 +3606,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewTextWriterSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.IO;
             using System.Text;
@@ -3672,7 +3632,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_TextWriterSubclass_NoDisposeAsyncOverride_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.IO;
             using System.Text;
@@ -3701,7 +3660,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewTextWriterSubclass_WithDisposeAsyncOverride_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.IO;
             using System.Text;

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -668,7 +668,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task Using_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestCode = """
             using System;
             using System.Threading.Tasks;

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
@@ -143,7 +143,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteConnection_CreateCommand_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using Microsoft.Data.Sqlite;
@@ -165,7 +164,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteCommand_Prepare_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using Microsoft.Data.Sqlite;
@@ -187,7 +185,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteConnection_Close_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using Microsoft.Data.Sqlite;
@@ -209,7 +206,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteConnection_Close_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
@@ -232,7 +228,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteCommand_Prepare_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
@@ -255,7 +250,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteDataReader_Read_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
             using Microsoft.Data.Sqlite;
@@ -277,7 +271,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteDataReader_Read_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
         test.TestCode = """
@@ -300,7 +293,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_UsingFactoryMethod_DbTransaction_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -332,7 +324,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_UsingFactoryMethod_DbTransaction_NoDisposeAsyncOverride_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_db_special_cases", "false");
         test.TestCode = """
             using System.Data;

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -21,8 +21,8 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests
     private static CodeFixTest CreateUnionTest()
     {
         var test = new CodeFixTest();
-        test.TestState.AddMeziantouAnnotations();
         test.LanguageVersion = LanguageVersion.Preview;
+        test.TestState.AddMeziantouAnnotations();
         return test;
     }
 #endif
@@ -199,7 +199,6 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests
     public Task InterpolatedStringDiagnostic_CodeFix()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             class Test
             {
@@ -229,7 +228,6 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests
     {
         var test = CreateTest();
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             class Test
             {
@@ -284,7 +282,6 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests
     public Task InterpolatedStringNoDiagnostic_CSharp11(string content)
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = $$"""
             using System.Linq;
             class Test
@@ -442,7 +439,6 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests
     public Task ObjectToString_InterpolatedStringHandler_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System.Runtime.CompilerServices;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -200,7 +200,6 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class Test
             {
@@ -229,8 +228,8 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests
     public Task InterpolatedStringDiagnostic_NoCodeFix_WhenStringCreateIsUnavailable()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
+        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             class Test
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.DoNotUseInterpolatedStringWithoutParametersAnalyzer,
     Meziantou.Analyzer.Rules.DoNotUseInterpolatedStringWithoutParametersFixer>;
@@ -109,7 +108,6 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersAnalyzerTests
     public Task InterpolatedStringWithoutParameters_CustomInterpolatedStringHandler_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class TypeName
             {
@@ -143,7 +141,6 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersAnalyzerTests
     public Task EmptyInterpolatedString_CustomInterpolatedStringHandler_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class TypeName
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.DoNotUseInterpolatedStringWithoutParametersAnalyzer,
     Meziantou.Analyzer.Rules.DoNotUseInterpolatedStringWithoutParametersFixer>;
@@ -282,7 +281,6 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersAnalyzerTests
     public Task RawInterpolatedStringWithoutParameters_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """"
             class TypeName
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseToStringIfObjectAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.DoNotUseToStringIfObjectAnalyzer>;
 
@@ -594,7 +593,6 @@ public sealed class DoNotUseToStringIfObjectAnalyzerTests
     public Task InterpolatedString_Struct_Interpolation_Net8()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             var o = new A();
             System.Diagnostics.Debug.Assert(false, $"foo{{|MA0150:o|}}bar");
@@ -609,7 +607,6 @@ public sealed class DoNotUseToStringIfObjectAnalyzerTests
     public Task InterpolatedString_Struct_Interpolation_CustomStringHandler()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             var o = new A();
             Foo($"foo{o}bar");
@@ -635,7 +632,6 @@ public sealed class DoNotUseToStringIfObjectAnalyzerTests
     public Task InterpolatedString_SealedType_CustomStringHandler()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             var o = new A();
             Foo($"foo{o}bar");

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseUnknownParameterForRazorComponentAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseUnknownParameterForRazorComponentAnalyzerTests.cs
@@ -12,7 +12,7 @@ public sealed class DoNotUseUnknownParameterForRazorComponentAnalyzerTests
     private static AnalyzerTest CreateTest()
     {
         var test = new AnalyzerTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddAspNetCore("8.0.0");
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddAspNetCore();
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests.cs
@@ -79,7 +79,6 @@ public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests
     public Task RefStruct_CSharp13()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp13;
         test.TestCode = """
             ref struct {|MA0077:Test|}
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.EqualityShouldBeCorrectlyImplementedAnalyzer,
     Meziantou.Analyzer.Rules.EqualityShouldBeCorrectlyImplementedFixer>;
@@ -65,7 +64,6 @@ public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp12;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             ref struct Test
             {
@@ -82,7 +80,6 @@ public sealed class EqualityShouldBeCorrectlyImplementedAnalyzerMA0077Tests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp13;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             ref struct {|MA0077:Test|}
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/FileNameMustMatchTypeNameAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using DiagnosticResult = Microsoft.CodeAnalysis.Testing.DiagnosticResult;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
@@ -134,7 +133,6 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
     public Task DoesMatchFileName_RecordStructWithArityGreaterThan1UsingOfT_WithConfiguration()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestState.SetConfiguration("MA0048.allow_oft_for_all_generic_types", "true");
         test.TestState.Sources.Add(("/0/FooOfT.cs", """
             public record struct Foo<T1, T2>(T1 Key, T2 Value);
@@ -375,7 +373,6 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
     public Task MatchOnlyFirstType_RecordStruct()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestState.SetConfiguration("MA0048.only_validate_first_type", "true");
         test.TestState.Sources.Add(("/0/Test0.cs", """
             record struct {|MA0048:Foo|} {}
@@ -613,7 +610,6 @@ public sealed class FileNameMustMatchTypeNameAnalyzerTests
     public Task TypeKindIncludedInMessage_RecordStruct()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestState.Sources.Add(("/0/Test.cs", """
             record struct {|#0:Sample|};
             """));

--- a/tests/Meziantou.Analyzer.Test/Rules/ILoggerParameterTypeShouldMatchContainingTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ILoggerParameterTypeShouldMatchContainingTypeAnalyzerTests.cs
@@ -12,7 +12,7 @@ public sealed class ILoggerParameterTypeShouldMatchContainingTypeAnalyzerTests
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages([new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", "8.0.0")]);
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/LocalVariablesShouldNotHideSymbolsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LocalVariablesShouldNotHideSymbolsAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.LocalVariablesShouldNotHideSymbolsAnalyzer>;
@@ -74,7 +73,6 @@ public sealed class LocalVariablesShouldNotHideSymbolsAnalyzerTests
     public Task LocalVariableHidePrimaryConstructorParameter()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class Test(int a)
             {
@@ -92,7 +90,6 @@ public sealed class LocalVariablesShouldNotHideSymbolsAnalyzerTests
     public Task LocalVariableDoesNotHidePrimaryConstructorParameterInStaticMethod()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class Test(int a)
             {
@@ -110,7 +107,6 @@ public sealed class LocalVariablesShouldNotHideSymbolsAnalyzerTests
     public Task LocalVariableDoesNotHidePrimaryConstructorParameter()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class Test(int a)
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
@@ -13,7 +13,7 @@ public sealed class LoggerParameterTypeAnalyzerTests
     {
         var test = new AnalyzerTest();
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages([new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", "8.0.0")]);
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/MakeClassStaticAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MakeClassStaticAnalyzerTests.cs
@@ -281,7 +281,6 @@ public sealed class MakeClassStaticAnalyzerTests
     public Task GenericType()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestCode = """
             public class Query : IQuery<Result<QueryResult>> { }
             public sealed record QueryResult();
@@ -296,7 +295,6 @@ public sealed class MakeClassStaticAnalyzerTests
     public Task TopLevelStatement_9()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             System.Console.WriteLine();
@@ -309,7 +307,6 @@ public sealed class MakeClassStaticAnalyzerTests
     public Task TopLevelStatement_10()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             System.Console.WriteLine();

--- a/tests/Meziantou.Analyzer.Test/Rules/MakeMemberReadOnlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MakeMemberReadOnlyAnalyzerTests.cs
@@ -591,7 +591,6 @@ public sealed class MakeMemberReadOnlyAnalyzerTests
     public Task CannotBeReadonly_AccessNonReadOnlyMember()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
         test.TestCode = """
             using System;
             internal ref struct PathReader
@@ -620,7 +619,6 @@ public sealed class MakeMemberReadOnlyAnalyzerTests
     public Task RefFixedMember()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
         test.TestCode = """
             using System;
             using System.Runtime.InteropServices;

--- a/tests/Meziantou.Analyzer.Test/Rules/MergeIsPatternChecksAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MergeIsPatternChecksAnalyzerTests.cs
@@ -335,7 +335,6 @@ public sealed class MergeIsPatternChecksAnalyzerTests
     public Task PrimaryConstructorParameter()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             _ = new Sample(1).M();
 

--- a/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
@@ -13,7 +13,6 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.LanguageVersion = LanguageVersion.Preview;
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
@@ -13,7 +13,6 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.LanguageVersion = LanguageVersion.Preview;
         return test;
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -714,7 +714,6 @@ public sealed class NamedParameterAnalyzerTests
     public Task ValueTask_FromResult_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class TypeName
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -12,7 +12,6 @@ public sealed class NamedParameterAnalyzerTests
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.LanguageVersion = LanguageVersion.Preview;
         return test;
     }
 
@@ -778,7 +777,6 @@ public sealed class NamedParameterAnalyzerTests
     public Task Expression_ParamsInLambda_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.TestCode = """
             using System.Linq;
             class Test

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerOrderTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerOrderTests.cs
@@ -12,7 +12,7 @@ public sealed class OptimizeLinqUsageAnalyzerOrderTests
     // This class covers MA0159 only, the way the original test filtered the diagnostics to that rule
     private static CodeFixTest CreateTest()
     {
-        var test = new CodeFixTest { ReferenceAssemblies = ReferenceAssemblies.Net.Net80 };
+        var test = new CodeFixTest();
         test.DisabledDiagnostics.Add(RuleIdentifiers.OptimizeEnumerable_WhereBeforeOrderBy);
         test.DisabledDiagnostics.Add(RuleIdentifiers.DuplicateEnumerable_OrderBy);
         return test;
@@ -48,7 +48,6 @@ public sealed class OptimizeLinqUsageAnalyzerOrderTests
     public Task IEnumerable_Order_LambdaNotValid()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
         test.TestCode = """
             using System.Collections.Generic;
             using System.Linq;
@@ -69,7 +68,6 @@ public sealed class OptimizeLinqUsageAnalyzerOrderTests
     public Task IEnumerable_Order_LambdaReferenceAnotherParameter()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
         test.TestCode = """
             using System.Collections.Generic;
             using System.Linq;

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseDirectMethodsTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseDirectMethodsTests.cs
@@ -29,7 +29,6 @@ public sealed class OptimizeLinqUsageAnalyzerUseDirectMethodsTests
     public Task FirstOrDefaultAsync_Net9()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System.Linq;
             class Test

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseIndexerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseIndexerTests.cs
@@ -208,7 +208,6 @@ public sealed class OptimizeLinqUsageAnalyzerUseIndexerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp8;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Linq;
             class Test

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseIndexerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerUseIndexerTests.cs
@@ -170,7 +170,6 @@ public sealed class OptimizeLinqUsageAnalyzerUseIndexerTests
     public Task Last_Array_CSharp8_IndexNotAvailable()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net48.Default;
         test.TestCode = """
             using System.Linq;
@@ -207,7 +206,6 @@ public sealed class OptimizeLinqUsageAnalyzerUseIndexerTests
     public Task Last_Array_CSharp8_IndexAvailable()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp8;
         test.TestCode = """
             using System.Linq;
             class Test

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerWhereBeforeOrderByTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerWhereBeforeOrderByTests.cs
@@ -12,7 +12,7 @@ public sealed class OptimizeLinqUsageAnalyzerWhereBeforeOrderByTests
     // This class covers MA0063 only, the way the original test filtered the diagnostics to that rule
     private static CodeFixTest CreateTest()
     {
-        var test = new CodeFixTest { ReferenceAssemblies = ReferenceAssemblies.Net.Net90 };
+        var test = new CodeFixTest();
         test.DisabledDiagnostics.Add(RuleIdentifiers.OptimizeEnumerable_UseOrder);
         return test;
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStartsWithAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStartsWithAnalyzerTests.cs
@@ -350,7 +350,6 @@ public sealed class OptimizeStartsWithAnalyzerTests
     public Task Join_Report(string method)
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = $$"""
             using System;
             using System.Collections.Generic;
@@ -410,7 +409,6 @@ public sealed class OptimizeStartsWithAnalyzerTests
     public Task Join_NoReport(string method)
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = $$"""
 
             using System;

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -211,7 +211,6 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = $$$""""
             {{{$$"""
                             using System.Text;
@@ -966,7 +965,6 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     public Task Append_StringJoin_AppendJoin()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System.Text;
             class Test
@@ -995,7 +993,6 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     public Task AppendLine_AppendJoin()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System.Text;
             class Test
@@ -1123,7 +1120,6 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     public Task AppendLine_ValueToString_Report(string dataType)
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = $$$""""
             {{{$$"""{|MA0028:new System.Text.StringBuilder().AppendLine(default({{dataType}}).ToString())|};"""}}}
@@ -1138,7 +1134,6 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     public Task AppendLine_ValueToString_NoReport(string dataType)
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = $$$""""
             {{{$$"""new System.Text.StringBuilder().AppendLine(default({{dataType}}).ToString());"""}}}

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -210,7 +210,6 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     public Task AppendLine_Net8_NoDiagnostic(string text)
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = $$$""""
             {{{$$"""
                             using System.Text;

--- a/tests/Meziantou.Analyzer.Test/Rules/PrimaryConstructorParameterShouldBeReadOnlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/PrimaryConstructorParameterShouldBeReadOnlyAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.PrimaryConstructorParameterShouldBeReadOnlyAnalyzer>;
@@ -11,7 +10,6 @@ public sealed class PrimaryConstructorParameterShouldBeReadOnlyAnalyzerTests
     private static AnalyzerTest CreateTest()
     {
         var test = new AnalyzerTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.RemoveUnnecessaryBracesInTypeDeclarationAnalyzer,
@@ -15,7 +14,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task PositionalRecord_WithEmptyBraces()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestCode = """
             public record Foo(string Value1, string Value2) {|MA0206:{|}}
             """;
@@ -27,7 +25,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task PositionalRecord_CodeFix()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestCode = """
             public record Foo(string Value1, string Value2) {|MA0206:{|}}
             """;
@@ -42,7 +39,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task PositionalRecord_WithSemicolon()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestCode = """
             public record Foo(string Value1, string Value2);
             """;
@@ -54,7 +50,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task PositionalRecord_WithMember()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestCode = """
             public record Foo(string Value1, string Value2)
             {
@@ -69,7 +64,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task PositionalRecord_WithComment()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestCode = """
             public record Foo(string Value1, string Value2)
             {
@@ -84,7 +78,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task RecordWithoutParameterList()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestCode = """
             public record Foo {|MA0206:{|}}
             """;
@@ -99,7 +92,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task ClassPrimaryConstructor_WithEmptyBraces()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             public class Foo(string Value1, string Value2) {|MA0206:{|}}
             """;
@@ -111,7 +103,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task ClassPrimaryConstructor_CodeFix()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             public class Foo(string Value1, string Value2) {|MA0206:{|}}
             """;
@@ -126,7 +117,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task StructPrimaryConstructor_CodeFix()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             public struct Foo(string Value1, string Value2) {|MA0206:{|}}
             """;
@@ -141,7 +131,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task ClassPrimaryConstructor_WithDocumentation()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             /// <summary>
             /// I show up when you hover my constructor invocation too!
@@ -162,7 +151,6 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
     public Task ClassWithoutPrimaryConstructor_WithDocumentation()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             /// <summary>
             /// I don't. :(

--- a/tests/Meziantou.Analyzer.Test/Rules/ReturnTaskInsteadOfAwaitingItAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ReturnTaskInsteadOfAwaitingItAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.ReturnTaskInsteadOfAwaitingItAnalyzer,
     Meziantou.Analyzer.Rules.ReturnTaskInsteadOfAwaitingItFixer>;
@@ -9,7 +8,7 @@ namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ReturnTaskInsteadOfAwaitingItAnalyzerTests
 {
-    private static CodeFixTest CreateTest() => new() { ReferenceAssemblies = ReferenceAssemblies.Net.Net80 };
+    private static CodeFixTest CreateTest() => new();
 
     [Fact]
     public void Rule_IsDisabledByDefault()

--- a/tests/Meziantou.Analyzer.Test/Rules/SequenceNumberMustBeAConstantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SequenceNumberMustBeAConstantAnalyzerTests.cs
@@ -6,8 +6,12 @@ namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class SequenceNumberMustBeAConstantAnalyzerTests
 {
-    private static AnalyzerTest CreateTest() =>
-        new() { ReferenceAssemblies = ReferenceAssemblies.Net.Net70.AddAspNetCore("7.0.0") };
+    private static AnalyzerTest CreateTest()
+    {
+        var test = new AnalyzerTest();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddAspNetCore();
+        return test;
+    }
 
     [Theory]
     [InlineData("builder.AddAttribute(0, frame: default)")]

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyCallerArgumentExpressionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyCallerArgumentExpressionAnalyzerTests.cs
@@ -11,7 +11,6 @@ public class SimplifyCallerArgumentExpressionAnalyzerTests
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzer,
     Meziantou.Analyzer.Rules.SimplifyStringCreateWhenAllParametersAreCultureInvariantFixer>;
@@ -19,7 +18,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_OnlyCultureInvariantParameters_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -52,7 +50,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_WithString_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -87,7 +84,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_WithGuid_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -122,7 +118,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_WithTimeSpanInvariantFormat_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -157,7 +152,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_WithCultureSensitiveParameter_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -179,7 +173,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_WithDateTimeNonInvariantFormat_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -200,7 +193,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithCurrentCulture_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -221,7 +213,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_LiteralOnly_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -254,7 +245,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_WithInteger_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -276,7 +266,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_WithNullableInteger_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -298,7 +287,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_WithNullableDouble_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -320,7 +308,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_Object_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -353,7 +340,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_Object_TreatOpaqueRuntimeTypesAsCultureSensitive_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestState.SetConfiguration("MA0185.treat_opaque_runtime_types_as_culture_sensitive", "true");
         test.TestCode = """
             using System;
@@ -375,7 +361,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_Interface_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -412,7 +397,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_IFormattable_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -433,7 +417,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_NonSealedType_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -470,7 +453,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_NonSealedType_TreatUnsealedTypesAsCultureSensitive_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestState.SetConfiguration("MA0185.treat_unsealed_types_as_culture_sensitive", "true");
         test.TestCode = """
             using System;
@@ -494,7 +476,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_UnconstrainedTypeParameter_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -527,7 +508,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_SealedNonFormattableType_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -570,7 +550,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_CultureInsensitiveTypeAttribute_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -615,7 +594,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_CultureInsensitiveAttribute_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -654,7 +632,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_EmptyString_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -687,7 +664,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     public Task StringCreateWithInvariantCulture_MultipleWords_ShouldReport()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
             using System.Globalization;

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzer,
     Meziantou.Analyzer.Rules.SimplifyStringCreateWhenAllParametersAreCultureInvariantFixer>;
@@ -11,7 +10,7 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
 {
     private static CodeFixTest CreateTest()
     {
-        var test = new CodeFixTest { ReferenceAssemblies = ReferenceAssemblies.Net.Net60 };
+        var test = new CodeFixTest();
         test.TestState.AddMeziantouAnnotations();
         return test;
     }
@@ -21,7 +20,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -55,7 +53,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -91,7 +88,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -127,7 +123,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -163,7 +158,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -186,7 +180,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -208,7 +201,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -230,7 +222,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -264,7 +255,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -287,7 +277,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -310,7 +299,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -333,7 +321,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -367,7 +354,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestState.SetConfiguration("MA0185.treat_opaque_runtime_types_as_culture_sensitive", "true");
         test.TestCode = """
             using System;
@@ -390,7 +376,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -428,7 +413,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -450,7 +434,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -488,7 +471,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestState.SetConfiguration("MA0185.treat_unsealed_types_as_culture_sensitive", "true");
         test.TestCode = """
             using System;
@@ -513,7 +495,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -547,7 +528,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -591,7 +571,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -637,7 +616,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -677,7 +655,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -711,7 +688,6 @@ public sealed class SimplifyStringCreateWhenAllParametersAreCultureInvariantAnal
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Globalization;

--- a/tests/Meziantou.Analyzer.Test/Rules/StringFormatShouldBeConstantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/StringFormatShouldBeConstantAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.StringFormatShouldBeConstantAnalyzer>;
 
@@ -643,7 +642,6 @@ public sealed class StringFormatShouldBeConstantAnalyzerTests
     public Task StringFormat_WithMultiplePlaceholdersAndArguments_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net100;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             string.Format("Zero: {0}, One: {1}, Two: {2}, Four: {3}", "Answer is", 42, true, false);
@@ -932,7 +930,6 @@ public sealed class StringFormatShouldBeConstantAnalyzerTests
     public Task StringFormat_WithParenthesizedArgAndPlaceholder_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net100;
         test.TestCode = """
             using System;
             using System.Globalization;
@@ -953,7 +950,6 @@ public sealed class StringFormatShouldBeConstantAnalyzerTests
     public Task StringFormat_WithParenthesizedArgAndNoPlaceholder_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net100;
         test.TestCode = """
             using System;
             using System.Globalization;

--- a/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
@@ -127,7 +127,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class Dummy
             {
@@ -146,7 +145,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class Dummy
             {
@@ -166,7 +164,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """"
             class Dummy
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using DiagnosticResult = Microsoft.CodeAnalysis.Testing.DiagnosticResult;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
@@ -13,7 +12,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         return test;
     }
 
@@ -126,7 +124,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     public Task U8String()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """
             class Dummy
             {
@@ -144,7 +141,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     public Task VerbatimU8String()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """
             class Dummy
             {
@@ -163,7 +159,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     public Task U8RawString()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """"
             class Dummy
             {
@@ -184,7 +179,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     public Task SingleLineRawString1()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """"
             class Dummy
             {
@@ -204,7 +198,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     public Task SingleLineRawString2()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """"
             class Dummy
             {
@@ -222,7 +215,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     public Task RawString()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """"
             class Dummy
             {
@@ -243,7 +235,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
     public Task InterpolatedRawString()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """"
             class Dummy
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -200,7 +200,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     public Task CallingMethodWithRecordPropsThatContainsAPropertyOfTypeCancellationToken_ShouldReportDiagnosticWithParameterName()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class Test
             {
@@ -228,7 +227,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     public Task CallingMethodWithRecordCtorThatContainsAPropertyOfTypeCancellationToken_ShouldReportDiagnosticWithParameterName()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class Test
             {
@@ -253,7 +251,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     public Task CallingMethodWithStructRecordCtorThatContainsAPropertyOfTypeCancellationToken_ShouldReportDiagnosticWithParameterName()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class Test
             {
@@ -278,7 +275,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     public Task CallingMethodWithStructRecordPropsThatContainsAPropertyOfTypeCancellationToken_ShouldReportDiagnosticWithParameterName()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class Test
             {
@@ -552,7 +548,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     public Task RecordCtor_ShouldReportDiagnosticWithProperty()
     {
         var test = CreateArgumentFixTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             record Test(System.Threading.CancellationToken CancellationToken)
             {
@@ -626,7 +621,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     public Task InterfaceImplicit_ShouldReportDiagnosticWithProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             interface ITest
             {
@@ -1035,7 +1029,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     public Task AwaitForeach_FixerRemovesWithCancellationToken()
     {
         var test = CreateArgumentFixTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System.Collections.Generic;
             using System.Threading;
@@ -1082,7 +1075,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     public Task AwaitForeach_FixerDoesNotRemoveWithCancellationToken()
     {
         var test = CreateArgumentFixTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System.Collections.Generic;
             using System.Threading;
@@ -1131,7 +1123,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     public Task AwaitForeach_FixerDoesNotRemoveWithCancellationTokenWhenAttributeIsNotPresent()
     {
         var test = CreateArgumentFixTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System.Collections.Generic;
             using System.Threading;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasMidpointRoundingAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasMidpointRoundingAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseAnOverloadThatHasMidpointRoundingAnalyzer,
     Meziantou.Analyzer.Rules.UseAnOverloadThatHasMidpointRoundingFixer>;
@@ -186,7 +185,6 @@ public sealed class UseAnOverloadThatHasMidpointRoundingAnalyzerTests
     public Task FloatingPointImplementationsRoundWithoutMode_ReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """
             class Test
             {
@@ -209,7 +207,6 @@ public sealed class UseAnOverloadThatHasMidpointRoundingAnalyzerTests
     public Task FloatingPointImplementationsRoundWithMode_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """
             class Test
             {
@@ -232,7 +229,6 @@ public sealed class UseAnOverloadThatHasMidpointRoundingAnalyzerTests
     public Task IFloatingPointRoundWithoutMode_ReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """
             using System.Numerics;
 
@@ -253,7 +249,6 @@ public sealed class UseAnOverloadThatHasMidpointRoundingAnalyzerTests
     public Task IFloatingPointRoundWithMode_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestCode = """
             using System.Numerics;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasMidpointRoundingAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasMidpointRoundingAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseAnOverloadThatHasMidpointRoundingAnalyzer,
     Meziantou.Analyzer.Rules.UseAnOverloadThatHasMidpointRoundingFixer>;
@@ -188,7 +187,6 @@ public sealed class UseAnOverloadThatHasMidpointRoundingAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             class Test
             {
@@ -212,7 +210,6 @@ public sealed class UseAnOverloadThatHasMidpointRoundingAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             class Test
             {
@@ -236,7 +233,6 @@ public sealed class UseAnOverloadThatHasMidpointRoundingAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System.Numerics;
 
@@ -258,7 +254,6 @@ public sealed class UseAnOverloadThatHasMidpointRoundingAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System.Numerics;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseAnOverloadThatHasTimeProviderAnalyzer,
     Meziantou.Analyzer.Rules.UseAnOverloadThatHasTimeProviderFixer>;
@@ -9,7 +8,7 @@ namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseAnOverloadThatHasTimeProviderAnalyzerTests
 {
-    private static CodeFixTest CreateTest() => new() { ReferenceAssemblies = ReferenceAssemblies.Net.Net90 };
+    private static CodeFixTest CreateTest() => new();
 
     [Fact]
     public Task NoReport_ConsoleWriteLine()

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseAwaitInsteadOfReturningTaskAnalyzer,
     Meziantou.Analyzer.Rules.UseAwaitInsteadOfReturningTaskFixer>;
@@ -9,7 +8,7 @@ namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class UseAwaitInsteadOfReturningTaskAnalyzerTests
 {
-    private static CodeFixTest CreateTest() => new() { ReferenceAssemblies = ReferenceAssemblies.Net.Net80 };
+    private static CodeFixTest CreateTest() => new();
 
     [Fact]
     public void Rule_IsDisabledByDefault()

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
@@ -247,7 +247,6 @@ public sealed class UseIFormatProviderAnalyzerTests
     public Task StringBuilder_AppendLine_AllStringParams_Net7()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System;
             var sb = new System.Text.StringBuilder();
@@ -262,7 +261,6 @@ public sealed class UseIFormatProviderAnalyzerTests
     public Task StringBuilder_AppendLine_Int32Params_Net7()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             var sb = new System.Text.StringBuilder();
             int value = 0;
@@ -282,7 +280,6 @@ public sealed class UseIFormatProviderAnalyzerTests
     public Task StringBuilder_AppendLine_DateTime_InvariantFormat_Net7(string format)
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = $$$""""
             {{{$$"""
                         var sb = new System.Text.StringBuilder();
@@ -298,7 +295,6 @@ public sealed class UseIFormatProviderAnalyzerTests
     public Task StringBuilder_AppendLine_DateTime_Net7()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             var sb = new System.Text.StringBuilder();
             System.DateTime value = default;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseInlineArrayInsteadOfFixedBufferAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseInlineArrayInsteadOfFixedBufferAnalyzerTests.cs
@@ -133,7 +133,6 @@ public sealed class UseInlineArrayInsteadOfFixedBufferAnalyzerTests
     {
         var test = CreateTest();
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             unsafe struct IpAddressBuffer
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseInlineArrayInsteadOfFixedBufferAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseInlineArrayInsteadOfFixedBufferAnalyzerTests.cs
@@ -118,7 +118,6 @@ public sealed class UseInlineArrayInsteadOfFixedBufferAnalyzerTests
     {
         var test = CreateTest();
         test.LanguageVersion = LanguageVersion.CSharp10;
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             unsafe struct IpAddressBuffer
             {
@@ -133,8 +132,8 @@ public sealed class UseInlineArrayInsteadOfFixedBufferAnalyzerTests
     public Task Net7WithoutInlineArrayAttribute_NoDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             unsafe struct IpAddressBuffer
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzerTests.cs
@@ -11,7 +11,6 @@ public sealed class UseIsPatternInsteadOfSequenceEqualAnalyzerTests
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         return test;
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseIsPatternInsteadOfSequenceEqualAnalyzer,
     Meziantou.Analyzer.Rules.UseIsPatternInsteadOfSequenceEqualFixer>;
@@ -11,7 +10,7 @@ public sealed class UseIsPatternInsteadOfSequenceEqualAnalyzerTests
 {
     private static CodeFixTest CreateTest()
     {
-        var test = new CodeFixTest { ReferenceAssemblies = ReferenceAssemblies.Net.Net70 };
+        var test = new CodeFixTest();
         test.LanguageVersion = LanguageVersion.CSharp11;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         return test;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzer,
     Meziantou.Analyzer.Rules.UseMemoryMarshalGetReferenceForEmptyBuffersFixer>;
@@ -318,7 +317,6 @@ public sealed class UseMemoryMarshalGetReferenceForEmptyBuffersAnalyzerTests
     public Task ArrayOnNet5_DiagnosticFiresButNoCodeFix()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
         test.TestCode = """
             class C
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexAnalyzerTests.cs
@@ -13,7 +13,6 @@ public sealed class UsePartialPropertyInsteadOfPartialMethodForGeneratedRegexAna
         var test = new CodeFixTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
-        test.LanguageVersion = LanguageVersion.Preview;
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
@@ -109,8 +109,8 @@ public sealed class UseRegexOptionsAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = $$"""
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -129,8 +129,8 @@ public sealed class UseRegexOptionsAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = $$"""
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -148,8 +148,8 @@ public sealed class UseRegexOptionsAnalyzerTests
     {
         var test = new GeneratedRegexCodeFixTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -176,8 +176,8 @@ public sealed class UseRegexOptionsAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 
@@ -196,8 +196,8 @@ public sealed class UseRegexOptionsAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 
@@ -216,8 +216,8 @@ public sealed class UseRegexOptionsAnalyzerTests
     {
         var test = new GeneratedRegexCodeFixTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.RegexMethodUsageAnalyzer,
@@ -110,7 +109,6 @@ public sealed class UseRegexOptionsAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = $$"""
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -130,7 +128,6 @@ public sealed class UseRegexOptionsAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = $$"""
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -149,7 +146,6 @@ public sealed class UseRegexOptionsAnalyzerTests
         var test = new GeneratedRegexCodeFixTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -177,7 +173,6 @@ public sealed class UseRegexOptionsAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 
@@ -197,7 +192,6 @@ public sealed class UseRegexOptionsAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 
@@ -217,7 +211,6 @@ public sealed class UseRegexOptionsAnalyzerTests
         var test = new GeneratedRegexCodeFixTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
@@ -14,15 +14,25 @@ public class UseRegexSourceGeneratorAnalyzerTests
     {
         var test = new CodeFixTest();
         test.UseFrameworkSourceGenerators = true;
+        return test;
+    }
+
+    /// <summary>
+    /// The code fixer generates a partial property when the language supports them,
+    /// so the tests that expect a partial method must use a language version that does not.
+    /// </summary>
+    private static CodeFixTest CreatePartialMethodTest()
+    {
+        var test = CreateTest();
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.LanguageVersion = LanguageVersion.CSharp11;
         return test;
     }
 
     [Fact]
     public Task NewRegex_Options_Timeout()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -51,8 +61,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task NewRegex_Options()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -81,8 +90,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task NewRegex()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -111,8 +119,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task RegexIsMatch_Options_Timeout()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -141,8 +148,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task RegexIsMatch_Options()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -171,8 +177,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task RegexIsMatch()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -201,8 +206,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task RegexReplace_Options_Timeout()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -231,8 +235,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task RegexReplace_Options()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -261,8 +264,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task RegexReplace()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -291,8 +293,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task RegexReplace_MatchEvaluator()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -325,6 +326,9 @@ public class UseRegexSourceGeneratorAnalyzerTests
     {
         var test = CreateTest();
 
+        // The generator of .NET 11 requires C# 12, which is not the default language version of every supported Roslyn version
+        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+
         // GeneratedRegex only accepts an infinite or strictly positive match timeout
         test.TestCode = $$"""
             using System;
@@ -351,8 +355,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [InlineData("new TimeSpan(1, 2, 3, 4, 5)", "93784005")]
     public Task Timeout(string timeout, string milliseconds)
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = $$"""
             using System;
             using System.Text.RegularExpressions;
@@ -384,8 +387,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [InlineData("Regex.InfiniteMatchTimeout")]
     public Task New_Timeout_Infinite(string timeout)
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = $$"""
             using System;
             using System.Text.RegularExpressions;
@@ -416,8 +418,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [InlineData("Regex.InfiniteMatchTimeout")]
     public Task Static_Timeout_Infinite(string timeout)
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = $$"""
             using System;
             using System.Text.RegularExpressions;
@@ -446,8 +447,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task GenerateUniqueMethodName()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -480,6 +480,9 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task NonConstantPattern()
     {
         var test = CreateTest();
+
+        // The generator of .NET 11 requires C# 12, which is not the default language version of every supported Roslyn version
+        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -496,8 +499,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task NestedTypeShouldAddPartialToAllAncestorTypes()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -540,7 +542,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task NewRegex_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -568,7 +569,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task NewRegex_Options_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -596,7 +596,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task NewRegex_Options_Timeout_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -624,7 +623,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task RegexIsMatch_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -654,7 +652,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task RegexIsMatch_Options_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -684,7 +681,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task RegexReplace_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -714,7 +710,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task NestedTypeShouldAddPartialToAllAncestorTypes_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -756,8 +751,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task Field_SuggestFieldName()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -796,8 +790,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task Field_SuggestFieldNameWithoutRegexSuffix()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -836,8 +829,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task Variable_SuggestPascalCaseName()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -874,8 +866,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task Variable_AlreadyPascalCase()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -911,8 +902,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task StaticMethod_UseDefaultName()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -943,7 +933,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task Field_RemoveAndReplaceWithProperty_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -982,7 +971,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task Variable_RemoveAndReplaceWithProperty_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -1173,7 +1161,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task Field_MultipleReferences_RemoveAndReplaceWithProperty_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -1222,8 +1209,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task TopLevelStatement_NewRegex_PartialMethod()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             using System.Text.RegularExpressions;
@@ -1252,7 +1238,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task TopLevelStatement_NewRegex_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             using System.Text.RegularExpressions;
@@ -1278,7 +1263,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task TopLevelStatement_StaticMethod_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             using System.Text.RegularExpressions;
@@ -1304,7 +1288,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task TopLevelStatement_WithExistingProgramClass_PartialProperty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             using System.Text.RegularExpressions;
@@ -1337,8 +1320,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task TopLevelStatement_StaticMethod_PartialMethod()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
             using System.Text.RegularExpressions;
@@ -1363,8 +1345,7 @@ public class UseRegexSourceGeneratorAnalyzerTests
     [Fact]
     public Task BatchFix_MultipleRegex()
     {
-        var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
+        var test = CreatePartialMethodTest();
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
@@ -15,7 +15,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
         var test = new CodeFixTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
-        test.LanguageVersion = LanguageVersion.Preview;
         return test;
     }
 
@@ -325,7 +324,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task Timeout_NotSupportedByTheGenerator_NoDiagnostic(string timeout)
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp11;
 
         // GeneratedRegex only accepts an infinite or strictly positive match timeout
         test.TestCode = $$"""
@@ -542,7 +540,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task NewRegex_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -571,7 +568,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task NewRegex_Options_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -600,7 +596,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task NewRegex_Options_Timeout_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -629,7 +624,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task RegexIsMatch_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -660,7 +654,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task RegexIsMatch_Options_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -691,7 +684,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task RegexReplace_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -722,7 +714,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task NestedTypeShouldAddPartialToAllAncestorTypes_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -952,7 +943,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task Field_RemoveAndReplaceWithProperty_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -992,7 +982,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task Variable_RemoveAndReplaceWithProperty_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -1032,7 +1021,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
         var test = new CodeFixTest();
         test.UseFrameworkSourceGenerators = true;
         test.CodeActionIndex = 1;
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -1074,7 +1062,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
         var test = new CodeFixTest();
         test.UseFrameworkSourceGenerators = true;
         test.CodeActionIndex = 1;
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -1106,7 +1093,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
         var test = new CodeFixTest();
         test.UseFrameworkSourceGenerators = true;
         test.CodeActionIndex = 1;
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -1148,7 +1134,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
         var test = new CodeFixTest();
         test.UseFrameworkSourceGenerators = true;
         test.CodeActionIndex = 1;
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.TestCode = """
             using System;
             using System.Text.RegularExpressions;
@@ -1188,7 +1173,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task Field_MultipleReferences_RemoveAndReplaceWithProperty_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System;
@@ -1268,7 +1252,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task TopLevelStatement_NewRegex_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
@@ -1295,7 +1278,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task TopLevelStatement_StaticMethod_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """
@@ -1322,7 +1304,6 @@ public class UseRegexSourceGeneratorAnalyzerTests
     public Task TopLevelStatement_WithExistingProgramClass_PartialProperty()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp14;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         test.TestCode = """

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexTimeoutAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexTimeoutAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using DiagnosticResult = Microsoft.CodeAnalysis.Testing.DiagnosticResult;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
@@ -152,7 +151,6 @@ public sealed class UseRegexTimeoutAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -171,7 +169,6 @@ public sealed class UseRegexTimeoutAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -190,7 +187,6 @@ public sealed class UseRegexTimeoutAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -213,7 +209,6 @@ public sealed class UseRegexTimeoutAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 
@@ -233,7 +228,6 @@ public sealed class UseRegexTimeoutAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 
@@ -253,7 +247,6 @@ public sealed class UseRegexTimeoutAnalyzerTests
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexTimeoutAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexTimeoutAnalyzerTests.cs
@@ -61,7 +61,6 @@ public sealed class UseRegexTimeoutAnalyzerTests
     public Task IsMatch_NonBacktracking_WithoutTimeout_ShouldNotReportError()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System.Text.RegularExpressions;
             class TestClass
@@ -116,7 +115,6 @@ public sealed class UseRegexTimeoutAnalyzerTests
     public Task Ctor_WithoutTimeout_NonBacktracking_ShouldNotReportError()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System.Text.RegularExpressions;
             class TestClass
@@ -153,8 +151,8 @@ public sealed class UseRegexTimeoutAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -172,8 +170,8 @@ public sealed class UseRegexTimeoutAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -191,8 +189,8 @@ public sealed class UseRegexTimeoutAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
             partial class TestClass
@@ -214,8 +212,8 @@ public sealed class UseRegexTimeoutAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 
@@ -234,8 +232,8 @@ public sealed class UseRegexTimeoutAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 
@@ -254,8 +252,8 @@ public sealed class UseRegexTimeoutAnalyzerTests
     {
         var test = CreateTest();
         test.UseFrameworkSourceGenerators = true;
-        test.LanguageVersion = LanguageVersion.Preview;
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
+        test.LanguageVersion = LanguageVersion.Preview;
         test.TestCode = """
             using System.Text.RegularExpressions;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -905,7 +905,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task MeziantouFrameworkAssertions_Assert_WithoutComparerOverload_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net100;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Meziantou.Framework.Assertions", "2.0.1")]);
         test.TestCode = """
             class TypeName
@@ -1114,7 +1113,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ReportOnlyNonOrdinal_Order_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestState.SetConfiguration(ReportOnlyNonOrdinalConfigurationName, "true");
         test.TestCode = """
             using System.Linq;
@@ -1282,7 +1280,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task Order_String_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
         test.TestCode = """
             using System.Linq;
             class TypeName
@@ -1508,7 +1505,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ISet_Contain()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System.Linq;
             class TypeName
@@ -1528,7 +1524,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task IReadOnlySet_Contain()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System.Linq;
             class TypeName
@@ -1548,7 +1543,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task IImmutableSet_Contain()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
         test.TestCode = """
             using System.Linq;
             class TypeName
@@ -1611,7 +1605,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task StringArray_QuerySyntax_OrderBy_NoConfiguration()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System.Linq;
             class TypeName
@@ -1633,7 +1626,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task StringArray_QuerySyntax_OrderBy()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestState.SetConfiguration("MA0002.exclude_query_operator_syntaxes", "true");
         test.TestCode = """
             using System.Linq;
@@ -1656,7 +1648,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task StringArray_QuerySyntax_OrderByDescending_NoConfiguration()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System.Linq;
             class TypeName
@@ -1678,7 +1669,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task StringArray_QuerySyntax_OrderByDescending()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestState.SetConfiguration("MA0002.exclude_query_operator_syntaxes", "true");
         test.TestCode = """
             using System.Linq;
@@ -1701,7 +1691,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task StringArray_QuerySyntax_Join_NoConfiguration()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System.Linq;
             class TypeName
@@ -1723,7 +1712,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task StringArray_QuerySyntax_Join()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestState.SetConfiguration("MA0002.exclude_query_operator_syntaxes", "true");
         test.TestCode = """
             using System.Linq;
@@ -1746,7 +1734,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task StringArray_QuerySyntax_JoinInto_NoConfiguration()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System.Linq;
             class TypeName
@@ -1768,7 +1755,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task StringArray_QuerySyntax_JoinInto()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestState.SetConfiguration("MA0002.exclude_query_operator_syntaxes", "true");
         test.TestCode = """
             using System.Linq;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -12,7 +12,6 @@ public sealed class UseStringComparerAnalyzerTests
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.LanguageVersion = LanguageVersion.CSharp9;
         return test;
     }
 
@@ -26,7 +25,6 @@ public sealed class UseStringComparerAnalyzerTests
     private static CodeFixTest CreateMSTestTest()
     {
         var test = new CodeFixTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("MSTest.TestFramework", "4.3.3")]);
         return test;
     }
@@ -273,7 +271,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task Dictionary_String_CollectionExpression_DefaultOnCSharp12_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class TypeName
             {
@@ -291,7 +288,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task HashSet_String_CollectionExpression_DefaultOnCSharp12_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class TypeName
             {
@@ -309,7 +305,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task Dictionary_String_CollectionExpression_CSharp12_OptionEnabled_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestState.SetConfiguration(ReportCollectionExpressionsConfigurationName, "true");
         test.TestCode = """
             class TypeName
@@ -328,7 +323,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task HashSet_String_CollectionExpression_CSharp12_OptionEnabled_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestState.SetConfiguration(ReportCollectionExpressionsConfigurationName, "true");
         test.TestCode = """
             class TypeName
@@ -347,7 +341,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task HashSet_String_CollectionExpression_ReportOnlyNonOrdinal_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestState.SetConfiguration((ReportCollectionExpressionsConfigurationName, "true"), (ReportOnlyNonOrdinalConfigurationName, "true"));
         test.TestCode = """
             class TypeName
@@ -366,7 +359,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task HashSet_String_CollectionExpression_WithElements_CSharp12_OptionEnabled_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestState.SetConfiguration(ReportCollectionExpressionsConfigurationName, "true");
         test.TestCode = """
             class TypeName
@@ -385,7 +377,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task HashSet_String_CollectionExpression_WithElements_ReportOnlyNonOrdinal_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestState.SetConfiguration((ReportCollectionExpressionsConfigurationName, "true"), (ReportOnlyNonOrdinalConfigurationName, "true"));
         test.TestCode = """
             class TypeName
@@ -404,7 +395,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task FrozenSet_String_CollectionExpression_DefaultOnCSharp12_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class TypeName
             {
@@ -422,7 +412,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task FrozenSet_String_CollectionExpression_CSharp12_OptionEnabled_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestState.SetConfiguration(ReportCollectionExpressionsConfigurationName, "true");
         test.TestCode = """
             class TypeName
@@ -441,7 +430,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ImmutableHashSet_String_CollectionExpression_DefaultOnCSharp12_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestCode = """
             class TypeName
             {
@@ -459,7 +447,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ImmutableHashSet_String_CollectionExpression_CSharp12_OptionEnabled_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp12;
         test.TestState.SetConfiguration(ReportCollectionExpressionsConfigurationName, "true");
         test.TestCode = """
             class TypeName

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerNonCultureSensitiveTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerNonCultureSensitiveTests.cs
@@ -93,7 +93,6 @@ public sealed class UseStringComparisonAnalyzerNonCultureSensitiveTests
     public Task String_GetHashCode_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             class TypeName
             {
@@ -332,7 +331,6 @@ public sealed class UseStringComparisonAnalyzerNonCultureSensitiveTests
     public Task MeziantouFrameworkAssertions_Assert_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net100;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Meziantou.Framework.Assertions", "2.0.1")]);
         test.TestCode = """
             class TypeName

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringCreateInsteadOfFormattableStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringCreateInsteadOfFormattableStringAnalyzerTests.cs
@@ -34,7 +34,6 @@ public sealed class UseStringCreateInsteadOfFormattableStringAnalyzerTests
     public Task FormattableString_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             class TypeName
@@ -55,7 +54,6 @@ public sealed class UseStringCreateInsteadOfFormattableStringAnalyzerTests
     public Task Charp9_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.LanguageVersion = LanguageVersion.CSharp9;
         test.TestCode = """
             using System;
@@ -75,7 +73,6 @@ public sealed class UseStringCreateInsteadOfFormattableStringAnalyzerTests
     public Task FormattableStringInvariant()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
@@ -108,7 +105,6 @@ public sealed class UseStringCreateInsteadOfFormattableStringAnalyzerTests
     public Task FormattableStringCurrentCulture()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringCreateInsteadOfFormattableStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringCreateInsteadOfFormattableStringAnalyzerTests.cs
@@ -73,7 +73,6 @@ public sealed class UseStringCreateInsteadOfFormattableStringAnalyzerTests
     public Task FormattableStringInvariant()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
 
@@ -105,7 +104,6 @@ public sealed class UseStringCreateInsteadOfFormattableStringAnalyzerTests
     public Task FormattableStringCurrentCulture()
     {
         var test = CreateTest();
-        test.LanguageVersion = LanguageVersion.CSharp10;
         test.TestCode = """
             using System;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateArgumentsCorrectlyAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.ValidateArgumentsCorrectlyAnalyzer,
     Meziantou.Analyzer.Rules.ValidateArgumentsCorrectlyFixer>;
@@ -208,7 +207,6 @@ public sealed class ValidateArgumentsCorrectlyAnalyzerTests
     public Task ValidValidation_ThrowIfNull()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Collections.Generic;
             class TypeName
@@ -238,7 +236,6 @@ public sealed class ValidateArgumentsCorrectlyAnalyzerTests
     public Task ValidValidation_ArgumentExceptionThrowIfNullOrEmpty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Collections.Generic;
             class TypeName
@@ -268,7 +265,6 @@ public sealed class ValidateArgumentsCorrectlyAnalyzerTests
     public Task ReportDiagnostic_ArgumentExceptionThrowIfNullOrEmpty()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Collections.Generic;
             class TypeName
@@ -394,7 +390,6 @@ public sealed class ValidateArgumentsCorrectlyAnalyzerTests
     public Task ReportDiagnostic_IAsyncEnumerable_ThrowIfNull()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Collections.Generic;
             class TypeName
@@ -435,7 +430,6 @@ public sealed class ValidateArgumentsCorrectlyAnalyzerTests
     public Task ReportDiagnostic_FixerPreserveEnumerableCancellationAttribute()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Runtime.CompilerServices;
             using System.Collections.Generic;

--- a/tests/Meziantou.Analyzer.Test/Rules/ValidateUnsafeAccessorAttributeUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ValidateUnsafeAccessorAttributeUsageAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.ValidateUnsafeAccessorAttributeUsageAnalyzer,
     Meziantou.Analyzer.Rules.ValidateUnsafeAccessorAttributeUsageFixer>;
@@ -9,7 +8,7 @@ namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class ValidateUnsafeAccessorAttributeUsageAnalyzerTests
 {
-    private static CodeFixTest CreateTest() => new() { ReferenceAssemblies = ReferenceAssemblies.Net.Net80 };
+    private static CodeFixTest CreateTest() => new();
 
     [Fact]
     public Task NotExternStaticMethod()


### PR DESCRIPTION
## What

Removes the explicit target framework, ASP.NET Core and C# language version settings in the tests when the defaults of the testing harness are enough.

- ~200 `test.ReferenceAssemblies = ReferenceAssemblies.Net.NetXX;` assignments removed, plus the equivalent object initializers (`new CodeFixTest { ReferenceAssemblies = ... }`).
- Pinned ASP.NET Core and NuGet combinations replaced by the shared defaults: `ReferenceAssemblies.Net.Net80.AddAspNetCore("8.0.0")` becomes `test.ReferenceAssemblies.AddAspNetCore()`, and `...Net80.AddPackages([...])` becomes `test.ReferenceAssemblies.AddPackages([...])`.
- 188 explicit `test.LanguageVersion = ...` assignments removed, plus 13 more in `UseStringComparerAnalyzerTests` that only existed to lift the C# 9 class default back up to C# 12.
- `UseRegexSourceGeneratorAnalyzerTests` gets a `CreatePartialMethodTest` helper (.NET 7 + C# 11) instead of repeating the language version in 23 tests, which also lets the partial property tests drop their `Net90` overrides.
- The now unused `using Microsoft.CodeAnalysis.Testing;` and `using Microsoft.CodeAnalysis.CSharp;` directives are removed.

## Why

Most tests were pinning a framework or a language version that predates the default of the harness, which hides which tests actually depend on a specific version.

## What is kept

Every setting that is load bearing was verified by removing it and observing the failures:

- Tests that assert version specific behavior (`ProcessWaitForExit_NET5`, `Net5_NoDiagnostic`, `RefStruct_CSharp12`, `CannotBeReadOnly_CSharp7`, `InjectProperty_AspNetCore8_NoDiagnostic`, ...).
- `LanguageVersion.Preview` for union types, `closed` types and `System.Threading.Lock`: `Latest` is below those features on the older Roslyn versions.
- The regex source generator tests: the .NET 11 generator emits collection expressions, which need C# 12, and the code fixer generates a partial property as soon as the language supports it.
- The `netstandard` and `net48` targets, and the DI based tests whose types are not in the .NET 11 ASP.NET Core reference pack.

## Testing

`dotnet test --max-parallel-test-modules 2`: 19013 passed, 0 failed, on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.

## Note for the reviewer

Names such as `Dictionary_String_CollectionExpression_DefaultOnCSharp12_ShouldNotReportDiagnostic` now run with the default language version instead of exactly C# 12. The behavior is identical, but tell me if you prefer to keep the explicit pin so the names keep matching.