### PR TITLE
Do not report MA0179 on user-defined GetCustomAttribute(s) methods

### DIFF
--- a/docs/Rules/MA0179.md
+++ b/docs/Rules/MA0179.md
@@ -33,6 +33,9 @@ if (!Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
 if (member.GetCustomAttributes<ObsoleteAttribute>().Any(a => a.Message != null)) { }
 if (member.GetCustomAttributes<ObsoleteAttribute>().Count(a => a.Message != null) > 0) { }
 
+// compliant - user-defined methods named GetCustomAttribute(s) are not detected
+if (member.GetCustomAttribute("name") != null) { } // custom extension method
+
 // compliant - accessing attribute properties
 var attr = type.GetCustomAttribute<ObsoleteAttribute>();
 if (attr != null)

--- a/src/Meziantou.Analyzer/Rules/UseAttributeIsDefinedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAttributeIsDefinedAnalyzer.cs
@@ -41,7 +41,6 @@ public sealed class UseAttributeIsDefinedAnalyzer : DiagnosticAnalyzer
         private readonly INamedTypeSymbol? _assemblySymbol = compilation.GetBestTypeByMetadataName("System.Reflection.Assembly");
         private readonly INamedTypeSymbol? _moduleSymbol = compilation.GetBestTypeByMetadataName("System.Reflection.Module");
         private readonly INamedTypeSymbol? _memberInfoSymbol = compilation.GetBestTypeByMetadataName("System.Reflection.MemberInfo");
-        private readonly INamedTypeSymbol? _parameterInfoSymbol = compilation.GetBestTypeByMetadataName("System.Reflection.ParameterInfo");
         private readonly INamedTypeSymbol? _typeSymbol = compilation.GetBestTypeByMetadataName("System.Type");
         private readonly INamedTypeSymbol? _customAttributeExtensionsSymbol = compilation.GetBestTypeByMetadataName("System.Reflection.CustomAttributeExtensions");
         private readonly IMethodSymbol? _enumerableAnyMethod = DocumentationCommentId.GetFirstSymbolForDeclarationId(EnumerableAnyMethodDocId, compilation) as IMethodSymbol;
@@ -209,39 +208,30 @@ public sealed class UseAttributeIsDefinedAnalyzer : DiagnosticAnalyzer
         private bool IsGetCustomAttributeInvocation(IOperation operation, out IInvocationOperation? invocation)
         {
             invocation = operation.UnwrapConversions() as IInvocationOperation;
-            if (invocation is null)
-                return false;
-
-            if (invocation.TargetMethod.Name != "GetCustomAttribute")
-                return false;
-
-            // For extension methods, the instance is in the first argument
-            var instance = invocation.Instance;
-            if (instance is null && invocation.TargetMethod.IsExtensionMethod && invocation.Arguments.Length > 0)
+            if (invocation is null || !IsAttributeProviderInvocation(invocation, "GetCustomAttribute"))
             {
-                instance = invocation.Arguments[0].Value;
-            }
-            else if (instance is null && invocation.TargetMethod.IsStatic && SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, _attributeSymbol))
-            {
-                if (invocation.Arguments.Length > 0)
-                {
-                    instance = invocation.Arguments[0].Value;
-                }
+                invocation = null;
+                return false;
             }
 
-            if (instance is null)
-                return false;
-
-            return IsValidInstanceType(instance.Type);
+            return true;
         }
 
         private bool IsGetCustomAttributesInvocation(IOperation operation, out IInvocationOperation? invocation)
         {
             invocation = operation as IInvocationOperation;
-            if (invocation is null)
+            if (invocation is null || !IsAttributeProviderInvocation(invocation, "GetCustomAttributes"))
+            {
+                invocation = null;
                 return false;
+            }
 
-            if (invocation.TargetMethod.Name != "GetCustomAttributes")
+            return true;
+        }
+
+        private bool IsAttributeProviderInvocation(IInvocationOperation invocation, string methodName)
+        {
+            if (invocation.TargetMethod.Name != methodName)
                 return false;
 
             if (!IsMethodFromReflectionTypes(invocation.TargetMethod))
@@ -269,28 +259,14 @@ public sealed class UseAttributeIsDefinedAnalyzer : DiagnosticAnalyzer
 
         private bool IsMethodFromReflectionTypes(IMethodSymbol method)
         {
-            if (SymbolEqualityComparer.Default.Equals(method.ContainingType, _customAttributeExtensionsSymbol))
+            if (method.ContainingType.IsEqualToAny(_customAttributeExtensionsSymbol, _attributeSymbol))
                 return true;
 
-            if (SymbolEqualityComparer.Default.Equals(method.ContainingType, _attributeSymbol))
-                return true;
-
-            // Check for extension methods on reflection types
-            if (method.Name is "GetCustomAttribute" or "GetCustomAttributes")
-            {
-                if (method.Parameters.Length > 0)
-                {
-                    var firstParamType = method.Parameters[0].Type;
-                    if (IsReflectionType(firstParamType) || IsParameterInfo(firstParamType))
-                        return true;
-                }
-            }
-
-            return false;
+            // Instance methods of the reflection types, such as MemberInfo.GetCustomAttributes(Type, bool).
+            // Methods declared by the user are not considered, even when they are named GetCustomAttribute(s)
+            // and take a reflection type as their first parameter.
+            return !method.IsStatic && IsValidInstanceType(method.ContainingType);
         }
-
-        private bool IsParameterInfo(ITypeSymbol type) => type.IsEqualTo(_parameterInfoSymbol);
-        private bool IsReflectionType(ITypeSymbol type) => type.IsEqualToAny(_assemblySymbol, _moduleSymbol, _memberInfoSymbol, _typeSymbol);
 
         private bool IsValidInstanceType(ITypeSymbol? type)
         {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
@@ -722,4 +722,140 @@ public sealed class UseAttributeIsDefinedAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task UserDefinedGetCustomAttributeExtensionMethod_ShouldNotReport()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Reflection;
+
+            static class Extensions
+            {
+                public static object GetCustomAttribute(this MemberInfo member, string name) => null;
+            }
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = member.GetCustomAttribute("name") != null;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task UserDefinedGetCustomAttributesExtensionMethod_ShouldNotReport()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Reflection;
+
+            static class Extensions
+            {
+                public static object[] GetCustomAttributes(this MemberInfo member, string name) => null;
+            }
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = member.GetCustomAttributes("name").Length > 0;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task UserDefinedGetCustomAttributeStaticMethod_ShouldNotReport()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Reflection;
+
+            static class Helper
+            {
+                public static object GetCustomAttribute(MemberInfo member, string name) => null;
+            }
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = Helper.GetCustomAttribute(member, "name") != null;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MemberInfo_GetCustomAttributes_WithAttributeType_Length_GreaterThanZero()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {|MA0179:member.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: true).Length > 0|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = Attribute.IsDefined(member, typeof(ObsoleteAttribute), inherit: true);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MemberInfo_GetCustomAttributes_WithInherit_Length_GreaterThanZero()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {|MA0179:member.GetCustomAttributes(inherit: true).Length > 0|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = Attribute.IsDefined(member, typeof(Attribute), inherit: true);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## Problem

MA0179 reported on any method named `GetCustomAttribute` / `GetCustomAttributes` whose first parameter is a reflection type, regardless of who declared it:

```csharp
static class MyExtensions
{
    public static object GetCustomAttribute(this MemberInfo m, string name) => null;
}

class C
{
    void M(MemberInfo member) => _ = member.GetCustomAttribute("name") != null; // MA0179
}
```

The offered fix rewrote that to `Attribute.IsDefined(member, typeof(Attribute))`, which has nothing to do with the method being called.

Two separate defects were involved:

- `IsGetCustomAttributeInvocation` (singular) never called `IsMethodFromReflectionTypes`, unlike its plural twin.
- Adding that call would not have been enough. The "extension methods on reflection types" fallback in `IsMethodFromReflectionTypes` accepts *any* method named `GetCustomAttribute(s)` whose first parameter is `Assembly`/`Module`/`MemberInfo`/`Type`/`ParameterInfo` — exactly the shape of a user-defined extension method. Verified by running it: the plural overload reported the false positive too.

## Change

- `IsMethodFromReflectionTypes` now decides from the **declaring type** instead of a parameter-shape heuristic: `System.Attribute`, `System.Reflection.CustomAttributeExtensions`, or an instance method of a reflection type (e.g. `MemberInfo.GetCustomAttributes(Type, bool)`). User-declared methods no longer match on either path.
- The two nearly identical overloads are merged into a single `IsAttributeProviderInvocation(invocation, methodName)`, so they cannot drift apart again — that drift is what made the singular one skip the validation.
- `IsReflectionType`, `IsParameterInfo` and `_parameterInfoSymbol` became dead code and were removed. `ParameterInfo` was never actually supported by the rule, since `IsValidInstanceType` never accepted it.

## Note for the reviewer

One deliberate behavior change: `member.GetCustomAttributes(inherit: true).Length > 0` was previously **not** reported, only because its first parameter is a `bool` and so missed the old heuristic. It is a genuine true positive and is now reported, fixed to `Attribute.IsDefined(member, typeof(Attribute), inherit: true)`, which is semantically equivalent. Happy to gate it back out if you would rather not widen the rule here.

## Tests

5 tests added to `UseAttributeIsDefinedAnalyzerTests`, all confirmed failing before the change: user-defined extension method (singular and plural), user-defined static helper, and the two BCL instance-call cases with their fixes.

- MA0179 tests: 29/29 pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9
- Full suite: 3881/3881 on `roslyn5.9`, 3769/3769 on `roslyn4.8`
- `dotnet run --project src/DocumentationGenerator` exits 0 (no generated markdown drift); `docs/Rules/MA0179.md` documents the user-defined-method exclusion.