### PR TITLE
Report MA0124/MA0125/MA0126 on [LoggerMessage(Message = "...")]

### DIFF
--- a/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
@@ -263,6 +263,19 @@ public sealed class LoggerParameterTypeAnalyzer : DiagnosticAnalyzer
                 }
             }
 
+            if (formatString is null)
+            {
+                // The message can also be set using the Message property: [LoggerMessage(Message = "...")]
+                foreach (var arg in loggerMessageAttribute.NamedArguments)
+                {
+                    if (arg.Key is "Message" && arg.Value.Type.IsString() && arg.Value.Value is string namedStr)
+                    {
+                        formatString = namedStr;
+                        break;
+                    }
+                }
+            }
+
             if (string.IsNullOrEmpty(formatString))
                 return;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
@@ -753,4 +753,67 @@ public sealed class LoggerParameterTypeAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task LoggerMessageAttribute_NamedMessageArgument_InvalidParameterType()
+    {
+        var test = CreateTest();
+        test.TestState.OutputKind = OutputKind.DynamicallyLinkedLibrary;
+        test.TestCode = """
+            using Microsoft.Extensions.Logging;
+
+            partial class LoggerExtensions
+            {
+                [LoggerMessage(EventId = 10_004, Level = LogLevel.Trace, Message = "Test message with {Prop}")]
+                static partial void LogTestMessage(ILogger logger, int {|MA0124:Prop|});
+            }
+            """;
+        test.TestState.AdditionalFiles.Add(("LoggerParameterTypes.txt", """
+            Prop;System.String
+            """));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task LoggerMessageAttribute_NamedMessageArgument_ValidParameterType()
+    {
+        var test = CreateTest();
+        test.TestState.OutputKind = OutputKind.DynamicallyLinkedLibrary;
+        test.TestCode = """
+            using Microsoft.Extensions.Logging;
+
+            partial class LoggerExtensions
+            {
+                [LoggerMessage(EventId = 10_004, Level = LogLevel.Trace, Message = "Test message with {Prop}")]
+                static partial void LogTestMessage(ILogger logger, string Prop);
+            }
+            """;
+        test.TestState.AdditionalFiles.Add(("LoggerParameterTypes.txt", """
+            Prop;System.String
+            """));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task LoggerMessageAttribute_NamedEventNameArgument_IsNotUsedAsMessage()
+    {
+        var test = CreateTest();
+        test.TestState.OutputKind = OutputKind.DynamicallyLinkedLibrary;
+        test.TestCode = """
+            using Microsoft.Extensions.Logging;
+
+            partial class LoggerExtensions
+            {
+                [LoggerMessage(EventName = "{Prop}", Level = LogLevel.Trace, Message = "Test message")]
+                static partial void LogTestMessage(ILogger logger, int Prop);
+            }
+            """;
+        test.TestState.AdditionalFiles.Add(("LoggerParameterTypes.txt", """
+            Prop;System.String
+            """));
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## What changed

`LoggerParameterTypeAnalyzer.AnalyzeMethodSymbol` now falls back to the `[LoggerMessage]` attribute's `NamedArguments` to find the message template when no string constructor argument is present.

## Why

The analyzer only scanned `ConstructorArguments` for the format string, so the named-property form of the attribute was silently skipped — MA0124, MA0125 and MA0126 reported nothing for it. With `Prop;System.String` configured:

```csharp
// Before: no diagnostic
[LoggerMessage(EventId = 10_004, Level = LogLevel.Trace, Message = "Test message with {Prop}")]
static partial void LogTestMessage(ILogger logger, int Prop);

// Before and after: reports MA0124
[LoggerMessage(10_004, LogLevel.Trace, "Test message with {Prop}")]
static partial void LogTestMessage(ILogger logger, int Prop);
```

The named form is the shape shown in the .NET documentation, so the rules did nothing for a large share of real `[LoggerMessage]` declarations while appearing to work for anyone who tested them with the positional form.

## For reviewers

The lookup is keyed on `"Message"` specifically rather than on "any string named argument". `LoggerMessageAttribute` also exposes `EventName`, which is a string but is not a message template and must not be parsed as one — `LoggerMessageAttribute_NamedEventNameArgument_IsNotUsedAsMessage` guards that.

No documentation change: `docs/Rules/MA0124.md` describes the rule's intent generally and never enumerates the `[LoggerMessage]` argument forms, so this restores documented behavior rather than changing it. `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.

## Tests

Three tests added to `LoggerParameterTypeAnalyzerTests`:

- `LoggerMessageAttribute_NamedMessageArgument_InvalidParameterType` — the reported case, now reports MA0124
- `LoggerMessageAttribute_NamedMessageArgument_ValidParameterType` — no false positive on the correct type
- `LoggerMessageAttribute_NamedEventNameArgument_IsNotUsedAsMessage` — guards the `EventName` exclusion

Verification:

- The new failing-case test was confirmed non-vacuous: with the analyzer change reverted but the tests kept, `LoggerMessageAttribute_NamedMessageArgument_InvalidParameterType` fails (1 failed / 0 succeeded); it passes with the fix.
- `LoggerParameterTypeAnalyzerTests`: 41/41 pass on roslyn4.8, 4.14, 5.0, 5.6 and 5.9 (38 before, +3 new; the new test names were checked in the `.trx` to confirm they actually ran).
- Full `dotnet build` succeeds with 0 warnings and 0 errors.
