### PR TITLE
Fix MA0113 NullReferenceException and named-argument false negatives

### DIFF
--- a/src/Meziantou.Analyzer/Rules/UseDateTimeUnixEpochAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseDateTimeUnixEpochAnalyzer.cs
@@ -80,42 +80,42 @@ public sealed class UseDateTimeUnixEpochAnalyzer : DiagnosticAnalyzer
 
                 if (operation.Arguments.Length == 1)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(), [621355968000000000L], context.CancellationToken))
+                    if (ArgumentsEquals(operation, [621355968000000000L], context.CancellationToken))
                         return true;
 
-                    if (IsUnixEpochProperty(operation.Arguments[0]))
+                    if (IsUnixEpochProperty(GetArgument(operation, 0)))
                         return true;
                 }
                 else if (operation.Arguments.Length == 2)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 1), [621355968000000000L], context.CancellationToken) && IsTimeSpanZero(operation.Arguments[1]))
+                    if (ArgumentsEquals(operation, [621355968000000000L], context.CancellationToken) && IsTimeSpanZero(GetArgument(operation, 1)))
                         return true;
 
-                    if (IsUnixEpochProperty(operation.Arguments[0]) && IsTimeSpanZero(operation.Arguments[1]))
+                    if (IsUnixEpochProperty(GetArgument(operation, 0)) && IsTimeSpanZero(GetArgument(operation, 1)))
                         return true;
                 }
                 else if (operation.Arguments.Length == 7)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 6), [1970, 1, 1, 0, 0, 0], context.CancellationToken) && IsTimeSpanZero(operation.Arguments[6]))
+                    if (ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0], context.CancellationToken) && IsTimeSpanZero(GetArgument(operation, 6)))
                         return true;
                 }
                 else if (operation.Arguments.Length == 8)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 7), [1970, 1, 1, 0, 0, 0, 0], context.CancellationToken) && IsTimeSpanZero(operation.Arguments[7]))
+                    if (ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0, 0], context.CancellationToken) && IsTimeSpanZero(GetArgument(operation, 7)))
                         return true;
                 }
                 else if (operation.Arguments.Length == 9)
                 {
-                    if (ArgumentsEquals(operation.Arguments.AsSpan(0, 8), [1970, 1, 1, 0, 0, 0, 0, 0], context.CancellationToken) && IsTimeSpanZero(operation.Arguments[8]))
+                    if (ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0, 0, 0], context.CancellationToken) && IsTimeSpanZero(GetArgument(operation, 8)))
                         return true;
                 }
 
                 return false;
             }
 
-            bool IsUnixEpochProperty(IArgumentOperation argumentOperation)
+            bool IsUnixEpochProperty(IArgumentOperation? argumentOperation)
             {
-                if (argumentOperation.Value is IMemberReferenceOperation memberReference)
+                if (argumentOperation?.Value is IMemberReferenceOperation memberReference)
                 {
                     if (memberReference.Member.Name == "UnixEpoch" && memberReference.Member.ContainingType.IsEqualTo(_dateTimeSymbol))
                         return true;
@@ -132,59 +132,87 @@ public sealed class UseDateTimeUnixEpochAnalyzer : DiagnosticAnalyzer
 
             if (operation.Arguments.Length == 1)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(), [621355968000000000L], cancellationToken))
+                if (ArgumentsEquals(operation, [621355968000000000L], cancellationToken))
                     return true;
             }
             else if (operation.Arguments.Length == 2)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(0, 1), [621355968000000000L], cancellationToken) && IsDateTimeKindUtc(operation.Arguments[1], cancellationToken))
+                if (ArgumentsEquals(operation, [621355968000000000L], cancellationToken) && IsDateTimeKindUtc(GetArgument(operation, 1), cancellationToken))
                     return true;
             }
             else if (operation.Arguments.Length == 3)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(), [1970, 1, 1], cancellationToken))
+                if (ArgumentsEquals(operation, [1970, 1, 1], cancellationToken))
                     return true;
             }
             else if (operation.Arguments.Length == 6)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(), [1970, 1, 1, 0, 0, 0], cancellationToken))
+                if (ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0], cancellationToken))
                     return true;
             }
             else if (operation.Arguments.Length == 7)
             {
-                if (ArgumentsEquals(operation.Arguments.AsSpan(0, 6), [1970, 1, 1, 0, 0, 0], cancellationToken) && IsDateTimeKindUtc(operation.Arguments[6], cancellationToken))
+                if (ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0], cancellationToken) && IsDateTimeKindUtc(GetArgument(operation, 6), cancellationToken))
                     return true;
             }
 
             return false;
         }
 
-        private bool IsDateTimeKindUtc(IArgumentOperation argument, CancellationToken cancellationToken)
+        private bool IsDateTimeKindUtc(IArgumentOperation? argument, CancellationToken cancellationToken)
         {
-            if (_dateTimeKindSymbol is null)
+            if (_dateTimeKindSymbol is null || argument is null)
                 return false;
 
-            return argument.Value.TryGetConstantValue(out var value, cancellationToken) && (DateTimeKind)value! == DateTimeKind.Utc;
+            var parameter = argument.Parameter;
+            if (parameter is null || !parameter.Type.IsEqualTo(_dateTimeKindSymbol))
+                return false;
+
+            return argument.Value.TryGetConstantValue(out var value, cancellationToken) && value is int intValue && intValue == (int)DateTimeKind.Utc;
         }
 
-        private static bool ArgumentsEquals(ReadOnlySpan<IArgumentOperation> arguments, object[] expectedValues, CancellationToken cancellationToken)
+        /// <summary>
+        /// Gets the argument for the parameter at the given position, whatever the order of the arguments in the source code.
+        /// </summary>
+        private static IArgumentOperation? GetArgument(IObjectCreationOperation operation, int parameterOrdinal)
         {
-            for (var i = 0; i < arguments.Length; i++)
+            foreach (var argument in operation.Arguments)
             {
-                var argument = arguments[i];
+                if (argument.Parameter?.Ordinal == parameterOrdinal)
+                    return argument;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Determines whether the arguments of the leading parameters are the constants <paramref name="expectedValues"/>,
+        /// whatever the order of the arguments in the source code. The arguments of the remaining parameters are not validated.
+        /// </summary>
+        private static bool ArgumentsEquals(IObjectCreationOperation operation, object[] expectedValues, CancellationToken cancellationToken)
+        {
+            var matchedParameters = 0;
+            foreach (var argument in operation.Arguments)
+            {
+                var parameter = argument.Parameter;
+                if (parameter is null || parameter.Ordinal >= expectedValues.Length)
+                    continue;
+
                 if (!argument.Value.TryGetConstantValue(out var value, cancellationToken))
                     return false;
 
-                if (!Equals(value, expectedValues[i]))
+                if (!Equals(value, expectedValues[parameter.Ordinal]))
                     return false;
+
+                matchedParameters++;
             }
 
-            return true;
+            return matchedParameters == expectedValues.Length;
         }
 
-        private bool IsTimeSpanZero(IArgumentOperation operation)
+        private bool IsTimeSpanZero(IArgumentOperation? operation)
         {
-            return _timeSpanOperation.GetMilliseconds(operation.Value) is 0L;
+            return operation is not null && _timeSpanOperation.GetMilliseconds(operation.Value) is 0L;
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
@@ -15,6 +15,8 @@ public class UseDateTimeUnixEpochAnalyzerTests
     [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)")]
     [InlineData("new DateTime(621355968000000000)")]
     [InlineData("new DateTime(621355968000000000, DateTimeKind.Utc)")]
+    [InlineData("new DateTime(day: 1, month: 1, year: 1970)")]
+    [InlineData("new DateTime(kind: DateTimeKind.Utc, year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0)")]
     public Task UnixEpoch_DateTime(string code)
     {
         var test = CreateTest();
@@ -50,6 +52,7 @@ public class UseDateTimeUnixEpochAnalyzerTests
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero)")]
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, 0, TimeSpan.Zero)")]
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, 0, default(TimeSpan))")]
+    [InlineData("new DateTimeOffset(offset: TimeSpan.Zero, day: 1, month: 1, year: 1970, hour: 0, minute: 0, second: 0)")]
     public Task UnixEpoch_DateTimeOffset(string code)
     {
         var test = CreateTest();
@@ -83,6 +86,9 @@ public class UseDateTimeUnixEpochAnalyzerTests
     [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Local)")]
     [InlineData("new DateTime(621355968000000001)")]
     [InlineData("new DateTime(621355968000000000, DateTimeKind.Local)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, null)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, new System.Globalization.GregorianCalendar())")]
+    [InlineData("new DateTime(day: 1, month: 1, year: 1971)")]
     public Task NonUnixEpoch_DateTime(string code)
     {
         var test = CreateTest();
@@ -107,6 +113,8 @@ public class UseDateTimeUnixEpochAnalyzerTests
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.MinValue)")]
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.FromMinutes(1))")]
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, 0, TimeSpan.FromHours(-1))")]
+    [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, null, TimeSpan.Zero)")]
+    [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, new System.Globalization.GregorianCalendar(), TimeSpan.Zero)")]
     public Task NonUnixEpoch_DateTimeOffset(string code)
     {
         var test = CreateTest();


### PR DESCRIPTION
## The crash

```csharp
_ = new DateTime(1970, 1, 1, 0, 0, 0, null);
```

binds to `DateTime(int, int, int, int, int, int, Calendar)`. The 7-argument branch of `UseDateTimeUnixEpochAnalyzer` passed that `null` `Calendar` argument to `IsDateTimeKindUtc`, which did:

```csharp
return argument.Value.TryGetConstantValue(out var value, cancellationToken) && (DateTimeKind)value! == DateTimeKind.Utc;
```

A `null` literal has `ConstantValue.HasValue == true` with a `null` value, so unboxing it to the `DateTimeKind` struct threw a `NullReferenceException`. The `!` suppressed the only compile-time signal that `value` was nullable.

An unhandled analyzer exception surfaces as `AD0001` and disables MA0113 for the rest of the compilation; in the IDE it recurs while the user types. The trigger is ordinary, compiling C#.

`IsDateTimeKindUtc` now verifies the argument's parameter type is `System.DateTimeKind` before looking at the constant, and pattern-matches it (`value is int intValue`) instead of unboxing. Either check alone stops the crash; both are cheap.

## The positional-argument assumption

The rule also indexed `IObjectCreationOperation.Arguments` positionally, assuming parameter order. `Arguments` is in **source** order, so this was a real false-negative source rather than a theoretical one — any named-argument reordering silently defeated the rule:

```csharp
_ = new DateTime(day: 1, month: 1, year: 1970); // MA0113 was not reported
```

`ArgumentsEquals` now indexes the expected values by `IParameterSymbol.Ordinal` and requires every leading parameter to have been matched. The arguments the rule inspects on their own — the `DateTimeKind`, the `TimeSpan` offset, and the `DateTime.UnixEpoch` reference — are looked up by ordinal through a new `GetArgument` helper instead of `Arguments[n]`.

As a side effect, trailing parameters the rule does not model (the `Calendar` of `DateTimeOffset(..., Calendar, TimeSpan)`) are now skipped by ordinal rather than compared against an `int`, so they can neither crash nor accidentally match.

## Tests

8 cases added to `UseDateTimeUnixEpochAnalyzerTests`: the `null` and non-null `Calendar` overloads for both `DateTime` and `DateTimeOffset`, and named/reordered arguments in both the match and the non-match direction.

I ran the new tests against the **unfixed** analyzer first to confirm they are meaningful — 4 failed, including the `AD0001` / `NullReferenceException` on `new DateTime(1970, 1, 1, 0, 0, 0, null)` and three missed diagnostics on reordered named arguments.

With the fix, all 32 tests in the class pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9, and the full 3884-test default-version suite passes. `dotnet run --project src/DocumentationGenerator` produced no markdown changes, as expected for a behavior-only fix.
