### PR TITLE
Fix MA0065/MA0066 never checking for a GetHashCode override

### DIFF
--- a/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
@@ -60,7 +60,7 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
             if (ValueTypeSymbol is not null)
             {
                 ValueTypeEqualsSymbol = ValueTypeSymbol.GetMembers(nameof(ValueType.Equals)).OfType<IMethodSymbol>().FirstOrDefault();
-                ValueTypeGetHashCodeSymbol = ValueTypeSymbol.GetMembers(nameof(ValueType.Equals)).OfType<IMethodSymbol>().FirstOrDefault();
+                ValueTypeGetHashCodeSymbol = ValueTypeSymbol.GetMembers(nameof(ValueType.GetHashCode)).OfType<IMethodSymbol>().FirstOrDefault();
             }
 
             ImmutableDictionarySymbol = compilation.GetBestTypeByMetadataName("System.Collections.Immutable.ImmutableDictionary");

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzerTests.cs
@@ -111,6 +111,73 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzerTests
     }
 
     [Fact]
+    public Task GetHashCode_OnlyEqualsOverriden()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            #pragma warning disable CS0659
+            struct Test
+            {
+                public override bool Equals(object o) => throw null;
+            }
+
+            class Sample
+            {
+                public void A()
+                {
+                    _ = {|MA0065:new Test().GetHashCode()|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Equals_OnlyGetHashCodeOverriden()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            struct Test
+            {
+                public override int GetHashCode() => throw null;
+            }
+
+            class Sample
+            {
+                public void A()
+                {
+                    _ = {|MA0065:new Test().Equals(new Test())|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("new System.Collections.Generic.HashSet<Test>()")]
+    [InlineData("new System.Collections.Generic.Dictionary<Test, object>()")]
+    public Task Constructor_OnlyEqualsOverriden(string text)
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = $$"""
+            #pragma warning disable CS0659
+            struct Test
+            {
+                public override bool Equals(object o) => throw null;
+
+                void A()
+                {
+                    _ = {|MA0066:{{text}}|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task GetHashCode_Enum()
     {
         var test = new AnalyzerTest();


### PR DESCRIPTION
## What

`DoNotUseDefaultEqualsOnValueTypeAnalyzer` resolved `ValueTypeGetHashCodeSymbol` with `nameof(ValueType.Equals)` instead of `nameof(ValueType.GetHashCode)`:

```csharp
ValueTypeEqualsSymbol      = ValueTypeSymbol.GetMembers(nameof(ValueType.Equals))...;
ValueTypeGetHashCodeSymbol = ValueTypeSymbol.GetMembers(nameof(ValueType.Equals))...;  // bug
```

Both fields held the same symbol, so the two checks in `HasDefaultEqualsOrHashCodeImplementations` both tested for an `Equals` override and `GetHashCode` was never looked at.

## Why it matters

A struct that overrides `Equals` but not `GetHashCode` still uses the reflection-based `ValueType.GetHashCode` — precisely the performance problem MA0065 and MA0066 exist to catch — yet was reported by neither rule:

```csharp
#pragma warning disable CS0659
struct Test { public override bool Equals(object o) => throw null; }

_ = new Test().GetHashCode();                              // was missing MA0065
_ = new System.Collections.Generic.Dictionary<Test, int>(); // was missing MA0066
```

Every such struct escaped both rules. The `Equals` half of the check was never broken, so this is purely a set of missed diagnostics — no false positives were being produced.

## Tests

Added to `DoNotUseDefaultEqualsOnValueTypeAnalyzerTests`:

- `GetHashCode_OnlyEqualsOverriden` — MA0065 on a `GetHashCode()` call
- `Constructor_OnlyEqualsOverriden` — MA0066 on `HashSet<T>` / `Dictionary<TKey, TValue>`
- `Equals_OnlyGetHashCodeOverriden` — guards the symmetric case (passed before the fix too)

## Verification

- Reverting the fix makes 3 of the 4 new tests fail, confirming they pin the bug.
- With the fix, 44/44 tests in the class pass on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9).
- Full suite on the default version (roslyn5.9): 3913/3913 pass.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes. The MA0065/MA0066 docs already describe checking both `Equals` and `GetHashCode`, so the fix brings the implementation in line with the documented behavior and no doc update was needed.

## Reviewer note

This makes the rules report in cases they previously stayed silent on, so consumers with structs that override only `Equals` may see new MA0065/MA0066 warnings after upgrading. That is the intended behavior of both rules.