### PR TITLE
Run the configured code fixer even without an expected fixed code

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Harness/CSharpCodeFixTest.cs
+++ b/tests/Meziantou.Analyzer.Test/Harness/CSharpCodeFixTest.cs
@@ -1,5 +1,7 @@
+using System.Collections.Immutable;
 using Meziantou.Analyzer.Annotations;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -59,6 +61,65 @@ internal sealed class CSharpCodeFixTest<TAnalyzer, TCodeFix>
         }
 
         await base.RunImplAsync(cancellationToken).ConfigureAwait(false);
+
+        // The base implementation only invokes the code fix provider when the test declares the fixed code
+        if (!CodeActionExpected(FixedState) && !CodeActionExpected(BatchFixedState))
+        {
+            await VerifyCodeFixActionsAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// The diagnostics of the test code, captured the first time they are computed, which is the verification of
+    /// the test state. The later computations are the ones of the <c>&lt;auto-generated&gt;</c> and the
+    /// <c>#pragma warning disable</c> variants of the code, which are not the code the test declares.
+    /// </summary>
+    private ImmutableArray<(Project Project, Diagnostic Diagnostic)>? _testStateDiagnostics;
+
+    protected override ImmutableArray<(Project project, Diagnostic diagnostic)> SortDistinctDiagnostics(ImmutableArray<(Project project, Diagnostic diagnostic)> diagnostics)
+    {
+        var sortedDiagnostics = base.SortDistinctDiagnostics(diagnostics);
+        _testStateDiagnostics ??= sortedDiagnostics;
+        return sortedDiagnostics;
+    }
+
+    /// <summary>
+    /// Registers the code fixes for every reported diagnostic the provider declares as fixable, and computes the
+    /// changes of every registered action, without applying them.
+    /// </summary>
+    /// <remarks>
+    /// A test that configures a code fix provider but no fixed code never invokes the provider otherwise, so a
+    /// provider that throws for that shape of code goes unnoticed, even though those snippets are inputs the
+    /// provider does run on in an IDE. Computing the changes is what runs the delegate the provider registered,
+    /// where the fix actually builds the new document. They cannot be compared, as the test did not declare what
+    /// the fixed code should be, but they must be computable.
+    /// </remarks>
+    private async Task VerifyCodeFixActionsAsync(CancellationToken cancellationToken)
+    {
+        if (_testStateDiagnostics is not { } diagnostics)
+            return;
+
+        var codeFixProviders = GetCodeFixProviders().ToArray();
+        foreach (var (project, diagnostic) in diagnostics)
+        {
+            if (project.Solution.GetDocument(diagnostic.Location.SourceTree) is not { } document)
+                continue;
+
+            foreach (var codeFixProvider in codeFixProviders)
+            {
+                if (!codeFixProvider.FixableDiagnosticIds.Contains(diagnostic.Id, StringComparer.Ordinal))
+                    continue;
+
+                var actions = new List<CodeAction>();
+                var context = CreateCodeFixContext(document, diagnostic.Location.SourceSpan, [diagnostic], (action, _) => actions.Add(action), cancellationToken);
+                await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+
+                foreach (var action in FilterCodeActions([.. actions]))
+                {
+                    await action.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/tests/Meziantou.Analyzer.Test/Harness/CodeFixTestValidationTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Harness/CodeFixTestValidationTests.cs
@@ -1,0 +1,217 @@
+// The analyzers of this file are test helpers, not compiler extensions that ship to users, so the analyzer
+// authoring rules do not apply
+#pragma warning disable RS1038 // This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Meziantou.Analyzer.Test.Harness;
+
+/// <summary>
+/// The tests of <see cref="CSharpCodeFixTest{TAnalyzer, TCodeFix}"/> itself, so that a change to the harness that
+/// stops reporting a defective analyzer or code fixer is detected.
+/// </summary>
+public sealed class CodeFixTestValidationTests
+{
+    private const string SourceCode = """
+        class TestClass
+        {
+            bool Test(object o) => [|o is string|];
+        }
+        """;
+
+    [Fact]
+    public async Task VerifyFix_ReportsFixedCodeThatDoesNotCompile()
+    {
+        // The fixer produces a valid tree, but the code it produces does not compile
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => new CSharpCodeFixTest<TypeCheckAnalyzer, ReplaceWithUndefinedIdentifierFixer>
+        {
+            TestCode = SourceCode,
+            FixedCode = """
+                class TestClass
+                {
+                    bool Test(object o) => undefinedVariable;
+                }
+                """,
+        }.RunAsync());
+
+        Assert.Contains("CS0103", exception.Message);
+    }
+
+    [Fact]
+    public async Task VerifyFix_DoesNotReportValidFix()
+    {
+        await new CSharpCodeFixTest<TypeCheckAnalyzer, NegateWithParenthesesFixer>
+        {
+            TestCode = SourceCode,
+            FixedCode = """
+                class TestClass
+                {
+                    bool Test(object o) => !(o is string);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task VerifyDiagnostic_ReportsAnalyzerException()
+    {
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => new CSharpAnalyzerTest<ThrowingAnalyzer>
+        {
+            TestCode = """
+                class TestClass
+                {
+                    bool Test(object o) => o is string;
+                }
+                """,
+        }.RunAsync());
+
+        Assert.Contains(nameof(ThrowingAnalyzer), exception.Message);
+    }
+
+    [Fact]
+    public async Task WithoutFixedCode_ReportsFixerThrowingWhenRegisteringTheFix()
+    {
+        var exception = await Assert.ThrowsAnyAsync<InvalidOperationException>(() => new CSharpCodeFixTest<TypeCheckAnalyzer, ThrowingWhenRegisteringFixer>
+        {
+            TestCode = SourceCode,
+        }.RunAsync());
+
+        Assert.Equal("Registration failure", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithoutFixedCode_ReportsFixerThrowingWhenComputingTheChanges()
+    {
+        var exception = await Assert.ThrowsAnyAsync<InvalidOperationException>(() => new CSharpCodeFixTest<TypeCheckAnalyzer, ThrowingWhenComputingChangesFixer>
+        {
+            TestCode = SourceCode,
+        }.RunAsync());
+
+        Assert.Equal("Computation failure", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithoutFixedCode_DoesNotReportValidFixer()
+    {
+        await new CSharpCodeFixTest<TypeCheckAnalyzer, NegateWithParenthesesFixer>
+        {
+            TestCode = SourceCode,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task WithoutFixedCode_DoesNotInvokeTheFixerWhenNoDiagnosticIsReported()
+    {
+        await new CSharpCodeFixTest<TypeCheckAnalyzer, ThrowingWhenRegisteringFixer>
+        {
+            TestCode = """
+                class TestClass
+                {
+                    bool Test(object o) => o != null;
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class ThrowingAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new("TEST0002", "Throw", "Throw", "Test", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(_ => throw new InvalidOperationException("Analyzer failure"), SyntaxKind.IsExpression);
+        }
+    }
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class TypeCheckAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new("TEST0001", "Negate the type check", "Negate the type check", "Test", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            // The type checks that are already negated are not reported, so that applying the fix removes the diagnostic
+            context.RegisterSyntaxNodeAction(ctx =>
+            {
+                if (ctx.Node.Parent is not ParenthesizedExpressionSyntax)
+                {
+                    ctx.ReportDiagnostic(Diagnostic.Create(Rule, ctx.Node.GetLocation()));
+                }
+            }, SyntaxKind.IsExpression);
+        }
+    }
+
+    private abstract class RewriteTypeCheckFixer : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("TEST0001");
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        protected abstract ExpressionSyntax Rewrite(BinaryExpressionSyntax expression);
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root?.FindNode(context.Span, getInnermostNodeForTie: true) is not BinaryExpressionSyntax expression)
+                return;
+
+            context.RegisterCodeFix(CodeAction.Create("Rewrite", async ct =>
+            {
+                var editor = await DocumentEditor.CreateAsync(context.Document, ct).ConfigureAwait(false);
+                editor.ReplaceNode(expression, Rewrite(expression));
+                return editor.GetChangedDocument();
+            }, equivalenceKey: "Rewrite"), context.Diagnostics);
+        }
+    }
+
+    private sealed class NegateWithParenthesesFixer : RewriteTypeCheckFixer
+    {
+        protected override ExpressionSyntax Rewrite(BinaryExpressionSyntax expression) =>
+            PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, ParenthesizedExpression(expression.WithoutTrivia()));
+    }
+
+    private sealed class ReplaceWithUndefinedIdentifierFixer : RewriteTypeCheckFixer
+    {
+        protected override ExpressionSyntax Rewrite(BinaryExpressionSyntax expression) =>
+            IdentifierName("undefinedVariable");
+    }
+
+    private sealed class ThrowingWhenRegisteringFixer : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("TEST0001");
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context) => throw new InvalidOperationException("Registration failure");
+    }
+
+    private sealed class ThrowingWhenComputingChangesFixer : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("TEST0001");
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(CodeAction.Create("Throw", static Task<Document> (CancellationToken _) => throw new InvalidOperationException("Computation failure"), equivalenceKey: "Throw"), context.Diagnostics);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`Microsoft.CodeAnalysis.Testing` only calls `VerifyFixAsync` when a test sets `FixedCode`, `FixedState` or `BatchFixedCode`. Otherwise `RegisterCodeFixesAsync` is **never called at all**, so the code fixer a `CSharpCodeFixTest<TAnalyzer, TCodeFix>` configures is dead weight for every test that only asserts diagnostics — even though those snippets are inputs the fixer does run on in an IDE. A fixer that throws on register, or that registers an action on a shape the tests only assert diagnostics for, is invisible to CI and surfaces as a crashed lightbulb for the user.

The old `ProjectBuilder` had this guard: it was added in #1353, after an MA0028 fixer threw `InvalidCastException` on a snippet whose fix nobody had declared. The migration to the Roslyn SDK harness removed `Helpers/ProjectBuilder.Validation.cs` and `Helpers/ProjectBuilderValidationTests.cs` without a replacement.

## Changes

**`Harness/CSharpCodeFixTest.cs`** — after `base.RunImplAsync`, when the test declares no fixed code (`!CodeActionExpected(FixedState) && !CodeActionExpected(BatchFixedState)`):

1. Reuse the diagnostics already computed for the test state, captured from an override of `SortDistinctDiagnostics` whose first invocation is the test state verification, so no project is recreated and no analysis runs twice. The later computations are the ones of the `<auto-generated>` and `#pragma warning disable` variants of the code, which are not the code the test declares.
2. Call `RegisterCodeFixesAsync` for each reported diagnostic the provider declares as fixable, through the base `CreateCodeFixContext`.
3. Call `GetOperationsAsync` on every registered action, after `FilterCodeActions`, which is what runs the delegate the provider registered, where the fix actually builds the new document. A provider often registers several actions, and `VerifyFixAsync` applies exactly one, so the others need to be computed explicitly.

The changes are not applied, as the test did not declare what the fixed code should be, but they must be computable, and an exception fails the test.

**`Harness/CodeFixTestValidationTests.cs`** — the self-tests of the harness, the equivalent of the deleted `ProjectBuilderValidationTests`, so that a future harness change that stops reporting a defective analyzer or code fixer is itself detected: a fixer that throws when registering the fix and one that throws when computing the changes must both fail a test that declares no fixed code, a valid fixer must not, the fixer must not run when no diagnostic is reported, plus the restored `VerifyFix` checks (fixed code that does not compile is reported, a valid fix is not) and the analyzer exception check.

## Notes for the reviewer

- **No existing test fails**, on any of the five Roslyn versions: this is a regression guard rather than a fix for a current crash. The MA0028 defect that motivated the original guard is already fixed on `main` (3981e6c).
- **The guard is not a no-op**: with a temporary throw inserted after `GetOperationsAsync`, 516 test methods failed — those are the tests that now compute a code fix action that was never invoked before.
- **The cost is unchanged in practice**: the suite runs in ~23s per Roslyn version before and after, as the diagnostics are reused rather than recomputed.
- **Not covered here**: the path where a test *does* declare fixed code still computes only the action the SDK applies, not the siblings a provider registered alongside it. The old `ProjectBuilder` covered that too. On the SDK harness it means collecting actions from `FilterCodeActions` across the iterative loop and the four fix-all modes and recomputing them at the end, which is a real cost increase on the slowest tests for a narrower class of defect. Happy to add it in a follow-up if wanted.

## Validation

- `dotnet test --max-parallel-test-modules 2`: **19128 passed, 0 failed** across roslyn4.8, roslyn4.14, roslyn5.0, roslyn5.6 and roslyn5.9.
- Build with 0 warnings.
- `dotnet run --project src/DocumentationGenerator` exits 0, no markdown drift (this change touches no analyzer code).
