### PR TITLE
Fix MA0078 false positive when the cast targets a captured parameter

### DIFF
--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -842,8 +842,12 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (returnOp.ReturnedValue is not IConversionOperation castOp || castOp.IsTryCast || castOp.Type is null)
                 return;
 
-            // If the cast is not applied directly to the source element (one of the selector's arguments)
-            if (castOp.Operand.Kind != OperationKind.ParameterReference)
+            // If the cast is not applied directly to the source element (the first parameter of the selector)
+            if (castOp.Operand is not IParameterReferenceOperation parameterReference)
+                return;
+
+            var selectorLambda = selectorArg.Descendants().OfType<IAnonymousFunctionOperation>().FirstOrDefault();
+            if (selectorLambda is null || selectorLambda.Symbol.Parameters.Length == 0 || !parameterReference.Parameter.IsEqualTo(selectorLambda.Symbol.Parameters[0]))
                 return;
 
             // Ensure the code is valid after replacement. The semantic may be different if you use Cast<T>() instead of Select(x => (T)x).

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
@@ -1417,6 +1417,8 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     [InlineData("source.Select(dt => dt.Name)")]            // No cast
     [InlineData("source.Select(dt => (object)dt.Name)")]    // Cast of property, not of element itself
     [InlineData("source.Select(dt => dt as BaseType)")]     // 'as' operator should not be replaced by Cast<>
+    [InlineData("source.Select(dt => (BaseType)other)")]    // Cast of a captured parameter, not of the element itself
+    [InlineData("source.Select((dt, index) => (object)index)")] // Cast of the index, not of the element itself
     public Task OptimizeLinq_WhenSelectorDoesNotReturnCastElement_NoDiagnosticReported(string selectInvocation)
     {
         var test = new CodeFixTest();
@@ -1427,7 +1429,7 @@ public sealed class OptimizeLinqUsageAnalyzerTests
                 class BaseType { public string Name { get; set; } }
                 class DerivedType : BaseType {}
 
-                public Test()
+                public Test(object other)
                 {
                     var source = System.Linq.Enumerable.Empty<DerivedType>();
                     {{selectInvocation}};


### PR DESCRIPTION
## What

`UseCastInsteadOfSelect` (MA0078) reported a diagnostic for any cast whose operand was a parameter reference, without checking *which* parameter was referenced. The only guard was:

```csharp
// If the cast is not applied directly to the source element (one of the selector's arguments)
if (castOp.Operand.Kind != OperationKind.ParameterReference)
    return;
```

Any captured enclosing-method or enclosing-lambda parameter satisfied it, so this reported MA0078:

```csharp
void M(object other)
{
    var source = Enumerable.Empty<DerivedType>();
    source.Select(dt => (BaseType)other);   // MA0078
}
```

The guard now requires the operand to be the selector lambda's **first** parameter — the source element, which is what the comment already claimed the check did.

## Why it matters

Beyond being a false positive, the offered code fix rewrote the call to `source.Cast<BaseType>()`. That compiles, and casts *each element* instead of `other` — a silent behaviour change delivered by a lightbulb.

## Note for reviewers

The obvious fix is to require the operand to be *one of* the selector lambda's parameters, but that leaves a second false positive on the indexed `Select` overload:

```csharp
source.Select((dt, index) => (object)index);   // Cast<object>() would cast the elements
```

Requiring specifically the first parameter closes both cases, so that is what this does. The indexed case is covered by a test.

`Select(x => (T)x)` with a single parameter is unaffected — the existing positive cases (including the implicit-conversion forms such as `Select<DerivedType, object>(i => i)`) still report.

## Testing

- Two regression cases added to the existing `OptimizeLinq_WhenSelectorDoesNotReturnCastElement_NoDiagnosticReported` theory: the captured parameter, and the index. Both were confirmed load-bearing — reverting the analyzer while keeping the tests produces exactly 2 failures, and the trx confirms the new cases actually ran.
- Full suite green on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9): 19103 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes — the rule's documented behaviour is unchanged, since this only removes cases that were never meant to be reported.