### PR TITLE
Report MA0179 on the array-returning GetCustomAttributes overloads

### DIFF
--- a/docs/Rules/MA0179.md
+++ b/docs/Rules/MA0179.md
@@ -18,6 +18,7 @@ if (member.GetCustomAttributes<ObsoleteAttribute>().Any()) { }
 if (member.GetCustomAttributes<ObsoleteAttribute>().Count() > 0) { }
 if (member.GetCustomAttributes<ObsoleteAttribute>().Length > 0) { }
 if (member.GetCustomAttributes<ObsoleteAttribute>().Length == 0) { }
+if (member.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: false).Any()) { }
 
 // compliant
 if (Attribute.IsDefined(type, typeof(ObsoleteAttribute))) { }
@@ -28,6 +29,7 @@ if (Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
 if (Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
 if (Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
 if (!Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
+if (Attribute.IsDefined(member, typeof(ObsoleteAttribute), inherit: false)) { }
 
 // compliant - with predicate (not detected)
 if (member.GetCustomAttributes<ObsoleteAttribute>().Any(a => a.Message != null)) { }

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAttributeIsDefinedFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAttributeIsDefinedFixer.cs
@@ -102,7 +102,7 @@ public sealed class UseAttributeIsDefinedFixer : CodeFixProvider
             if (enumerableAnyMethod is not null &&
                 SymbolEqualityComparer.Default.Equals(invocationOperation.TargetMethod.OriginalDefinition, enumerableAnyMethod) &&
                 invocationOperation.Arguments.Length == 1 &&
-                invocationOperation.Arguments[0].Value is IInvocationOperation getCustomAttributesInvocation)
+                invocationOperation.Arguments[0].Value.UnwrapConversions() is IInvocationOperation getCustomAttributesInvocation)
             {
                 replacement = CreateAttributeIsDefinedInvocation(generator, semanticModel, getCustomAttributesInvocation, negate: false);
             }
@@ -158,7 +158,7 @@ public sealed class UseAttributeIsDefinedFixer : CodeFixProvider
         if (countInvocation.Arguments.Length != 1)
             return null;
 
-        if (countInvocation.Arguments[0].Value is not IInvocationOperation invocation)
+        if (countInvocation.Arguments[0].Value.UnwrapConversions() is not IInvocationOperation invocation)
             return null;
 
         if (invocation.TargetMethod.Name != "GetCustomAttributes")

--- a/src/Meziantou.Analyzer/Rules/UseAttributeIsDefinedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAttributeIsDefinedAnalyzer.cs
@@ -219,7 +219,8 @@ public sealed class UseAttributeIsDefinedAnalyzer : DiagnosticAnalyzer
 
         private bool IsGetCustomAttributesInvocation(IOperation operation, out IInvocationOperation? invocation)
         {
-            invocation = operation as IInvocationOperation;
+            // The overloads returning an array are wrapped in an implicit conversion when they are used as an IEnumerable<T>
+            invocation = operation.UnwrapConversions() as IInvocationOperation;
             if (invocation is null || !IsAttributeProviderInvocation(invocation, "GetCustomAttributes"))
             {
                 invocation = null;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
@@ -858,4 +858,131 @@ public sealed class UseAttributeIsDefinedAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task MemberInfo_GetCustomAttributes_Array_Any()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {|MA0179:member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Any()|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = Attribute.IsDefined(member, typeof(ObsoleteAttribute), false);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Attribute_GetCustomAttributes_Array_Any()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {|MA0179:Attribute.GetCustomAttributes(member, typeof(ObsoleteAttribute)).Any()|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = Attribute.IsDefined(member, typeof(ObsoleteAttribute));
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MemberInfo_GetCustomAttributes_Array_Count_GreaterThanZero()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {|MA0179:member.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: true).Count() > 0|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = Attribute.IsDefined(member, typeof(ObsoleteAttribute), inherit: true);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task UserDefinedGetCustomAttributesExtensionMethod_Any_ShouldNotReport()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Linq;
+            using System.Reflection;
+
+            static class Extensions
+            {
+                public static object[] GetCustomAttributes(this MemberInfo member, string name) => null;
+            }
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = member.GetCustomAttributes("name").Any();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## What

`MA0179` (`Use Attribute.IsDefined instead of GetCustomAttribute(s)`) did not report the `GetCustomAttributes` overloads that return an array when they are followed by `.Any()` or `.Count()`:

```csharp
_ = member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Any();   // was not reported
_ = member.GetCustomAttributes<ObsoleteAttribute>().Any();                // was reported
```

## Why

`IsGetCustomAttributesInvocation` did `operation as IInvocationOperation`. The array-returning overloads (`MemberInfo.GetCustomAttributes(Type, bool)`, the static `Attribute.GetCustomAttributes` methods, …) produce an implicit `IConversionOperation` (`Attribute[]`/`object[]` to `IEnumerable<T>`) around the invocation when they are passed to `Enumerable.Any` or `Enumerable.Count`, so the cast yielded `null`. Its singular twin `IsGetCustomAttributeInvocation` already called `UnwrapConversions()` first.

These are the overloads available on `netstandard2.0` and the ones used by older code, so the rule was silent exactly where the older API is in use.

The `.Length` comparisons were already reported: there the array is the direct instance of the `Length` property reference, with no conversion in between.

## Changes

- `UseAttributeIsDefinedAnalyzer`: unwrap the conversions in `IsGetCustomAttributesInvocation`.
- `UseAttributeIsDefinedFixer`: the same unwrapping in the `Any()` and `Count()` paths. Without it, the fixer would be offered on the newly reported patterns and return the document unchanged.
- `docs/Rules/MA0179.md`: added the array-returning overload to the examples.
- 4 tests: `MemberInfo.GetCustomAttributes(Type, bool).Any()`, `Attribute.GetCustomAttributes(member, Type).Any()`, `.Count() > 0` with a named `inherit` argument, and a negative case checking that a user-defined `GetCustomAttributes` extension method followed by `.Any()` is still not reported (the conversion unwrapping must not weaken the check added in #1386).

## Verification

- Reverting only the two source files makes the 3 new positive tests fail and leaves the negative one passing; with the fix they all pass (33/33 in `UseAttributeIsDefinedAnalyzerTests`).
- Full suite on all 5 Roslyn versions: 19278 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes.