### PR TITLE
Do not offer the MA0028 Substring fix when it would duplicate side effects

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
@@ -74,6 +74,15 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
                 break;
 
             case OptimizeStringBuilderUsageData.ReplaceSubstring:
+                var substringSemanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                if (substringSemanticModel?.GetOperation(nodeToFix, context.CancellationToken) is not IInvocationOperation { Arguments: [{ Value: IInvocationOperation substringOperation }, ..] })
+                    return;
+
+                // Substring(startIndex) is replaced by Append(str, startIndex, str.Length - startIndex),
+                // so both the string and the start index are evaluated twice
+                if (substringOperation.Arguments.Length == 1 && (!CanBeEvaluatedMultipleTimes(substringOperation.Instance) || !CanBeEvaluatedMultipleTimes(substringOperation.Arguments[0].Value)))
+                    return;
+
                 context.RegisterCodeFix(CodeAction.Create(title, ct => ReplaceSubstring(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
@@ -204,6 +213,23 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
         }
 
         return operation.Type is IArrayTypeSymbol { Rank: 1, ElementType.SpecialType: SpecialType.System_Char };
+    }
+
+    /// <summary>
+    /// Indicates whether duplicating the expression in the generated code is safe, i.e. evaluating it twice
+    /// has no side effect and always returns the same value.
+    /// </summary>
+    private static bool CanBeEvaluatedMultipleTimes(IOperation? operation)
+    {
+        return operation switch
+        {
+            null => false,
+            IConversionOperation { IsImplicit: true } conversion => CanBeEvaluatedMultipleTimes(conversion.Operand),
+            IParenthesizedOperation parenthesized => CanBeEvaluatedMultipleTimes(parenthesized.Operand),
+            ILiteralOperation or IInstanceReferenceOperation or ILocalReferenceOperation or IParameterReferenceOperation => true,
+            IFieldReferenceOperation fieldReference => fieldReference.Field.IsStatic || fieldReference.Field.IsConst || CanBeEvaluatedMultipleTimes(fieldReference.Instance),
+            _ => operation.ConstantValue.HasValue,
+        };
     }
 
     private static async Task<Document> RemoveToString(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -1074,6 +1074,65 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     }
 
     [Fact]
+    public Task AppendLine_AppendSubStringWithoutLength_Parameters()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Text;
+            class Test
+            {
+                void A(string text, int start)
+                {
+                    {|MA0028:new StringBuilder().AppendLine(text.Substring(start))|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Text;
+            class Test
+            {
+                void A(string text, int start)
+                {
+                    new StringBuilder().Append(text, start, text.Length - start).AppendLine();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("GetText().Substring(GetStart())")]
+    [InlineData("Text.Substring(0)")]
+    [InlineData(@"""abc"".Substring(Start)")]
+    public Task AppendLine_AppendSubStringWithoutLength_SideEffects_NoFix(string expression)
+    {
+        // The fix would evaluate the string and the start index twice
+        var code = $$"""
+            using System.Text;
+            class Test
+            {
+                void A()
+                {
+                    {|MA0028:new StringBuilder().AppendLine({{expression}})|};
+                }
+
+                string Text => "abc";
+                int Start => 2;
+                string GetText() => "abc";
+                int GetStart() => 2;
+            }
+            """;
+
+        var test = CreateTest();
+        test.FixedState.MarkupHandling = MarkupMode.Allow;
+        test.TestCode = code;
+        test.FixedCode = code;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task AppendLine_CustomStructToString()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

The MA0028 code fix for `Substring` is no longer offered when applying it would evaluate an expression twice.

## Why

`ReplaceSubstring` rewrites `sb.Append(str.Substring(startIndex))` into `sb.Append(str, startIndex, str.Length - startIndex)`. It builds the length argument from `str` and `startIndex`, then passes both of them **again** as the first two arguments, so each is evaluated twice — and in a different order than in the original expression.

For example, `sb.AppendLine(GetText().Substring(GetStart()))` was fixed to:

```csharp
sb.Append(GetText(), GetStart(), GetText().Length - GetStart()).AppendLine();
```

The result compiles and reads plausibly, so it survives review, but if either expression has a side effect (a counter, an iterator, a lazily built buffer) the appended slice is silently wrong or throws `ArgumentOutOfRangeException` at run time. MA0028 is enabled by default and is typically applied in bulk over logging and formatting code.

The existing `AppendLine_AppendSubStringWithoutLength` test only used the literal `"abc"`, where duplication is harmless, so it locked in the buggy shape rather than catching it.

## How

Following the repository convention of validating before registering, the check lives in `RegisterCodeFixesAsync` rather than in the fix action, so no fix is shown that would return a broken document. For a single-argument `Substring`, the fix is only registered when both the receiver and the start index are safe to evaluate multiple times.

`CanBeEvaluatedMultipleTimes` accepts literals, constant expressions, `this`, locals, parameters and fields (with a safe instance chain), unwrapping implicit conversions and parenthesized expressions. Property references and method invocations are rejected.

The two-argument overload of `Substring` is unaffected: it never duplicates anything, so its behavior is unchanged.

## Notes for the reviewer

- The diagnostic is still reported when the fix is not offered, and its message already points at `Append(string, int, int)` and `Append(ReadOnlySpan<char>)`.
- Rejecting property references means `this.SomeProperty.Substring(i)` no longer gets a fix, a small loss of coverage for a shape that is usually side-effect free. Emitting `Append(text.AsSpan(start))` instead would keep coverage for every shape, since it needs each expression only once, but it requires checking that `StringBuilder.Append(ReadOnlySpan<char>)` is available for the target framework. This PR takes the conservative option; happy to switch to the span overload if preferred.
- No documentation change: `docs/Rules/MA0028.md` does not cover the `Substring` case and the analyzer's reporting behavior is unchanged. `dotnet run --project src/DocumentationGenerator` exits 0 with no file changes.

## Testing

- Added three no-fix cases (method receiver + method index, property receiver, property index) and one case with parameters where the fix is still offered.
- Verified the new tests are meaningful: with the new guard temporarily short-circuited to `false`, all three no-fix cases fail with the duplicated-expression output; with the guard in place they pass.
- Full suite on all five Roslyn versions: 19093 passed, 0 failed.