### PR TITLE
Remove redundant FixedState.MarkupHandling assignments in tests

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
@@ -2403,16 +2403,8 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             }
             """;
         test.CodeActionIndex = 1;
-        // Only one type is removed, and MarkupMode.Allow is needed for the fixed code to declare the diagnostic still reported on the other one
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
-        test.FixedCode = """
-
-            internal class {|MA0182:UnusedClass2|}
-            {
-                public int Value { get; set; }
-            }
-            """;
+        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.SkipFixAllCheck;
+        test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
 
         return test.RunAsync();
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
@@ -2249,7 +2249,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             """;
         test.CodeActionIndex = 1;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
 
         return test.RunAsync();
@@ -2272,7 +2271,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             """;
         test.CodeActionIndex = 1;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
 
             public class UsedClass
@@ -2299,7 +2297,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             """;
         test.CodeActionIndex = 1;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
             public class OuterClass
             {
@@ -2324,7 +2321,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             """;
         test.CodeActionIndex = 1;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
 
         return test.RunAsync();
@@ -2339,7 +2335,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             """;
         test.CodeActionIndex = 1;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
 
         return test.RunAsync();
@@ -2387,7 +2382,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             """;
         test.CodeActionIndex = 1;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
 
         return test.RunAsync();
@@ -2409,6 +2403,7 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             }
             """;
         test.CodeActionIndex = 1;
+        // Only one type is removed, and MarkupMode.Allow is needed for the fixed code to declare the diagnostic still reported on the other one
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
@@ -2436,7 +2431,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             """;
         test.CodeActionIndex = 1;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
             [assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
 

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -736,7 +736,6 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
         var test = CreateTest();
         // Applying this fix reveals another diagnostic, and the test asserts the result of a single application
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.TestCode = """
             using System.Text;
             class Test

--- a/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
@@ -56,7 +56,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
             """;
         test.CodeActionIndex = 1;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
             class Dummy
             {
@@ -87,7 +86,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
             """;
         test.CodeActionIndex = 2;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
             class Dummy
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -328,7 +328,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
             """;
         test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0040", DiagnosticSeverity.Info).WithLocation(0).WithMessage("Use an overload with a CancellationToken, available tokens: MyCancellationToken, Context.RequestAborted"));
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
             class Test : ControllerBase
             {
@@ -388,7 +387,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
         test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0040", DiagnosticSeverity.Info).WithLocation(0).WithMessage("Use an overload with a CancellationToken, available tokens: MyCancellationToken, Context.RequestAborted"));
         test.CodeActionIndex = 1;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
             class Test : ControllerBase
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsAnalyzerTests.cs
@@ -198,7 +198,6 @@ public sealed class UseStringEqualsAnalyzerTests
             """;
         test.CodeActionIndex = 2;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
             using Meziantou.Framework;
 
@@ -230,7 +229,6 @@ public sealed class UseStringEqualsAnalyzerTests
             """;
         test.CodeActionIndex = 3;
         test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
         test.FixedCode = """
             using Meziantou.Framework;
 


### PR DESCRIPTION
`FixedState.MarkupHandling` controls how markup (`{|MA0000:...|}`) in the **fixed** code is interpreted. When the fixed sources differ from the test sources, `SolutionState.WithInheritedValuesApplied` defaults it to `MarkupMode.IgnoreFixable`, which drops markup for diagnostics the code fixer can fix. `MarkupMode.Allow` is therefore only needed when the fixed code declares a diagnostic that the fixer handles — typically with `CodeFixTestBehaviors.FixOne`, where applying a single fix leaves (or reveals) another diagnostic.

Removing the assignment from all 19 usages and running the affected test classes showed only 5 actually depend on it. This removes the other 14 and adds a comment to the one remaining usage that had none.

All 3860 tests pass on `roslyn5.9`; the affected classes also pass on `roslyn4.8`.
