### PR TITLE
Parenthesize the expressions produced by the MA0112 and MA0128 fixers

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
@@ -214,7 +214,12 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
 
         var generator = editor.Generator;
         var countExpression = generator.MemberAccessExpression(invocation.Arguments[0].Syntax, "Count");
-        var newExpression = generator.ValueNotEqualsExpression(countExpression, generator.LiteralExpression(0));
+
+        // The invocation may be the operand of an operator or the target of a member access, both of which bind
+        // tighter than '!=', so the comparison must be parenthesized. Simplifier removes the useless parentheses.
+        var newExpression = generator.ValueNotEqualsExpression(countExpression, generator.LiteralExpression(0))
+            .Parenthesize()
+            .WithTrailingTrivia(nodeToFix.GetTrailingTrivia());
 
         editor.ReplaceNode(nodeToFix, newExpression);
         return editor.GetChangedDocument();

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseIsPatternInsteadOfSequenceEqualFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseIsPatternInsteadOfSequenceEqualFixer.cs
@@ -33,7 +33,12 @@ public sealed class UseIsPatternInsteadOfSequenceEqualFixer : CodeFixProvider
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         var operation = (IInvocationOperation)editor.SemanticModel.GetOperation(nodeToFix, cancellationToken)!;
 
-        var newExpression = SyntaxFactory.IsPatternExpression((ExpressionSyntax)operation.Arguments[0].Value.Syntax, SyntaxFactory.ConstantPattern((ExpressionSyntax)operation.Arguments[1].Value.Syntax));
+        // The invocation may be the operand of an operator or the target of a member access, both of which bind
+        // tighter than 'is', so the pattern must be parenthesized. Simplifier removes the useless parentheses.
+        var newExpression = SyntaxFactory.IsPatternExpression((ExpressionSyntax)operation.Arguments[0].Value.Syntax, SyntaxFactory.ConstantPattern((ExpressionSyntax)operation.Arguments[1].Value.Syntax))
+            .Parenthesize()
+            .WithTrailingTrivia(nodeToFix.GetTrailingTrivia());
+
         editor.ReplaceNode(nodeToFix, newExpression);
         return editor.GetChangedDocument();
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
@@ -865,6 +865,102 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     }
 
     [Fact]
+    public Task Any_List_Negated_CodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var collection = new System.Collections.Generic.List<int>();
+                    if (!{|MA0112:collection.Any()|}) { }
+                }
+            }
+
+            """;
+        test.FixedCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var collection = new System.Collections.Generic.List<int>();
+                    if (!(collection.Count != 0)) { }
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Any_List_MemberAccess_CodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var collection = new System.Collections.Generic.List<int>();
+                    _ = {|MA0112:collection.Any()|}.ToString();
+                }
+            }
+
+            """;
+        test.FixedCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var collection = new System.Collections.Generic.List<int>();
+                    _ = (collection.Count != 0).ToString();
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Any_List_KeepsTrivia_CodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var collection = new System.Collections.Generic.List<int>();
+                    _ = /* before */ {|MA0112:collection.Any()|} /* after */;
+                }
+            }
+
+            """;
+        test.FixedCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var collection = new System.Collections.Generic.List<int>();
+                    _ = /* before */ collection.Count != 0 /* after */;
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Any_Array()
     {
         var test = new CodeFixTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIsPatternInsteadOfSequenceEqualAnalyzerTests.cs
@@ -125,6 +125,60 @@ public sealed class UseIsPatternInsteadOfSequenceEqualAnalyzerTests
     }
 
     [Fact]
+    public Task ReadOnlySpanChar_SequenceEqual_Negated()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            Span<char> str = default;
+            if (!{|MA0128:str.SequenceEqual("bar")|}) { }
+            """;
+        test.FixedCode = """
+            using System;
+            Span<char> str = default;
+            if (!(str is "bar")) { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReadOnlySpanChar_SequenceEqual_MemberAccess()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            Span<char> str = default;
+            _ = {|MA0128:str.SequenceEqual("bar")|}.ToString();
+            """;
+        test.FixedCode = """
+            using System;
+            Span<char> str = default;
+            _ = (str is "bar").ToString();
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReadOnlySpanChar_SequenceEqual_KeepsTrivia()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            Span<char> str = default;
+            _ = /* before */ {|MA0128:str.SequenceEqual("bar")|} /* after */;
+            """;
+        test.FixedCode = """
+            using System;
+            Span<char> str = default;
+            _ = /* before */ str is "bar" /* after */;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task ReadOnlySpanChar_EqualsOrdinalIgnoreCase()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

`OptimizeLinqUsageAnalyzer` (MA0112) and `UseIsPatternInsteadOfSequenceEqualAnalyzer` (MA0128) both report on the inner `IInvocationOperation`, so their fixers get the invocation node and `editor.ReplaceNode` splices the replacement straight under the invocation's parent. The replacements — an `!=` comparison for MA0112, an `is` pattern for MA0128 — bind looser than the invocation they replace, so under a unary operator or a member access the fix changed the meaning of the code and produced `CS0023`:

```csharp
if (!list.Any()) { }               // -> if (!list.Count != 0) { }
if (!str.SequenceEqual("bar")) { } // -> if (!str is "bar") { }
_ = list.Any().ToString();         // -> _ = list.Count != 0.ToString();
```

`!x.Any()` is the most common way `Any()` is written, so this was the majority case of MA0112's fix rather than an edge case. Both fixers use `WellKnownFixAllProviders.BatchFixer`, so "Fix all in document" broke every site at once. It went unnoticed because every existing fix test used the bare `_ = expr;` form, where the replacement happens to need no parentheses.

## Fix

Wrap both replacements with `Parenthesize()` (the `Meziantou.Framework.Roslyn` helper), which annotates the parentheses with `Simplifier.Annotation` so the code-fix post-processing removes the ones the final document doesn't need. The existing tests that expect `_ = collection.Count != 0;` and `_ = str is "bar";` still pass unchanged.

Both fixers also dropped the trailing trivia of the invocation, so it is now carried over to the new expression.

## Note for the reviewer

`WithTriviaFrom` is not usable here, even though sibling fixers such as `SimplifyNegatedBooleanExpressionFixer` use it. Both of these fixers reuse the receiver syntax of the invocation (`invocation.Arguments[0].Syntax` / `operation.Arguments[0].Value.Syntax`), which already carries the leading trivia, so copying it onto the parenthesized node would emit it twice — `/* c */(/* c */ x is "bar")`. Only the trailing trivia, which sits on the invocation's closing parenthesis, was actually being lost, so only that is copied. The `KeepsTrivia` tests cover both ends.

## Tests

Six tests added to the existing test files, covering the negated, member-access and trivia shapes for each rule. Each was run against the unfixed code first and reproduced the exact broken output above.

- MA0112: `Any_List_Negated_CodeFix`, `Any_List_MemberAccess_CodeFix`, `Any_List_KeepsTrivia_CodeFix`
- MA0128: `ReadOnlySpanChar_SequenceEqual_Negated`, `ReadOnlySpanChar_SequenceEqual_MemberAccess`, `ReadOnlySpanChar_SequenceEqual_KeepsTrivia`

## Verification

- The two rules' tests pass on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9), 156 tests each.
- Full suite: 19123 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes — this is a behavior-only fix to the code fixers, the rule documentation is unaffected.