### PR TITLE
Do not report MA0214 on functions returning only completed tasks

### DIFF
--- a/docs/Rules/MA0214.md
+++ b/docs/Rules/MA0214.md
@@ -14,3 +14,14 @@ async Task<int> Sample() => await GetValueAsync(); // compliant
 ````
 
 The rule reports methods, local functions, and lambdas whose **every** `return` statement returns an awaitable task (or whose expression body does). It is not reported when a return value cannot be awaited (`return null;`, `return default;`), nor inside `try`/`using`/`lock`/`fixed` blocks. When several `return` statements are present they are all rewritten to use `await`.
+
+Functions that only return already-completed tasks, such as the ones implementing an asynchronous interface synchronously, are not reported as awaiting those tasks brings no benefit:
+
+````c#
+Task Sample() => Task.CompletedTask; // compliant
+Task<bool> Sample() => Task.FromResult(false); // compliant
+ValueTask<bool> Sample() => new ValueTask<bool>(false); // compliant
+
+// Still reported, as one of the returned tasks is not completed
+Task<bool> Sample(bool condition) => condition ? GetValueAsync() : Task.FromResult(false); // non-compliant
+````

--- a/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
+++ b/src/Meziantou.Analyzer/Internals/AwaitableTypes.cs
@@ -206,6 +206,40 @@ internal sealed class AwaitableTypes
         return false;
     }
 
+    /// <summary>
+    /// Determines whether the operation always produces an already-completed task, such as
+    /// <c>Task.CompletedTask</c>, <c>Task.FromResult(value)</c> or <c>new ValueTask&lt;T&gt;(value)</c>.
+    /// Awaiting such a task does not introduce any asynchrony.
+    /// </summary>
+    public bool IsCompletedTask(IOperation operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        // Task.CompletedTask, ValueTask.CompletedTask
+        if (operation is IPropertyReferenceOperation propertyReference)
+            return propertyReference.Property.Name is nameof(Task.CompletedTask) && propertyReference.Property.ContainingType.IsEqualToAny(TaskSymbol, ValueTaskSymbol);
+
+        // Task.FromResult, Task.FromCanceled, Task.FromException and their ValueTask counterparts
+        if (operation is IInvocationOperation invocation)
+            return invocation.TargetMethod.Name is nameof(Task.FromResult) or nameof(Task.FromCanceled) or nameof(Task.FromException) && invocation.TargetMethod.ContainingType.IsEqualToAny(TaskSymbol, ValueTaskSymbol);
+
+        if (operation is IObjectCreationOperation objectCreation && objectCreation.Type is INamedTypeSymbol type)
+        {
+            // new ValueTask()
+            if (type.OriginalDefinition.IsEqualTo(ValueTaskSymbol) && objectCreation.Arguments.Length == 0)
+                return true;
+
+            // new ValueTask<T>(T value)
+            if (type.OriginalDefinition.IsEqualTo(ValueTaskOfTSymbol) && objectCreation.Arguments is [{ Parameter: { } parameter }] && parameter.Type.IsEqualTo(type.TypeArguments[0]))
+                return true;
+        }
+
+        return false;
+    }
+
     public bool IsAsyncBuildableAndNotVoid(ITypeSymbol? symbol)
     {
         if (symbol is null)

--- a/src/Meziantou.Analyzer/Rules/AwaitTaskBeforeDisposingResourcesAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AwaitTaskBeforeDisposingResourcesAnalyzer.cs
@@ -31,10 +31,6 @@ public class AwaitTaskBeforeDisposingResourcesAnalyzer : DiagnosticAnalyzer
     {
         private readonly AwaitableTypes _awaitableTypes = new(compilation);
 
-        public INamedTypeSymbol? TaskSymbol { get; set; } = compilation.GetBestTypeByMetadataName("System.Threading.Tasks.Task");
-        public INamedTypeSymbol? TaskOfTSymbol { get; set; } = compilation.GetBestTypeByMetadataName("System.Threading.Tasks.Task`1");
-        public INamedTypeSymbol? ValueTaskSymbol { get; set; } = compilation.GetBestTypeByMetadataName("System.Threading.Tasks.ValueTask");
-        public INamedTypeSymbol? ValueTaskOfTSymbol { get; set; } = compilation.GetBestTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
         public INamedTypeSymbol? AsyncFlowControlSymbol { get; set; } = compilation.GetBestTypeByMetadataName("System.Threading.AsyncFlowControl");
 
         public void AnalyzeReturn(OperationAnalysisContext context)
@@ -145,46 +141,7 @@ public class AwaitTaskBeforeDisposingResourcesAnalyzer : DiagnosticAnalyzer
             if (operation.ConstantValue.HasValue && operation.ConstantValue.Value is null)
                 return false;
 
-            // Task.CompletedTask
-            if (operation.Kind == OperationKind.PropertyReference)
-            {
-                var prop = (IPropertyReferenceOperation)operation;
-                if (prop.Property.Name == nameof(Task.CompletedTask) && prop.Property.ContainingType.IsEqualToAny(TaskSymbol, ValueTaskSymbol))
-                    return false;
-            }
-
-            // Task.FromResult, Task.FromCanceled, FromException
-            if (operation.Kind == OperationKind.Invocation)
-            {
-                var invocation = (IInvocationOperation)operation;
-                if (invocation.TargetMethod.Name is nameof(Task.FromResult) or nameof(Task.FromCanceled) or nameof(Task.FromException) &&
-                    invocation.TargetMethod.ContainingType.IsEqualToAny(TaskSymbol, ValueTaskSymbol))
-                {
-                    return false;
-                }
-            }
-
-            if (operation.Kind == OperationKind.ObjectCreation)
-            {
-                var create = (IObjectCreationOperation)operation;
-                if (create.Type is not null)
-                {
-                    // new ValueTask()
-                    if (create.Type.OriginalDefinition.IsEqualTo(ValueTaskSymbol) && create.Arguments.Length == 0)
-                        return false;
-
-                    // new ValueTask<T>(T value)
-                    if (create.Type.OriginalDefinition.IsEqualTo(ValueTaskOfTSymbol) &&
-                        create.Arguments.Length == 1 &&
-                        create.Arguments[0].Parameter is { } firstParameter &&
-                        firstParameter.Type.IsEqualTo(((INamedTypeSymbol?)create.Type)?.TypeArguments[0]))
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
+            return !_awaitableTypes.IsCompletedTask(operation);
         }
     }
 }

--- a/src/Meziantou.Analyzer/Rules/UseAwaitInsteadOfReturningTaskAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAwaitInsteadOfReturningTaskAnalyzer.cs
@@ -72,7 +72,7 @@ public sealed class UseAwaitInsteadOfReturningTaskAnalyzer : DiagnosticAnalyzer
         var returns = new List<IReturnOperation>();
         CollectReturns(functionOperation, returns);
 
-        var hasValueToAwait = false;
+        var hasTaskWorthAwaiting = false;
         foreach (var returnOperation in returns)
         {
             if (returnOperation.ReturnedValue is null)
@@ -100,10 +100,16 @@ public sealed class UseAwaitInsteadOfReturningTaskAnalyzer : DiagnosticAnalyzer
             if (IsInProtectedContext(returnOperation.Syntax, functionOperation.Syntax))
                 return;
 
-            hasValueToAwait = true;
+            // Awaiting an already-completed task (Task.CompletedTask, Task.FromResult(value), ...) does not
+            // bring any benefit. Functions whose returns are all synchronous, such as the ones implementing an
+            // asynchronous interface synchronously, are not reported.
+            if (!awaitableTypes.IsCompletedTask(unwrappedValue))
+            {
+                hasTaskWorthAwaiting = true;
+            }
         }
 
-        if (!hasValueToAwait)
+        if (!hasTaskWorthAwaiting)
             return;
 
         foreach (var returnOperation in returns)

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
@@ -767,4 +767,165 @@ public sealed class UseAwaitInsteadOfReturningTaskAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task CompletedTask_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task A() => Task.CompletedTask;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TaskFromResult_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task<bool> A() => Task.FromResult(false);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TaskFromException_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task A() => Task.FromException(new Exception());
+                Task<int> B() => Task.FromCanceled<int>(default);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ValueTaskCompletedTask_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                ValueTask A() => ValueTask.CompletedTask;
+                ValueTask<int> B() => ValueTask.FromResult(0);
+                ValueTask C() => new ValueTask();
+                ValueTask<int> D() => new ValueTask<int>(0);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task CompletedTaskConvertedToTask_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task A() => Task.FromResult(0);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MultipleReturns_AllCompletedTasks_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task<int> A(bool condition)
+                {
+                    if (condition)
+                        return Task.FromResult(0);
+
+                    return Task.FromResult(1);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MultipleReturns_MixedCompletedTaskAndTask()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task<int> Inner() => throw null;
+                Task<int> A(bool condition)
+                {
+                    if (condition)
+                        return {|MA0214:Inner()|};
+
+                    return {|MA0214:Task.FromResult(0)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task<int> Inner() => throw null;
+                async Task<int> A(bool condition)
+                {
+                    if (condition)
+                        return await Inner();
+
+                    return await Task.FromResult(0);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task CompletedTaskFromAnotherType_Diagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task CompletedTask => throw null;
+                Task A() => {|MA0214:CompletedTask|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task CompletedTask => throw null;
+                async Task A() => await CompletedTask;
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
Fixes #1371

## What

MA0214 (*Use 'await' instead of returning the task*) no longer reports a function when **every** return produces an already-completed task:

```c#
Task FooAsync() => Task.CompletedTask;          // no longer reported
Task<bool> BarAsync() => Task.FromResult(false); // no longer reported
```

Completed tasks recognized: `Task.CompletedTask` / `ValueTask.CompletedTask`, `Task`/`ValueTask` `FromResult`, `FromException`, `FromCanceled`, `new ValueTask()`, and `new ValueTask<T>(value)`.

Functions that mix a completed task with a real task are still reported on every return:

```c#
Task<bool> BarAsync(bool condition) => condition ? OtherAsync() : Task.FromResult(false); // still reported
```

## Why

These are "bridging methods", e.g. implementing an asynchronous interface synchronously. Awaiting the task there brings no accuracy to the stack trace and only adds a state machine, so the rule was making the code worse.

## Notes for the reviewer

- The detection of completed tasks already existed inside `AwaitTaskBeforeDisposingResourcesAnalyzer` (MA0100). It moved to `AwaitableTypes.IsCompletedTask` and both rules now share it; MA0100 behavior is unchanged (its four now-unused symbol properties were removed).
- MA0215 needs no change: for `async Task Foo() => await Task.CompletedTask;` it already suggests `Task Foo() => Task.CompletedTask;`, which is the shape MA0214 now leaves alone.
- 8 tests added, including the mixed case (with the fixer output) and a same-named `CompletedTask` property declared on another type (still reported).
- `dotnet run --project src/DocumentationGenerator` produces no further markdown change. Full test suite passes on roslyn5.9 (3862 tests) and roslyn4.8 (3750 tests).