### PR TITLE
Create the GitHub release from the commit that was built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,6 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-    - run: 'gh release create "${{ needs.compute_package_version.outputs.package_version }}" --generate-notes --notes "NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/${{ needs.compute_package_version.outputs.package_version }}>"'
+    - run: 'gh release create "${{ needs.compute_package_version.outputs.package_version }}" --target "${{ github.sha }}" --generate-notes --notes "NuGet package: <https://www.nuget.org/packages/Meziantou.Analyzer/${{ needs.compute_package_version.outputs.package_version }}>"'
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What

Pass `--target "${{ github.sha }}"` to `gh release create` in the `create_release` job of `.github/workflows/ci.yml`.

## Why

`gh release create` was called without `--target`, so it omitted `target_commitish` from the API call. The GitHub API then defaults it to *the repository's default branch* — its tip at the moment the job runs — rather than the commit the workflow run built.

The `ci-main` concurrency group (`cancel-in-progress: true`) masks this most of the time: a new push to main cancels the in-flight run, so the last run standing usually matches HEAD. But the two can diverge:

- **A path-ignored push to main.** `paths-ignore` covers `docs/**`, `tests/**`, `.github/*`, `renovate.json`, `GenerateDocumentation.cmd` and `.markdownlint.json`. Such a push starts no run, so it cancels nothing — main advances while the release run is still going, and the tag lands on the newer commit. This repo merges docs- and test-only PRs to main regularly.
- **A race at the end of the run.** A push arriving after `create_release` has started still takes time to cancel it; `gh release create` can win.

The result is a tag and release pointing at a commit whose code is not what was packed and pushed to nuget.org under that version, and `--generate-notes` crediting the release with commits it does not contain.

## Notes for reviewers

- `github.sha` is the pushed commit on a `push` to main, and the tip of the selected ref on `workflow_dispatch` — in both cases the commit `actions/checkout` fetched and `create_nuget` packed.
- The `actions/checkout` step in `create_release` is still needed: `gh` resolves the repository from the git remote.
- `--generate-notes` keeps computing notes relative to the previous tag, which is now more accurate since the tags sit on the commits that were actually released.
- Workflow-only change, so there is nothing to build or test locally; the YAML was validated as parsing and the job list is unchanged.