### PR TITLE
Fix MA0151 false positive on System.Object members of interface-typed members

### DIFF
--- a/src/Meziantou.Analyzer/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzer.cs
@@ -231,11 +231,6 @@ public sealed class DebuggerDisplayAttributeShouldContainValidExpressionsAnalyze
 
         static ISymbol? FindSymbol(Compilation compilation, ISymbol parent, string name)
         {
-            if (name is "ToString" or "GetHashCode")
-            {
-                compilation.GetSpecialType(SpecialType.System_Object).GetMembers(name).FirstOrDefault();
-            }
-
             if (parent is INamespaceOrTypeSymbol typeSymbol)
             {
                 if (typeSymbol.GetAllMembers(name).FirstOrDefault() is { } member)
@@ -244,6 +239,13 @@ public sealed class DebuggerDisplayAttributeShouldContainValidExpressionsAnalyze
                         return member;
 
                     return member.GetSymbolType();
+                }
+
+                // Interfaces don't derive from System.Object, but its members are still accessible on interface-typed expressions
+                if (typeSymbol is ITypeSymbol { TypeKind: TypeKind.Interface })
+                {
+                    if (compilation.GetSpecialType(SpecialType.System_Object).GetMembers(name).FirstOrDefault() is { } objectMember)
+                        return objectMember.GetSymbolType();
                 }
             }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzerTests.cs
@@ -459,4 +459,49 @@ public sealed class DebuggerDisplayAttributeShouldContainValidExpressionsAnalyze
 
         return test.RunAsync();
     }
+
+    [Theory]
+    [InlineData("Foo.ToString()")]
+    [InlineData("Foo.GetHashCode()")]
+    [InlineData("Foo.GetType()")]
+    [InlineData("Foo.Equals(null)")]
+    [InlineData("Foo.ToString().Length")]
+    public Task ObjectMembersOnInterfaceTypedMember(string value)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            using System.Diagnostics;
+            [DebuggerDisplay("{{{value}}}")]
+            public class Dummy
+            {
+                public IFoo Foo { get; }
+            }
+
+            public interface IFoo
+            {
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task UnknownMemberOnInterfaceTypedMember()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics;
+            [{|MA0151:DebuggerDisplay("{Foo.Unknown()}")|}]
+            public class Dummy
+            {
+                public IFoo Foo { get; }
+            }
+
+            public interface IFoo
+            {
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## What

`MA0151` (DebuggerDisplay must contain valid members) reported a false positive when a `[DebuggerDisplay]` expression called a `System.Object` member on an interface-typed member:

```csharp
interface IFoo { }

[DebuggerDisplay("{Foo.ToString()}")] // MA0151: Member 'ToString' does not exist
class Sample
{
    public IFoo Foo { get; }
}
```

The same applied to `GetHashCode()`, `GetType()` and `Equals(...)`. The only remedy was to suppress the diagnostic.

## Why

`FindSymbol` already resolved the `System.Object` member for `ToString` and `GetHashCode`, but discarded the result — the lookup had no `return` statement:

```csharp
if (name is "ToString" or "GetHashCode")
{
    compilation.GetSpecialType(SpecialType.System_Object).GetMembers(name).FirstOrDefault();
}
```

Execution then fell through to `GetAllMembers`, which for an interface walks only its own members plus `AllInterfaces`. `BaseType` is `null` for interfaces, so the `System.Object` members were never reachable and the member was reported as non-existent. Classes and structs were unaffected because they reach `System.Object` through `BaseType`.

## How

The lookup is now an actual fallback, applied **after** the regular member lookup and only when the containing symbol is an interface:

- Ordering means a type that declares its own member still wins, so the change is purely additive.
- Restricting it to `TypeKind.Interface` keeps it from resolving something like `SomeNamespace.ToString`, and leaves classes and structs untouched.
- It returns `objectMember.GetSymbolType()` — the method's return type — matching what the surrounding code returns for other non-type members, so chained paths keep resolving.
- Dropping the `name is "ToString" or "GetHashCode"` filter also covers `GetType()` and `Equals(...)`, which had the same false positive.

## Tests

Added to the existing `DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzerTests`:

- A theory covering `Foo.ToString()`, `Foo.GetHashCode()`, `Foo.GetType()`, `Foo.Equals(null)` and `Foo.ToString().Length` on an interface-typed property — all expected to be clean.
- A fact asserting `Foo.Unknown()` on the same interface-typed property still reports `MA0151`, so the fallback does not swallow genuine errors.

Reverting the analyzer change makes 5 of the 6 new tests fail (the negative test passes either way), confirming they pin the fix.

## Notes for reviewers

- Full suite is green on all five Roslyn versions: 19123 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.
- `docs/Rules/MA0151.md` was left as is: it describes the rule's purpose rather than the interface behavior, so nothing in it became inaccurate.