### PR TITLE
Clean up the test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
     paths-ignore:
       - "docs/**"
+      - "tests/**"
       - "renovate.json"
       - "GenerateDocumentation.cmd"
       - ".markdownlint.json"

--- a/global.json
+++ b/global.json
@@ -4,9 +4,9 @@
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {
-    "Meziantou.NET.Sdk": "1.0.152",
-    "Meziantou.NET.Sdk.Test": "1.0.152",
-    "Meziantou.NET.Sdk.Web": "1.0.152"
+    "Meziantou.NET.Sdk": "1.0.161",
+    "Meziantou.NET.Sdk.Test": "1.0.161",
+    "Meziantou.NET.Sdk.Web": "1.0.161"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/src/Meziantou.Analyzer/Rules/DoNotIgnoreReturnValueAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotIgnoreReturnValueAnalyzer.cs
@@ -8,28 +8,17 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
 {
     private static readonly ConfigurationDefinition<bool> EnableTryParsePatternConfiguration = new(RuleIdentifiers.DoNotIgnoreReturnValue + ".enable_tryparse_pattern", defaultValue: true);
 
-    private static readonly DiagnosticDescriptor ReturnValueRule = new(
+    private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.DoNotIgnoreReturnValue,
         title: "The return value of the method should be used",
-        messageFormat: "The return value of '{0}' should be used{1}",
+        messageFormat: "{0}",
         RuleCategories.Design,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.DoNotIgnoreReturnValue));
 
-    private static readonly DiagnosticDescriptor OutParameterRule = new(
-        RuleIdentifiers.DoNotIgnoreReturnValue,
-        title: "The return value of the method should be used",
-        messageFormat: "The out parameter '{0}' of '{1}' should not be discarded{2}",
-        RuleCategories.Design,
-        DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
-        description: "",
-        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.DoNotIgnoreReturnValue));
-
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(ReturnValueRule, OutParameterRule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -85,8 +74,7 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
             var methodName = argument.Parent is IInvocationOperation inv ? inv.TargetMethod.Name : "?";
             var attr = outParam.GetFirstAttribute(DoNotIgnoreAttributeSymbol);
             var message = attr is not null ? GetMessageFromAttributeData(attr) : null;
-            context.ReportDiagnostic(OutParameterRule, argument,
-                outParam.Name, methodName, message is null ? "" : ": " + message);
+            context.ReportDiagnostic(Rule, argument, $"The out parameter '{outParam.Name}' of '{methodName}' should not be discarded{GetMessageSuffix(message)}");
         }
 
         public void AnalyzeInvocation(OperationAnalysisContext context)
@@ -108,15 +96,14 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
                 if (attr is not null)
                 {
                     var message = GetMessageFromAttributeData(attr);
-                    context.ReportDiagnostic(ReturnValueRule, invocation,
-                        targetMethod.Name, message is null ? "" : ": " + message);
+                    context.ReportDiagnostic(Rule, invocation, $"The return value of '{targetMethod.Name}' should be used{GetMessageSuffix(message)}");
                     return;
                 }
             }
 
             if (AssemblyLevelDoNotIgnoreSymbols.Contains(targetMethod.OriginalDefinition))
             {
-                context.ReportDiagnostic(ReturnValueRule, invocation, targetMethod.Name, "");
+                context.ReportDiagnostic(Rule, invocation, $"The return value of '{targetMethod.Name}' should be used");
                 return;
             }
 
@@ -124,7 +111,7 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
             if ((SystemDiagnosticsContractsPureAttributeSymbol is not null && targetMethod.HasAttribute(SystemDiagnosticsContractsPureAttributeSymbol)) ||
                 (JetBrainsAnnotationsPureAttributeSymbol is not null && targetMethod.HasAttribute(JetBrainsAnnotationsPureAttributeSymbol)))
             {
-                context.ReportDiagnostic(ReturnValueRule, invocation, targetMethod.Name, "");
+                context.ReportDiagnostic(Rule, invocation, $"The return value of '{targetMethod.Name}' should be used");
                 return;
             }
 
@@ -134,14 +121,14 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
                 if (IsIgnoredHResultMethod(targetMethod))
                     return;
 
-                context.ReportDiagnostic(ReturnValueRule, invocation, targetMethod.Name, "");
+                context.ReportDiagnostic(Rule, invocation, $"The return value of '{targetMethod.Name}' should be used");
                 return;
             }
 
             // Check built-in CLR list
             if (IsBuiltInMethod(context, targetMethod))
             {
-                context.ReportDiagnostic(ReturnValueRule, invocation, targetMethod.Name, "");
+                context.ReportDiagnostic(Rule, invocation, $"The return value of '{targetMethod.Name}' should be used");
             }
         }
 
@@ -263,6 +250,8 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
                 method.Parameters.Length >= 2 &&
                 method.Parameters[method.Parameters.Length - 1].RefKind != RefKind.None;
         }
+
+        private static string GetMessageSuffix(string? message) => message is null ? "" : ": " + message;
 
         private static string? GetMessageFromAttributeData(AttributeData attr)
         {

--- a/tests/Meziantou.Analyzer.Test/Directory.Build.props
+++ b/tests/Meziantou.Analyzer.Test/Directory.Build.props
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.6" PrivateAssets="all" />
+    <!-- Loaded at runtime by the IDE analyzers the suppressor tests run, so it must be in the output folder -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />

--- a/tests/Meziantou.Analyzer.Test/Harness/AnalyzerTestDefaults.cs
+++ b/tests/Meziantou.Analyzer.Test/Harness/AnalyzerTestDefaults.cs
@@ -20,7 +20,7 @@ internal static class AnalyzerTestDefaults
 
     /// <summary>
     /// The version of the .NET packages the tests reference by default, shared by the runtime reference assemblies
-    /// and the packages shipped with them, such as the one of <see cref="ReferenceAssembliesExtensions.AddAspNetCore(ReferenceAssemblies)"/>.
+    /// and the packages shipped with them, such as the one of <see cref="ReferenceAssembliesExtensions.AddAspNetCore(ReferenceAssemblies, string)"/>.
     /// </summary>
     public const string DotNetVersion = "11.0.0-preview.7.26381.103";
 

--- a/tests/Meziantou.Analyzer.Test/Harness/CSharpCodeFixTest.cs
+++ b/tests/Meziantou.Analyzer.Test/Harness/CSharpCodeFixTest.cs
@@ -1,3 +1,4 @@
+using Meziantou.Analyzer.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -26,6 +27,7 @@ internal sealed class CSharpCodeFixTest<TAnalyzer, TCodeFix>
     /// Runs the test with the cancellation token of the running test, which the base method cannot default to.
     /// This overload wins over the inherited <c>RunAsync(CancellationToken)</c> as it has no optional parameter.
     /// </summary>
+    [ExcludeFromCancellationTokenAnalysis]
     public Task RunAsync() => RunAsync(TestContext.Current.CancellationToken);
 
     /// <summary>

--- a/tests/Meziantou.Analyzer.Test/Harness/ReferenceAssembliesExtensions.cs
+++ b/tests/Meziantou.Analyzer.Test/Harness/ReferenceAssembliesExtensions.cs
@@ -30,12 +30,6 @@ internal static class ReferenceAssembliesExtensions
         ]);
 
     /// <summary>
-    /// Adds <c>System.Text.Json</c>.
-    /// </summary>
-    public static ReferenceAssemblies AddSystemTextJson(this ReferenceAssemblies referenceAssemblies) =>
-        referenceAssemblies.AddPackages([new PackageIdentity("System.Text.Json", "4.7.2")]);
-
-    /// <summary>
     /// Adds the NUnit API.
     /// </summary>
     public static ReferenceAssemblies AddNUnitApi(this ReferenceAssemblies referenceAssemblies) =>

--- a/tests/Meziantou.Analyzer.Test/Harness/ReferenceAssembliesExtensions.cs
+++ b/tests/Meziantou.Analyzer.Test/Harness/ReferenceAssembliesExtensions.cs
@@ -2,36 +2,120 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Meziantou.Analyzer.Test.Harness;
 
+/// <summary>
+/// The packages a test can reference, so that the tests referencing the same package use the same version.
+/// Every method uses the latest version of the package unless the test asks for a specific one.
+/// </summary>
 internal static class ReferenceAssembliesExtensions
 {
     /// <summary>
     /// Adds the reference assemblies of ASP.NET Core, in the version matching the .NET version the tests use by default.
     /// </summary>
-    public static ReferenceAssemblies AddAspNetCore(this ReferenceAssemblies referenceAssemblies) =>
-        referenceAssemblies.AddAspNetCore(AnalyzerTestDefaults.DotNetVersion);
+    public static ReferenceAssemblies AddAspNetCore(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Microsoft.AspNetCore.App.Ref", version ?? AnalyzerTestDefaults.DotNetVersion)]);
 
-    /// <inheritdoc cref="AddAspNetCore(ReferenceAssemblies)" />
-    public static ReferenceAssemblies AddAspNetCore(this ReferenceAssemblies referenceAssemblies, string version) =>
-        referenceAssemblies.AddPackages([new PackageIdentity("Microsoft.AspNetCore.App.Ref", version)]);
+    /// <summary>
+    /// Adds the attributes of BenchmarkDotNet, such as <c>[Benchmark]</c>.
+    /// </summary>
+    public static ReferenceAssemblies AddBenchmarkDotNet(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("BenchmarkDotNet.Annotations", version ?? "0.15.8")]);
+
+    /// <summary>
+    /// Adds the data classification API, such as <c>[PersonalData]</c>.
+    /// </summary>
+    public static ReferenceAssemblies AddComplianceAbstractions(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Extensions.Compliance.Abstractions", version ?? "10.9.0")]);
+
+    /// <summary>
+    /// Adds Entity Framework Core.
+    /// </summary>
+    public static ReferenceAssemblies AddEntityFrameworkCore(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([
+            new PackageIdentity("Microsoft.EntityFrameworkCore", version ?? "10.0.11"),
+            new PackageIdentity("Microsoft.EntityFrameworkCore.Abstractions", version ?? "10.0.11"),
+        ]);
+
+    /// <summary>
+    /// Adds the JavaScript interop API of Blazor WebAssembly, in the version matching the .NET version the tests use by default.
+    /// </summary>
+    public static ReferenceAssemblies AddJSInterop(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Microsoft.JSInterop.WebAssembly", version ?? AnalyzerTestDefaults.DotNetVersion)]);
+
+    /// <summary>
+    /// Adds <c>ILogger</c> and its extension methods.
+    /// </summary>
+    public static ReferenceAssemblies AddLoggingAbstractions(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", version ?? "10.0.11")]);
+
+    /// <summary>
+    /// Adds <c>Meziantou.Framework</c>.
+    /// </summary>
+    public static ReferenceAssemblies AddMeziantouFramework(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Meziantou.Framework", version ?? "6.0.2")]);
+
+    /// <summary>
+    /// Adds the assertions of <c>Meziantou.Framework</c>.
+    /// </summary>
+    public static ReferenceAssemblies AddMeziantouFrameworkAssertions(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Meziantou.Framework.Assertions", version ?? "2.0.5")]);
+
+    /// <summary>
+    /// Adds Moq.
+    /// </summary>
+    public static ReferenceAssemblies AddMoq(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Moq", version ?? "4.20.72")]);
 
     /// <summary>
     /// Adds the MSTest API.
     /// </summary>
-    public static ReferenceAssemblies AddMSTestApi(this ReferenceAssemblies referenceAssemblies) =>
-        referenceAssemblies.AddPackages([new PackageIdentity("MSTest.TestFramework", "2.1.1")]);
+    public static ReferenceAssemblies AddMSTest(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("MSTest.TestFramework", version ?? "4.3.3")]);
 
     /// <summary>
-    /// Adds the xUnit v3 API.
+    /// Adds <c>Newtonsoft.Json</c>.
     /// </summary>
-    public static ReferenceAssemblies AddXUnitApi(this ReferenceAssemblies referenceAssemblies) =>
-        referenceAssemblies.AddPackages([
-            new PackageIdentity("xunit.v3.extensibility.core", "4.0.0"),
-            new PackageIdentity("xunit.v3.assert", "4.0.0"),
-        ]);
+    public static ReferenceAssemblies AddNewtonsoftJson(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Newtonsoft.Json", version ?? "13.0.4")]);
 
     /// <summary>
     /// Adds the NUnit API.
     /// </summary>
-    public static ReferenceAssemblies AddNUnitApi(this ReferenceAssemblies referenceAssemblies) =>
-        referenceAssemblies.AddPackages([new PackageIdentity("NUnit", "3.12.0")]);
+    public static ReferenceAssemblies AddNUnit(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("NUnit", version ?? "4.6.1")]);
+
+    /// <summary>
+    /// Adds Serilog.
+    /// </summary>
+    public static ReferenceAssemblies AddSerilog(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Serilog", version ?? "4.4.0")]);
+
+    /// <summary>
+    /// Adds the SQLite ADO.NET provider.
+    /// </summary>
+    public static ReferenceAssemblies AddSqlite(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", version ?? "10.0.11")]);
+
+    /// <summary>
+    /// Adds <c>YamlDotNet</c>.
+    /// </summary>
+    public static ReferenceAssemblies AddYamlDotNet(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([new PackageIdentity("YamlDotNet", version ?? "18.1.0")]);
+
+    /// <summary>
+    /// Adds the xUnit v3 API.
+    /// </summary>
+    public static ReferenceAssemblies AddXunitV3(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([
+            new PackageIdentity("xunit.v3.extensibility.core", version ?? "4.0.0"),
+            new PackageIdentity("xunit.v3.assert", version ?? "4.0.0"),
+        ]);
+
+    /// <summary>
+    /// Adds the xUnit v2 API, which the tests asserting the behavior of the previous major version rely on.
+    /// </summary>
+    public static ReferenceAssemblies AddXunitV2(this ReferenceAssemblies referenceAssemblies, string? version = null) =>
+        referenceAssemblies.AddPackages([
+            new PackageIdentity("xunit.extensibility.core", version ?? "2.9.3"),
+            new PackageIdentity("xunit.assert", version ?? "2.9.3"),
+        ]);
 }

--- a/tests/Meziantou.Analyzer.Test/Harness/ReferenceAssembliesExtensions.cs
+++ b/tests/Meziantou.Analyzer.Test/Harness/ReferenceAssembliesExtensions.cs
@@ -21,12 +21,12 @@ internal static class ReferenceAssembliesExtensions
         referenceAssemblies.AddPackages([new PackageIdentity("MSTest.TestFramework", "2.1.1")]);
 
     /// <summary>
-    /// Adds the xUnit API.
+    /// Adds the xUnit v3 API.
     /// </summary>
     public static ReferenceAssemblies AddXUnitApi(this ReferenceAssemblies referenceAssemblies) =>
         referenceAssemblies.AddPackages([
-            new PackageIdentity("xunit.extensibility.core", "2.4.1"),
-            new PackageIdentity("xunit.assert", "2.4.1"),
+            new PackageIdentity("xunit.v3.extensibility.core", "4.0.0"),
+            new PackageIdentity("xunit.v3.assert", "4.0.0"),
         ]);
 
     /// <summary>

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
@@ -1055,7 +1055,7 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     public Task InternalClassUsedByNewtonsoftJsonSerializer_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Newtonsoft.Json", "13.0.3")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddNewtonsoftJson();
         test.TestCode = """
             using Newtonsoft.Json;
 
@@ -1083,7 +1083,7 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     {
         var test = CreateTest();
         test.ReferenceAssemblies = ReferenceAssemblies.NetStandard.NetStandard20;
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("YamlDotNet", "16.3.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddYamlDotNet();
         test.TestCode = """
             using YamlDotNet.Serialization;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
@@ -2248,8 +2248,8 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             }
             """;
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
+        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.SkipFixAllCheck;
 
         return test.RunAsync();
     }
@@ -2270,7 +2270,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             }
             """;
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedCode = """
 
             public class UsedClass
@@ -2296,7 +2295,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             }
             """;
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedCode = """
             public class OuterClass
             {
@@ -2320,8 +2318,8 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             }
             """;
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
+        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.SkipFixAllCheck;
 
         return test.RunAsync();
     }
@@ -2334,8 +2332,8 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             internal record struct {|MA0182:UnusedRecordStruct|}(int Value);
             """;
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
+        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.SkipFixAllCheck;
 
         return test.RunAsync();
     }
@@ -2381,8 +2379,8 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             }
             """;
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
+        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.SkipFixAllCheck;
 
         return test.RunAsync();
     }
@@ -2403,8 +2401,8 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             }
             """;
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
+        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.SkipFixAllCheck;
 
         return test.RunAsync();
     }
@@ -2422,7 +2420,6 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
             }
             """;
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedCode = """
             [assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
 

--- a/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
@@ -227,7 +227,7 @@ public sealed class ClassMustBeSealedAnalyzerTests
     public Task BenchmarkDotNetAttributes()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("BenchmarkDotNet.Annotations", "0.15.8")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddBenchmarkDotNet();
         test.TestCode = """
             using BenchmarkDotNet.Attributes;
             internal class Test

--- a/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ClassMustBeSealedAnalyzerTests.cs
@@ -227,7 +227,7 @@ public sealed class ClassMustBeSealedAnalyzerTests
     public Task BenchmarkDotNetAttributes()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("BenchmarkDotNet.Annotations", "0.13.2")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("BenchmarkDotNet.Annotations", "0.15.8")]);
         test.TestCode = """
             using BenchmarkDotNet.Attributes;
             internal class Test

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotIgnoreReturnValueAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotIgnoreReturnValueAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.DoNotIgnoreReturnValueAnalyzer>;
@@ -12,9 +11,6 @@ public sealed class DoNotIgnoreReturnValueAnalyzerTests
     {
         var test = new AnalyzerTest();
         test.TestState.AddMeziantouAnnotations();
-
-        // The analyzer declares two descriptors with the same MA0060 id, so the markup cannot tell them apart
-        test.MarkupOptions = MarkupOptions.UseFirstDescriptor;
         return test;
     }
 
@@ -224,10 +220,11 @@ public sealed class DoNotIgnoreReturnValueAnalyzerTests
 
                 void A()
                 {
-                    {|MA0060:Compute()|};
+                    {|#0:Compute()|};
                 }
             }
             """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0060", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("The return value of 'Compute' should be used: Use the result to check success"));
 
         return test.RunAsync();
     }
@@ -244,10 +241,11 @@ public sealed class DoNotIgnoreReturnValueAnalyzerTests
 
                 void A()
                 {
-                    TryGet({|MA0060:out _|});
+                    TryGet({|#0:out _|});
                 }
             }
             """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0060", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("The out parameter 'value' of 'TryGet' should not be discarded"));
 
         return test.RunAsync();
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotLogClassifiedDataAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotLogClassifiedDataAnalyzerTests.cs
@@ -13,10 +13,7 @@ public sealed class DoNotLogClassifiedDataAnalyzerTests
     {
         var test = new AnalyzerTest();
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([
-            new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", "8.0.0"),
-            new PackageIdentity("Microsoft.Extensions.Compliance.Abstractions", "8.0.0"),
-        ]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddLoggingAbstractions().AddComplianceAbstractions();
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -12,7 +12,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.NetStandard.NetStandard21;
         test.DisabledDiagnostics.Add("MA0045");
         return test;
     }
@@ -486,7 +485,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task AsyncMethodWithAsyncOverload()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSystemTextJson();
         test.TestCode = """
             using System;
             using System.IO;
@@ -612,6 +610,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task ProcessWaitForExit_NET5()
     {
         var test = CreateTest();
+        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50;
         test.TestCode = """
             using System.Threading.Tasks;
             using System.Diagnostics;

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -632,7 +632,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task ProcessWaitForExit_NET6()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System.Threading.Tasks;
             using System.Diagnostics;
@@ -1691,7 +1690,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task Argument_ImplicitNumericHalfToSingle_ShouldReport()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.TestCode = """
             using System;
             using System.Threading;
@@ -1987,7 +1985,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task CreateAsyncScope()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60.AddAspNetCore("6.0.10");
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddAspNetCore();
         test.TestCode = """
             using System;
             using System.Threading.Tasks;
@@ -2034,8 +2032,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task DbContext_Add()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.EntityFrameworkCore", "6.0.8"), new PackageIdentity("Microsoft.EntityFrameworkCore.Abstractions", "6.0.8")]);
+        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60.AddPackages([new PackageIdentity("Microsoft.EntityFrameworkCore", "6.0.8"), new PackageIdentity("Microsoft.EntityFrameworkCore.Abstractions", "6.0.8")]);
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.EntityFrameworkCore;
@@ -2065,7 +2062,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task IDbContextFactory_CreateDbContext_NoReport()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
         test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.EntityFrameworkCore", "6.0.8"), new PackageIdentity("Microsoft.EntityFrameworkCore.Abstractions", "6.0.8")]);
         test.TestCode = """
             using System.Threading.Tasks;
@@ -3431,7 +3427,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbBatchSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3472,7 +3467,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbBatchSubclass_NoDisposeAsyncOverride_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;
@@ -3515,7 +3509,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingFactoryMethod_DbBatchSubclass_NoDisposeAsyncOverride_OptionDisabled_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.SetConfiguration("MA0042.enable_db_special_cases", "false");
         test.TestCode = """
             using System.Data;
@@ -3559,7 +3552,6 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task UsingNewDbBatchSubclass_WithDisposeAsyncOverride_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestCode = """
             using System.Data;
             using System.Data.Common;

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests.cs
@@ -2032,7 +2032,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task DbContext_Add()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net60.AddPackages([new PackageIdentity("Microsoft.EntityFrameworkCore", "6.0.8"), new PackageIdentity("Microsoft.EntityFrameworkCore.Abstractions", "6.0.8")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddEntityFrameworkCore();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.EntityFrameworkCore;
@@ -2062,7 +2062,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task IDbContextFactory_CreateDbContext_NoReport()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.EntityFrameworkCore", "6.0.8"), new PackageIdentity("Microsoft.EntityFrameworkCore.Abstractions", "6.0.8")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddEntityFrameworkCore();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.EntityFrameworkCore;
@@ -2088,7 +2088,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteConnection_CreateCommand_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.Data.Sqlite;
@@ -2110,7 +2110,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteConnection_Close_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.Data.Sqlite;
@@ -2132,7 +2132,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteCommand_Prepare_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.Data.Sqlite;
@@ -2155,7 +2155,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     {
         var test = CreateTest();
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.Data.Sqlite;
@@ -2178,7 +2178,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     {
         var test = CreateTest();
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.Data.Sqlite;
@@ -2201,7 +2201,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     {
         var test = CreateTest();
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.Data.Sqlite;
@@ -2223,7 +2223,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task SqliteDataReader_Read_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.Data.Sqlite;
@@ -2246,7 +2246,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     {
         var test = CreateTest();
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.Data.Sqlite;
@@ -2268,7 +2268,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task DbConnectionAssignedFromSqliteConnection_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Data.Common;
             using System.Threading.Tasks;
@@ -2292,7 +2292,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task DbConnectionNotAssignedFromSqliteConnection_Diagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using System.Data.Common;
             using System.Threading.Tasks;
@@ -2438,7 +2438,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task Moq_Raise()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Moq", "4.20.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMoq();
         test.TestCode = """
             using System;
             using Moq;
@@ -2665,7 +2665,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task TemporaryDirectory_InTestProject_WithXunit_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
         test.TestCode = """
             using System.Threading.Tasks;
             using Meziantou.Framework;
@@ -2696,7 +2696,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task TemporaryDirectory_InTestProject_WithNUnit_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddNUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddNUnit();
         test.TestCode = """
             using System.Threading.Tasks;
             using Meziantou.Framework;
@@ -2727,7 +2727,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests
     public Task TemporaryDirectory_InTestProject_WithMSTest_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTestApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTest();
         test.TestCode = """
             using System.Threading.Tasks;
             using Meziantou.Framework;

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.DoNotUseBlockingCallInAsyncContextAnalyzer>;
 
@@ -143,7 +142,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteConnection_CreateCommand_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using Microsoft.Data.Sqlite;
 
@@ -164,7 +163,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteCommand_Prepare_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using Microsoft.Data.Sqlite;
 
@@ -185,7 +184,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteConnection_Close_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using Microsoft.Data.Sqlite;
 
@@ -207,7 +206,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     {
         var test = CreateTest();
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using Microsoft.Data.Sqlite;
 
@@ -229,7 +228,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     {
         var test = CreateTest();
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using Microsoft.Data.Sqlite;
 
@@ -250,7 +249,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     public Task PrivateNonAsync_SqliteDataReader_Read_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using Microsoft.Data.Sqlite;
 
@@ -272,7 +271,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer_NonAsyncContextTe
     {
         var test = CreateTest();
         test.TestState.SetConfiguration("MA0042.enable_sqlite_special_cases", "false");
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Data.Sqlite.Core", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSqlite();
         test.TestCode = """
             using Microsoft.Data.Sqlite;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/ILoggerParameterTypeShouldMatchContainingTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ILoggerParameterTypeShouldMatchContainingTypeAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.ILoggerParameterTypeShouldMatchContainingTypeAnalyzer,
     Meziantou.Analyzer.Rules.ILoggerParameterTypeShouldMatchContainingTypeFixer>;
@@ -12,7 +11,7 @@ public sealed class ILoggerParameterTypeShouldMatchContainingTypeAnalyzerTests
     private static CodeFixTest CreateTest()
     {
         var test = new CodeFixTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddLoggingAbstractions();
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/JSInteropMustNotBeUsedInOnInitializedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/JSInteropMustNotBeUsedInOnInitializedAnalyzerTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.JSInteropMustNotBeUsedInOnInitializedAnalyzer>;
 
@@ -17,7 +16,7 @@ public sealed class JSInteropMustNotBeUsedInOnInitializedAnalyzerTests
     public Task WebAssembly_NoReport()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.JSInterop.WebAssembly", AnalyzerTestDefaults.DotNetVersion)]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddJSInterop();
         test.TestCode = """
             using System.Threading.Tasks;
             using Microsoft.AspNetCore.Components;

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
@@ -13,7 +13,7 @@ public sealed class LoggerParameterTypeAnalyzerTests
     {
         var test = new AnalyzerTest();
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", "8.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddLoggingAbstractions();
         return test;
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzer_SerilogTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzer_SerilogTests.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.LoggerParameterTypeAnalyzer>;
 
@@ -11,7 +10,7 @@ public sealed class LoggerParameterTypeAnalyzer_SerilogTests
     private static AnalyzerTest CreateTest()
     {
         var test = new AnalyzerTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Serilog", "3.1.1")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddSerilog();
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
         return test;
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/MakeClassStaticAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MakeClassStaticAnalyzerTests.cs
@@ -164,7 +164,7 @@ public sealed class MakeClassStaticAnalyzerTests
     public Task MsTestClass_NoDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTestApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTest();
         test.TestCode = """
             [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
             class Test

--- a/tests/Meziantou.Analyzer.Test/Rules/MakeMethodStaticAnalyzerTests_Methods.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MakeMethodStaticAnalyzerTests_Methods.cs
@@ -384,7 +384,7 @@ public sealed class MakeMethodStaticAnalyzerTests_Methods
     public Task MSTest_TestMethod()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTestApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTest();
         test.TestCode = """
             class TestClass
             {
@@ -402,7 +402,7 @@ public sealed class MakeMethodStaticAnalyzerTests_Methods
     public Task MSTest_DataTestMethod()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTestApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTest();
         test.TestCode = """
             class TestClass
             {
@@ -420,7 +420,7 @@ public sealed class MakeMethodStaticAnalyzerTests_Methods
     public Task XUnit_TestMethod()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
         test.TestCode = """
             class TestClass
             {
@@ -438,7 +438,7 @@ public sealed class MakeMethodStaticAnalyzerTests_Methods
     public Task XUnit_TestMethodCustomAttribute()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
         test.TestCode = """
             class TestClass
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyzerTests.cs
@@ -294,7 +294,7 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
     public Task IgnoreTestMethods()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
         test.TestCode = """
             class TypeName
             {
@@ -383,7 +383,7 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
     {
         var test = CreateTest();
         test.TestState.SetConfiguration("MA0137.exclude_test_methods", "true");
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
         test.TestCode = """
             class TypeName
             {
@@ -400,7 +400,7 @@ public sealed class MethodsReturningAnAwaitableTypeMustHaveTheAsyncSuffixAnalyze
     {
         var test = CreateTest();
         test.TestState.SetConfiguration("MA0137.exclude_test_methods", "false");
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
         test.TestCode = """
             class TypeName
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.NamedParameterAnalyzer,
     Meziantou.Analyzer.Rules.NamedParameterFixer>;
@@ -502,11 +501,11 @@ public sealed class NamedParameterAnalyzerTests
     public Task MSTestAssert_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTestApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTest();
         test.TestCode = """
             class TypeName
             {
-                public void Test() => Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual(null, true);
+                public void Test() => Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual(null, "dummy");
             }
             """;
 
@@ -517,11 +516,11 @@ public sealed class NamedParameterAnalyzerTests
     public Task NunitAssert_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddNUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddNUnit();
         test.TestCode = """
             class TypeName
             {
-                public void Test() => NUnit.Framework.Assert.AreEqual(null, true);
+                public void Test() => NUnit.Framework.Assert.That(true, NUnit.Framework.Is.True);
             }
             """;
 
@@ -532,7 +531,7 @@ public sealed class NamedParameterAnalyzerTests
     public Task XunitAssert_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
         test.TestCode = """
             class TypeName
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -617,8 +617,8 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     {
         var test = CreateTest();
         // Applying this fix reveals another diagnostic, and the test asserts the result of a single application
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedState.MarkupHandling = MarkupMode.Allow;
+        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne;
         test.TestCode = """
             using System.Text;
             class Test
@@ -648,8 +648,8 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     {
         var test = CreateTest();
         // Applying this fix reveals another diagnostic, and the test asserts the result of a single application
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedState.MarkupHandling = MarkupMode.Allow;
+        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne;
         test.TestCode = """
             using System.Text;
             class Test
@@ -735,7 +735,6 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     {
         var test = CreateTest();
         // Applying this fix reveals another diagnostic, and the test asserts the result of a single application
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.TestCode = """
             using System.Text;
             class Test
@@ -1020,8 +1019,8 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     {
         var test = CreateTest();
         // Applying this fix reveals another diagnostic, and the test asserts the result of a single application
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedState.MarkupHandling = MarkupMode.Allow;
+        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne;
         test.TestCode = """
             using System.Text;
             class Test

--- a/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTests.cs
@@ -55,7 +55,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
             }
             """;
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedCode = """
             class Dummy
             {
@@ -85,7 +84,6 @@ public sealed class StringShouldNotContainsNonDeterministicEndOfLineAnalyzerTest
             }
             """;
         test.CodeActionIndex = 2;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedCode = """
             class Dummy
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -327,7 +327,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
             }
             """;
         test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0040", DiagnosticSeverity.Info).WithLocation(0).WithMessage("Use an overload with a CancellationToken, available tokens: MyCancellationToken, Context.RequestAborted"));
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedCode = """
             class Test : ControllerBase
             {
@@ -386,7 +385,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
             """;
         test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0040", DiagnosticSeverity.Info).WithLocation(0).WithMessage("Use an overload with a CancellationToken, available tokens: MyCancellationToken, Context.RequestAborted"));
         test.CodeActionIndex = 1;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedCode = """
             class Test : ControllerBase
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -1252,7 +1252,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     {
         var test = CreateTest();
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("xunit.abstractions", "2.0.3")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV2();
         test.TestCode = """
             using System.Threading;
             using System.Threading.Tasks;
@@ -1274,7 +1274,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     {
         var test = CreateTest();
         test.TestState.OutputKind = OutputKind.ConsoleApplication;
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("xunit.v3.extensibility.core", "1.0.0")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
         test.TestCode = """
             using System.Threading;
             using System.Threading.Tasks;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
@@ -575,7 +575,7 @@ public sealed class UseConfigureAwaitAnalyzerTests
     public Task XUnitAttribute_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXUnitApi();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
         test.TestCode = """
             using System.Threading.Tasks;
             class ClassTest

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparerAnalyzerTests.cs
@@ -25,7 +25,7 @@ public sealed class UseStringComparerAnalyzerTests
     private static CodeFixTest CreateMSTestTest()
     {
         var test = new CodeFixTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("MSTest.TestFramework", "4.3.3")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMSTest();
         return test;
     }
 
@@ -785,7 +785,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ImmutableDictionary_CreateBuilder_String_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net48.Wpf.AddPackages([new PackageIdentity("System.Collections.Immutable", "8.0.0")]);
         test.TestCode = """
             class TypeName
             {
@@ -803,7 +802,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ImmutableDictionary_CreateBuilder_String_WithComparer_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net48.Wpf.AddPackages([new PackageIdentity("System.Collections.Immutable", "8.0.0")]);
         test.TestCode = """
             class TypeName
             {
@@ -821,7 +819,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ImmutableDictionary_Create_String_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net48.Wpf.AddPackages([new PackageIdentity("System.Collections.Immutable", "8.0.0")]);
         test.TestCode = """
             class TypeName
             {
@@ -892,7 +889,7 @@ public sealed class UseStringComparerAnalyzerTests
     public Task MeziantouFrameworkAssertions_Assert_WithoutComparerOverload_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Meziantou.Framework.Assertions", "2.0.1")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMeziantouFrameworkAssertions();
         test.TestCode = """
             class TypeName
             {
@@ -1005,7 +1002,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ReportOnlyNonOrdinal_ImmutableDictionaryCreateBuilder_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net48.Wpf.AddPackages([new PackageIdentity("System.Collections.Immutable", "8.0.0")]);
         test.TestState.SetConfiguration(ReportOnlyNonOrdinalConfigurationName, "true");
         test.TestCode = """
             class TypeName
@@ -1024,7 +1020,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ReportOnlyNonOrdinal_ImmutableDictionaryCreate_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net48.Wpf.AddPackages([new PackageIdentity("System.Collections.Immutable", "8.0.0")]);
         test.TestState.SetConfiguration(ReportOnlyNonOrdinalConfigurationName, "true");
         test.TestCode = """
             class TypeName
@@ -1043,7 +1038,6 @@ public sealed class UseStringComparerAnalyzerTests
     public Task ReportOnlyNonOrdinal_ImmutableSortedDictionaryCreate_ShouldReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net48.Wpf.AddPackages([new PackageIdentity("System.Collections.Immutable", "8.0.0")]);
         test.TestState.SetConfiguration(ReportOnlyNonOrdinalConfigurationName, "true");
         test.TestCode = """
             class TypeName

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerNonCultureSensitiveTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerNonCultureSensitiveTests.cs
@@ -331,7 +331,7 @@ public sealed class UseStringComparisonAnalyzerNonCultureSensitiveTests
     public Task MeziantouFrameworkAssertions_Assert_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Meziantou.Framework.Assertions", "2.0.1")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMeziantouFrameworkAssertions();
         test.TestCode = """
             class TypeName
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsAnalyzerTests.cs
@@ -197,7 +197,6 @@ public sealed class UseStringEqualsAnalyzerTests
             }
             """;
         test.CodeActionIndex = 2;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedCode = """
             using Meziantou.Framework;
 
@@ -228,7 +227,6 @@ public sealed class UseStringEqualsAnalyzerTests
             }
             """;
         test.CodeActionIndex = 3;
-        test.CodeFixTestBehaviors |= CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck;
         test.FixedCode = """
             using Meziantou.Framework;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsAnalyzerTests.cs
@@ -186,7 +186,7 @@ public sealed class UseStringEqualsAnalyzerTests
     public Task Replace_Meziantou_Framework_EqualsOrdinal()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Meziantou.Framework", "3.0.23")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMeziantouFramework();
         test.TestCode = """
             class TypeName
             {
@@ -216,7 +216,7 @@ public sealed class UseStringEqualsAnalyzerTests
     public Task Replace_Meziantou_Framework_EqualsIgnoreCase()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Meziantou.Framework", "3.0.23")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddMeziantouFramework();
         test.TestCode = """
             class TypeName
             {

--- a/tests/Meziantou.Analyzer.Test/Suppressors/CA1507SerializationPropertyNameSuppressorTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Suppressors/CA1507SerializationPropertyNameSuppressorTests.cs
@@ -60,7 +60,7 @@ public sealed class CA1507SerializationPropertyNameSuppressorTests
     public Task CA1507_NewtonsoftJson_JsonPropertyName()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Newtonsoft.Json", "13.0.3")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddNewtonsoftJson();
         test.TestCode = """
             internal class Test
             {
@@ -77,7 +77,7 @@ public sealed class CA1507SerializationPropertyNameSuppressorTests
     public Task CA1507_NewtonsoftJson_JsonPropertyName_NamedParameter()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Newtonsoft.Json", "13.0.3")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddNewtonsoftJson();
         test.TestCode = """
             internal class Test
             {
@@ -94,7 +94,7 @@ public sealed class CA1507SerializationPropertyNameSuppressorTests
     public Task CA1507_NewtonsoftJson_JsonPropertyName_AfterAnUnrelatedDiagnostic()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("Newtonsoft.Json", "13.0.3")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddNewtonsoftJson();
         test.TestCode = """
             internal class Test
             {

--- a/tests/Meziantou.Analyzer.Test/Suppressors/CA1822DecoratedMethodSuppressorTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Suppressors/CA1822DecoratedMethodSuppressorTests.cs
@@ -47,7 +47,7 @@ public sealed class CA1822DecoratedMethodSuppressorTests
     public Task CA1822IsSuppressOnBenchmarkAttributeMethods()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("BenchmarkDotNet.Annotations", "0.15.8")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddBenchmarkDotNet();
         test.TestCode = """
             internal class A
             {

--- a/tests/Meziantou.Analyzer.Test/Suppressors/CA1822DecoratedMethodSuppressorTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Suppressors/CA1822DecoratedMethodSuppressorTests.cs
@@ -47,7 +47,7 @@ public sealed class CA1822DecoratedMethodSuppressorTests
     public Task CA1822IsSuppressOnBenchmarkAttributeMethods()
     {
         var test = CreateTest();
-        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("BenchmarkDotNet.Annotations", "0.13.5")]);
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddPackages([new PackageIdentity("BenchmarkDotNet.Annotations", "0.15.8")]);
         test.TestCode = """
             internal class A
             {


### PR DESCRIPTION
## What changed

### Analyzer

- **MA0060 (`DoNotIgnoreReturnValueAnalyzer`) now declares a single descriptor.** `ReturnValueRule` and `OutParameterRule` shared the `MA0060` id, which forced every test of that rule to use `MarkupOptions.UseFirstDescriptor`. They are merged into one `Rule` with `messageFormat: "{0}"` (the pattern already used by `OptimizeStringBuilderUsageAnalyzer` and others), and the message is composed at the report site. **The reported messages are unchanged**, suffix included:
  - `The return value of 'X' should be used` (+ `: <Message>` from `[DoNotIgnore]`)
  - `The out parameter 'x' of 'M' should not be discarded` (+ `: <Message>`)

### Tests

- Removed the redundant `CodeFixTestBehaviors.FixOne | CodeFixTestBehaviors.SkipFixAllCheck` pairs. The two flags are orthogonal and the pairing is valid, but only 7 of the 13 sites needed a flag at all: 4 tests in `AvoidUnusedInternalTypesAnalyzerTests` keep `SkipFixAllCheck` (the fix removes the file's only type, so the harness cannot compare a state with no document) and 3 in `OptimizeStringBuilderUsageAnalyzerTests` keep `FixOne` (the fix reveals another diagnostic). Each removal was verified by re-running the affected classes.
- `DoNotIgnoreReturnValueAnalyzerTests` drops `UseFirstDescriptor` and, now that the message is assertable, pins both message shapes with `{|#0:…|}` + `WithMessage(...)`.
- All package references go through named extension methods on `ReferenceAssemblies` with an optional version — `AddSerilog()`, `AddSqlite()`, `AddEntityFrameworkCore()`, `AddNewtonsoftJson()`, `AddMoq()`, … — instead of inline `AddPackages([new PackageIdentity(...)])`. Default versions are the latest stable ones (MSTest 4.3.3, NUnit 4.6.1, xUnit v3 4.0.0, EF Core 10.0.11, Serilog 4.4.0, YamlDotNet 18.1.0, …); a test that needs a specific version passes it.
- Renamed `AddXUnitApi` → `AddXunit` (now xUnit **v3**), `AddMSTestApi` → `AddMSTest`, `AddNUnitApi` → `AddNUnit`. Added `AddXunitV2` for the test that asserts the pre-`Xunit.TestContext` behavior. Removed `AddSystemTextJson` and `AddSystemCollectionsImmutable`, which only existed because a few tests compiled against an older target framework.
- `DoNotUseBlockingCallInAsyncContextAnalyzer_AsyncContextTests` no longer pins `netstandard2.1` for the whole class (it dated back to needing `ValueTask` in 2020). Only `ProcessWaitForExit_NET5` depended on it and now pins `Net50` explicitly, matching its name and its `ProcessWaitForExit_NET6` counterpart.
- The 6 `UseStringComparerAnalyzerTests` immutable-collection tests no longer target `net48` + a `System.Collections.Immutable` package; nothing in them is framework specific.

### Build / CI

- `paths-ignore` of the `push` trigger now includes `tests/**`, so a push to `main` touching only tests does not run the workflow and does not publish a package. Pull requests still run the full matrix.
- Bumped `Meziantou.NET.Sdk`, `.Test` and `.Web` to `1.0.161`.
- Documented why `Microsoft.Bcl.AsyncInterfaces` must stay: the suppressor tests `Assembly.LoadFrom` the IDE code-style analyzers, which need it in the output folder.

## Notes for reviewers

- Two test snippets had to be adapted to the newer test frameworks: MSTest 4 cannot infer `T` for `AreEqual(null, true)`, and NUnit 4 moved `Assert.AreEqual` to `ClassicAssert` (which MA0003 does not exempt), so the snippet is now `Assert.That(true, Is.True)` — still a boolean literal on `NUnit.Framework.Assert`, so it exercises the same exemption. `Assert.That(null, Is.Null)` was rejected because it is ambiguous under Roslyn 4.8.
- `DbContext_Add` moved off `Net60` because EF Core 10 does not support `net6.0`.
- `global.json` was updated despite the `AGENTS.md` rule, at the maintainer's request.

## Validation

Full test suite passes on every supported Roslyn version: 4.8 (3748), 4.14 (3775), 5.0 (3803), 5.6 (3827), 5.9 (3860) — 0 failures. `dotnet build` is clean and `dotnet run --project src/DocumentationGenerator` reports no documentation change.
