### PR TITLE
Do not report MA0063 on the indexed Where overload

### DIFF
--- a/docs/Rules/MA0063.md
+++ b/docs/Rules/MA0063.md
@@ -10,3 +10,10 @@ Using a `Where` clause after an `OrderBy` clause requires the entire collection 
 enumerable.Where(...).OrderBy(...) // compliant
 enumerable.OrderBy(...).Where(...) // non-compliant
 ````
+
+The rule is not reported when `Where` uses the overload taking the index of the element (`Func<TSource, int, bool>`),
+as moving it before the ordering would make the index refer to the unsorted sequence.
+
+````csharp
+enumerable.OrderBy(x => x).Where((x, index) => index < 3) // compliant
+````

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -234,6 +234,10 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 {
                     if (parent.TargetMethod.Name == nameof(Enumerable.Where))
                     {
+                        // Cannot move Where before OrderBy when using Func<TSource,int,bool> as the index would refer to the unsorted sequence
+                        if (IsIndexedPredicateOverload(parent.TargetMethod))
+                            return;
+
                         var properties = CreateLinqChainProperties(OptimizeLinqUsageData.CombineWhereWithNextMethod, operation, parent, parent.TargetMethod.Name);
 
                         context.ReportDiagnostic(OptimizeWhereAndOrderByRule, properties, parent, operation.TargetMethod.Name);
@@ -460,13 +464,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (operation.TargetMethod.Name == nameof(Enumerable.Where))
             {
                 // Cannot replace Where when using Func<TSource,int,bool>
-                if (operation.TargetMethod.Parameters.Length != 2)
-                    return;
-
-                if (operation.TargetMethod.Parameters[1].Type is not INamedTypeSymbol type)
-                    return;
-
-                if (type.TypeArguments.Length == 3)
+                if (IsIndexedPredicateOverload(operation.TargetMethod))
                     return;
 
                 // Check parent methods
@@ -492,6 +490,30 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Detects the overloads taking a predicate with the index of the element, such as <c>Where(Func&lt;TSource,int,bool&gt;)</c>.
+        /// Returns <see langword="true" /> when the shape of the method is unknown, so the callers stay on the safe side.
+        /// </summary>
+        private bool IsIndexedPredicateOverload(IMethodSymbol method)
+        {
+            if (method.Parameters.Length != 2)
+                return true;
+
+            if (method.Parameters[1].Type is not INamedTypeSymbol type)
+                return true;
+
+            // Queryable methods take an Expression<Func<...>>
+            if (type.OriginalDefinition.IsEqualTo(ExpressionOfTSymbol))
+            {
+                if (type.TypeArguments is not [INamedTypeSymbol delegateType])
+                    return true;
+
+                type = delegateType;
+            }
+
+            return type.TypeArguments.Length == 3;
         }
 
         private bool IsExpressionPredicateReference(IOperation operation)

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
@@ -2277,6 +2277,50 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     }
 
     [Theory]
+    [InlineData("OrderBy(x => x.Length)")]
+    [InlineData("OrderByDescending(x => x.Length)")]
+    [InlineData("Order()")]
+    [InlineData("OrderDescending()")]
+    public Task Enumerable_WhereWithIndexAfterOrderBy_Valid(string a)
+    {
+        var test = new CodeFixTest();
+        test.TestCode = $$"""
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    System.Collections.Generic.IEnumerable<string> enumerable = null;
+                    enumerable.{{a}}.Where((x, i) => i < 3);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("OrderBy(x => x.Length)")]
+    [InlineData("OrderByDescending(x => x.Length)")]
+    public Task Queryable_WhereWithIndexAfterOrderBy_Valid(string a)
+    {
+        var test = new CodeFixTest();
+        test.TestCode = $$"""
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    System.Linq.IQueryable<string> query = null;
+                    query.{{a}}.Where((x, i) => i < 3);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
     [InlineData("Order")]
     [InlineData("OrderDescending")]
     public Task Enumerable_WhereAfterOrder_Invalid(string a)


### PR DESCRIPTION
## Problem

MA0063 (*Use `Where` before `OrderBy`*) fired on the indexed `Where` overload:

```csharp
IEnumerable<string> e = null;
e.OrderBy(x => x.Length).Where((x, i) => i < 3);   // reported MA0063
```

`WhereShouldBeBeforeOrderBy` only checked `parent.TargetMethod.Name == "Where"` and never excluded the `Func<TSource, int, bool>` overload. Moving such a `Where` ahead of the ordering makes `i` index the **unsorted** sequence, so both the diagnostic and its code fix silently changed the result of the query.

The sibling `CombineWhereWithNextMethod` already had the correct guard a few hundred lines away in the same file, which makes this a copy-paste omission rather than a design gap.

## What changed

- **`OptimizeLinqUsageAnalyzer.cs`** — `WhereShouldBeBeforeOrderBy` now bails out when the parent `Where` uses the indexed overload.
- Rather than duplicating the inline check, it is extracted into a shared `IsIndexedPredicateOverload` helper used by both `WhereShouldBeBeforeOrderBy` and `CombineWhereWithNextMethod`.
- **`docs/Rules/MA0063.md`** — documents the exclusion.

### Note for reviewers: the helper also fixes the `IQueryable` case

The extracted helper additionally unwraps `Expression<Func<...>>`, which the original inline check did not. For `Queryable.Where` the parameter type is `Expression<Func<TSource, int, bool>>`, whose own `TypeArguments.Length` is `1`, so the old `type.TypeArguments.Length == 3` test never matched the `IQueryable` form.

This makes the pre-existing `CombineWhereWithNextMethod` guard strictly more correct too. That path was only partly masked before by the separate Queryable early-return, which requires *both* the operation and its parent to be `Queryable` — so a `Queryable.Where` whose parent was an `Enumerable` method was not covered.

## Tests

6 new cases in `OptimizeLinqUsageAnalyzerTests`:

- `Enumerable_WhereWithIndexAfterOrderBy_Valid` — `OrderBy` / `OrderByDescending` / `Order` / `OrderDescending`
- `Queryable_WhereWithIndexAfterOrderBy_Valid` — `OrderBy` / `OrderByDescending`

**Verification performed:**

- Temporarily reverted the guard and confirmed all 6 new tests fail — including the two `IQueryable` ones, which validates the `Expression<>` unwrapping is doing real work — then restored it and confirmed they pass.
- Full suite across all 5 Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9): **19123 passed, 0 failed**.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no pending markdown changes.

## Out of scope

While in this code I noticed a related pre-existing bug that I deliberately left alone, as it belongs to MA0029 rather than MA0063: `CombineWhereWithNextMethod` checks only the inner `Where` for an indexed predicate, not the *parent* one, so `e.Where(x => ...).Where((x, i) => ...)` may still be reported even though the two cannot be combined. Happy to address it here or in a follow-up.