### PR TITLE
Remove Feedz publishing from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
     - name: NuGet login (OIDC → temp API key)
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      if: github.ref == 'refs/heads/main'
       uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
       id: login
       with:
@@ -294,20 +294,12 @@ jobs:
         $files = Get-ChildItem "${{ env.NuGetDirectory }}/*" -Recurse -Include *.nupkg
         foreach($file in $files) {
             Write-Host "Pushing NuGet package: $($file.FullName)"
-            if ($env:GITHUB_REF -eq 'refs/heads/main')
-            {
-              & dotnet nuget push "$($file.FullName)" --api-key "$env:NuGetApiKey" --source https://api.nuget.org/v3/index.json --force-english-output --skip-duplicate
-            }
-            else
-            {
-              & dotnet nuget push "$($file.FullName)" --api-key "$env:FeedzApiKey" --source https://f.feedz.io/meziantou/meziantou-analyzer/nuget/index.json --force-english-output --skip-duplicate
-            }
+            & dotnet nuget push "$($file.FullName)" --api-key "$env:NuGetApiKey" --source https://api.nuget.org/v3/index.json --force-english-output --skip-duplicate
         }
       name: Publish NuGet packages
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      if: github.ref == 'refs/heads/main'
       env:
         NuGetApiKey: ${{steps.login.outputs.NUGET_API_KEY}}
-        FeedzApiKey: ${{ secrets.FEEDZ_APIKEY }}
 
   create_release:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
## What changed

Removes the Feedz feed from the `deploy` job of `.github/workflows/ci.yml`:

- The `Publish NuGet packages` step no longer branches on `GITHUB_REF`. It always pushes to nuget.org, and the whole step is gated on `github.ref == 'refs/heads/main'` — previously the `else` branch (non-main) is what pushed to `https://f.feedz.io/meziantou/meziantou-analyzer/nuget/index.json`.
- Dropped the `FeedzApiKey` env var and its `secrets.FEEDZ_APIKEY` usage.
- Gated the `NuGet login (OIDC → temp API key)` step on `main` as well, since its only consumer is the push step. It was previously minting a temporary nuget.org API key on every non-fork PR run with nothing left to use it.

## Why

Feedz publishing of CI builds is no longer wanted.

## Notes for reviewers

- The `deploy` job itself still runs on PRs (it checks out, downloads the `nuget` artifact and sets up .NET), so any required status check on `deploy` keeps reporting instead of being skipped. Both remaining publish-related steps simply no-op off `main`.
- No source or test code changed, so there was nothing to build or run; the workflow file parses as valid YAML and no `feedz` reference remains in the repo.
- The `FEEDZ_APIKEY` repository secret is now unused and can be deleted in the GitHub settings.