### PR TITLE
Give MA0107 its own exclude_tostring_methods configuration key

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0104](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0104.md)|Design|Do not create a type with a name from the BCL|⚠️|❌|❌|✔️|
 |[MA0105](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0105.md)|Performance|Use the lambda parameters instead of using a closure|ℹ️|✔️|✔️|❌|
 |[MA0106](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0106.md)|Performance|Avoid closure by using an overload with the 'factoryArgument' parameter|ℹ️|✔️|✔️|❌|
-|[MA0107](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0107.md)|Design|Do not use object.ToString|ℹ️|❌|❌|❌|
+|[MA0107](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0107.md)|Design|Do not use object.ToString|ℹ️|❌|❌|✔️|
 |[MA0108](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0108.md)|Usage|Remove redundant argument value|ℹ️|✔️|✔️|❌|
 |[MA0109](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0109.md)|Design|Consider adding an overload with a Span\<T\> or Memory\<T\>|ℹ️|❌|❌|❌|
 |[MA0110](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0110.md)|Performance|Use the Regex source generator|ℹ️|✔️|✔️|❌|

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,7 @@
 |[MA0104](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0104.md)|Design|Do not create a type with a name from the BCL|<span title='Warning'>⚠️</span>|❌|❌|<span title='MA0104.namespaces_regex&#xA;MA0104.only_consider_public_symbols&#xA;MA0104.use_preview_types'>✔️</span>|
 |[MA0105](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0105.md)|Performance|Use the lambda parameters instead of using a closure|<span title='Info'>ℹ️</span>|✔️|✔️|❌|
 |[MA0106](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0106.md)|Performance|Avoid closure by using an overload with the 'factoryArgument' parameter|<span title='Info'>ℹ️</span>|✔️|✔️|❌|
-|[MA0107](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0107.md)|Design|Do not use object.ToString|<span title='Info'>ℹ️</span>|❌|❌|❌|
+|[MA0107](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0107.md)|Design|Do not use object.ToString|<span title='Info'>ℹ️</span>|❌|❌|<span title='MA0107.exclude_tostring_methods'>✔️</span>|
 |[MA0108](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0108.md)|Usage|Remove redundant argument value|<span title='Info'>ℹ️</span>|✔️|✔️|❌|
 |[MA0109](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0109.md)|Design|Consider adding an overload with a Span\<T\> or Memory\<T\>|<span title='Info'>ℹ️</span>|❌|❌|❌|
 |[MA0110](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0110.md)|Performance|Use the Regex source generator|<span title='Info'>ℹ️</span>|✔️|✔️|❌|

--- a/docs/Rules/MA0060.md
+++ b/docs/Rules/MA0060.md
@@ -29,7 +29,7 @@ In addition, any method whose name starts with `TryParse`, returns `bool`, and h
 This `TryParse` pattern detection can be disabled with:
 
 ```ini
-dotnet_diagnostic.MA0060.enable_tryparse_pattern = false
+MA0060.enable_tryparse_pattern = false
 ```
 
 ## [Pure] attribute

--- a/src/DocumentationGenerator/Program.cs
+++ b/src/DocumentationGenerator/Program.cs
@@ -42,7 +42,9 @@ var diagnosticSuppressors = assemblies.SelectMany(assembly => assembly.GetExport
   .Select(type => (DiagnosticSuppressor)Activator.CreateInstance(type)!)
   .ToList();
 
-var ruleConfigurationKeys = GetRuleConfigurationKeys(assemblies);
+var configurationDefinitions = GetConfigurationDefinitions(assemblies);
+var ruleConfigurationKeys = GetRuleConfigurationKeys(configurationDefinitions);
+var declaredConfigurationKeys = new HashSet<string>(configurationDefinitions.Select(definition => definition.Key), StringComparer.Ordinal);
 
 var sb = new StringBuilder();
 sb.Append("# ").Append(assemblies[0].GetName().Name).Append("'s rules\n");
@@ -100,6 +102,25 @@ Console.WriteLine(sb.ToString());
 
             documentationValidationErrorCount++;
             Console.Error.WriteLine($"Missing configuration key '{configurationKey}' in {path.MakePathRelativeTo(outputFolder)}");
+        }
+    }
+
+    // Last segments that look like a configuration key but are not one: links to another rule page or to a source file, and the severity of a rule
+    var nonConfigurationKeySuffixes = new HashSet<string>(StringComparer.Ordinal) { "md", "cs", "severity" };
+
+    void ValidateRuleDocumentationConfigurationKeysExist(FullPath path, string content)
+    {
+        foreach (Match match in Regex.Matches(content, @"(?<![\w.])(?:dotnet_diagnostic\.)?MA[0-9]{4}\.(?<suffix>[A-Za-z0-9_]+)"))
+        {
+            var key = match.Value;
+            if (nonConfigurationKeySuffixes.Contains(match.Groups["suffix"].Value))
+                continue;
+
+            if (declaredConfigurationKeys.Contains(key))
+                continue;
+
+            documentationValidationErrorCount++;
+            Console.Error.WriteLine($"Configuration key '{key}' in {path.MakePathRelativeTo(outputFolder)} is not declared by any ConfigurationDefinition");
         }
     }
 
@@ -181,6 +202,7 @@ Console.WriteLine(sb.ToString());
                 newContent = Regex.Replace(newContent, "(?<=<!-- sources -->\\r?\\n).*(?=<!-- sources -->)", (sourceLinks.Count == 1 ? "Source: " : "Sources: ") + string.Join(", ", sourceLinks) + "\n", RegexOptions.Singleline);
 
                 ValidateRuleDocumentationContainsConfigurationKeys(detailPath, diagnostic.Id, newContent);
+                ValidateRuleDocumentationConfigurationKeysExist(detailPath, newContent);
                 WriteFileIfChanged(detailPath, newContent);
             }
             else
@@ -490,12 +512,12 @@ static string GetBoolean(bool value)
     return value ? "✔️" : "❌";
 }
 
-static IReadOnlyDictionary<string, IReadOnlyList<string>> GetRuleConfigurationKeys(IEnumerable<Assembly> assemblies)
+static IReadOnlyList<(string Key, bool IsHidden)> GetConfigurationDefinitions(IEnumerable<Assembly> assemblies)
 {
     var configurationDefinitionType = typeof(ConfigurationDefinition<bool>).GetGenericTypeDefinition();
     var keyPropertyName = nameof(ConfigurationDefinition<bool>.Key);
     var isHiddenPropertyName = nameof(ConfigurationDefinition<bool>.IsHidden);
-    var result = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+    var result = new List<(string Key, bool IsHidden)>();
 
     foreach (var type in assemblies.SelectMany(assembly => assembly.GetTypes()))
     {
@@ -508,23 +530,36 @@ static IReadOnlyDictionary<string, IReadOnlyList<string>> GetRuleConfigurationKe
             if (fieldValue is null)
                 continue;
 
-            if (field.FieldType.GetProperty(isHiddenPropertyName)?.GetValue(fieldValue) is bool isHidden && isHidden)
-                continue;
-
             if (field.FieldType.GetProperty(keyPropertyName)?.GetValue(fieldValue) is not string key)
                 continue;
 
-            if (TryGetRuleIdPrefix(key, out var ruleId) is false)
-                continue;
-
-            if (!result.TryGetValue(ruleId, out var keys))
-            {
-                keys = [with(StringComparer.Ordinal)];
-                result.Add(ruleId, keys);
-            }
-
-            keys.Add(key);
+            var isHidden = field.FieldType.GetProperty(isHiddenPropertyName)?.GetValue(fieldValue) is bool value && value;
+            result.Add((key, isHidden));
         }
+    }
+
+    return result;
+}
+
+static IReadOnlyDictionary<string, IReadOnlyList<string>> GetRuleConfigurationKeys(IEnumerable<(string Key, bool IsHidden)> configurationDefinitions)
+{
+    var result = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+
+    foreach (var (key, isHidden) in configurationDefinitions)
+    {
+        if (isHidden)
+            continue;
+
+        if (TryGetRuleIdPrefix(key, out var ruleId) is false)
+            continue;
+
+        if (!result.TryGetValue(ruleId, out var keys))
+        {
+            keys = [with(StringComparer.Ordinal)];
+            result.Add(ruleId, keys);
+        }
+
+        keys.Add(key);
     }
 
     var output = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);

--- a/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzer.cs
@@ -42,8 +42,9 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
     private static readonly ConfigurationDefinition<bool> StringInterpolationTreatOpaqueRuntimeTypesAsCultureSensitiveConfiguration = new(RuleIdentifiers.DoNotUseImplicitCultureSensitiveToStringInterpolation + ".treat_opaque_runtime_types_as_culture_sensitive", defaultValue: false);
     private static readonly ConfigurationDefinition<bool> StringConcatTreatUnsealedTypesAsCultureSensitiveConfiguration = new(RuleIdentifiers.DoNotUseImplicitCultureSensitiveToString + ".treat_unsealed_types_as_culture_sensitive", defaultValue: false);
     private static readonly ConfigurationDefinition<bool> StringInterpolationTreatUnsealedTypesAsCultureSensitiveConfiguration = new(RuleIdentifiers.DoNotUseImplicitCultureSensitiveToStringInterpolation + ".treat_unsealed_types_as_culture_sensitive", defaultValue: false);
-    private static readonly ConfigurationDefinition<bool> ExcludeToStringMethodsConfiguration = new(RuleIdentifiers.DoNotUseImplicitCultureSensitiveToString + ".exclude_tostring_methods", defaultValue: true);
-    private static readonly ConfigurationDefinition<bool> ExcludeToStringMethodsInterpolationConfiguration = new(RuleIdentifiers.DoNotUseImplicitCultureSensitiveToStringInterpolation + ".exclude_tostring_methods", defaultValue: true);
+    private static readonly ConfigurationDefinition<bool> StringConcatExcludeToStringMethodsConfiguration = new(RuleIdentifiers.DoNotUseImplicitCultureSensitiveToString + ".exclude_tostring_methods", defaultValue: true);
+    private static readonly ConfigurationDefinition<bool> StringInterpolationExcludeToStringMethodsConfiguration = new(RuleIdentifiers.DoNotUseImplicitCultureSensitiveToStringInterpolation + ".exclude_tostring_methods", defaultValue: true);
+    private static readonly ConfigurationDefinition<bool> ObjectToStringExcludeToStringMethodsConfiguration = new(RuleIdentifiers.DoNotUseCultureSensitiveObjectToString + ".exclude_tostring_methods", defaultValue: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(StringConcatRule, StringInterpolationRule, ObjectToStringRule);
 
@@ -70,7 +71,7 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
         public static void AnalyzeInvocation(OperationAnalysisContext context)
         {
             var operation = (IInvocationOperation)context.Operation;
-            if (IsExcludedMethod(context, ExcludeToStringMethodsConfiguration, operation))
+            if (IsExcludedMethod(context, ObjectToStringExcludeToStringMethodsConfiguration, operation))
                 return;
 
             if (operation.TargetMethod.Name == "ToString" && operation.TargetMethod.ContainingType.IsObject() && operation.TargetMethod.Parameters.Length == 0)
@@ -94,7 +95,7 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
             if (operation.ConstantValue.HasValue)
                 return;
 
-            if (IsExcludedMethod(context, ExcludeToStringMethodsConfiguration, operation))
+            if (IsExcludedMethod(context, StringConcatExcludeToStringMethodsConfiguration, operation))
                 return;
 
             if (_cultureSensitiveContext.IsInCultureInsensitiveParameterContext(operation))
@@ -119,7 +120,11 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
             if (operation.ConstantValue.HasValue)
                 return;
 
-            if (IsExcludedMethod(context, ExcludeToStringMethodsInterpolationConfiguration, operation))
+            // MA0076 and MA0107 are excluded independently, as they have their own configuration key
+            var isInToStringMethod = IsInToStringMethod(context, operation);
+            var reportStringInterpolation = !isInToStringMethod || !context.Options.GetConfigurationValue(operation.Syntax.SyntaxTree, StringInterpolationExcludeToStringMethodsConfiguration);
+            var reportObjectToString = !isInToStringMethod || !context.Options.GetConfigurationValue(operation.Syntax.SyntaxTree, ObjectToStringExcludeToStringMethodsConfiguration);
+            if (!reportStringInterpolation && !reportObjectToString)
                 return;
 
             if (_cultureSensitiveContext.IsInInterpolatedStringHandlerContext(operation))
@@ -145,12 +150,12 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
                 if (expression is null || type is null)
                     continue;
 
-                if (CultureSensitiveFormattingContext.IsCultureSensitive(_cultureSensitiveContext.GetCultureSensitivity(part, options | CultureSensitiveOptions.UseInvocationReturnType), options))
+                if (reportStringInterpolation && CultureSensitiveFormattingContext.IsCultureSensitive(_cultureSensitiveContext.GetCultureSensitivity(part, options | CultureSensitiveOptions.UseInvocationReturnType), options))
                 {
                     context.ReportDiagnostic(StringInterpolationRule, part);
                 }
 
-                if (CultureSensitiveFormattingContext.UsesObjectToString(type, context.CancellationToken))
+                if (reportObjectToString && CultureSensitiveFormattingContext.UsesObjectToString(type, context.CancellationToken))
                 {
                     context.ReportDiagnostic(ObjectToStringRule, expression);
                 }
@@ -160,12 +165,17 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzer : Diagnosti
         private static bool IsExcludedMethod(OperationAnalysisContext context, ConfigurationDefinition<bool> configuration, IOperation operation)
         {
             // ToString show culture-sensitive data by default
-            if (operation?.GetContainingMethod(context.CancellationToken)?.Name == "ToString")
+            if (IsInToStringMethod(context, operation))
             {
                 return context.Options.GetConfigurationValue(operation.Syntax.SyntaxTree, configuration);
             }
 
             return false;
+        }
+
+        private static bool IsInToStringMethod(OperationAnalysisContext context, IOperation operation)
+        {
+            return operation?.GetContainingMethod(context.CancellationToken)?.Name == "ToString";
         }
 
         private bool ShouldReportCultureSensitiveOperand(OperationAnalysisContext context, DiagnosticDescriptor rule, IOperation operand)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseImplicitCultureSensitiveToStringAnalyzerTests.cs
@@ -436,6 +436,112 @@ public sealed class DoNotUseImplicitCultureSensitiveToStringAnalyzerTests
     }
 
     [Fact]
+    public Task ObjectToString_InToStringMethod()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                public override string ToString() => new object().ToString();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ObjectToString_InToStringMethod_ConfigNotExcludeToString()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("MA0107.exclude_tostring_methods", "false");
+        test.TestCode = """
+            class Test
+            {
+                public override string ToString() => {|MA0107:new object().ToString()|};
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ObjectToString_InToStringMethod_MA0075ConfigDoesNotApply()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("MA0075.exclude_tostring_methods", "false");
+        test.TestCode = """
+            class Test
+            {
+                public override string ToString() => new object().ToString();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ObjectToString_InterpolatedString_InToStringMethod()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            sealed class Sample {}
+
+            class Test
+            {
+                public override string ToString()
+                {
+                    var sample = new Sample();
+                    return $"Value: {sample}";
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ObjectToString_InterpolatedString_InToStringMethod_ConfigNotExcludeToString()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("MA0107.exclude_tostring_methods", "false");
+        test.TestCode = """
+            sealed class Sample {}
+
+            class Test
+            {
+                public override string ToString()
+                {
+                    var sample = new Sample();
+                    return $"Value: {{|MA0107:sample|}}";
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ObjectToString_InterpolatedString_InToStringMethod_MA0076ConfigDoesNotApply()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("MA0076.exclude_tostring_methods", "false");
+        test.TestCode = """
+            sealed class Sample {}
+
+            class Test
+            {
+                public override string ToString()
+                {
+                    var sample = new Sample();
+                    return $"Value: {sample}";
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task ObjectToString_InterpolatedStringHandler_NoDiagnostic()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

`docs/Rules/MA0107.md` documents `MA0107.exclude_tostring_methods`, but nothing read that key. The `ConfigurationDefinition` backing it was declared with `RuleIdentifiers.DoNotUseImplicitCultureSensitiveToString`, which is **MA0075**:

```csharp
private static readonly ConfigurationDefinition<bool> ExcludeToStringMethodsConfiguration =
    new(RuleIdentifiers.DoNotUseImplicitCultureSensitiveToString + ".exclude_tostring_methods", defaultValue: true);
```

A consumer setting `MA0107.exclude_tostring_methods` got no effect and no way to discover why. To affect MA0107 they had to set MA0075's key, which simultaneously changed MA0075's behaviour. The generated tables agreed with the code and disagreed with the doc: `docs/README.md` marked MA0107 as not configurable while its rule page had a `## Configuration` section.

## Changes

**Analyzer** — added `ObjectToStringExcludeToStringMethodsConfiguration`, keyed on `DoNotUseCultureSensitiveObjectToString`, used at both places that report MA0107:

- `AnalyzeInvocation` reports MA0107 only, so it just switches keys.
- `AnalyzeInterpolatedString` reports both MA0076 and MA0107, and its exclusion check returned from the whole method on MA0076's key. It now computes the two exclusions independently, returns early only when both apply, and guards each report site. The other early returns (interpolated-string handler, culture-insensitive parameter context, `FormattableString`) are unchanged.

The two existing fields are renamed to `StringConcat*` / `StringInterpolation*`, the convention the neighbouring fields already use, so each field states which rule it belongs to. That naming gap is what made the mix-up invisible.

**Reverse validation** — `ValidateRuleDocumentationContainsConfigurationKeys` only checked code key → doc, never doc → code key, so CI stayed green. `ValidateRuleDocumentationConfigurationKeysExist` now scans each rule page for `MAxxxx.<key>` tokens and errors on any that no `ConfigurationDefinition` declares. `GetRuleConfigurationKeys` consumes the extracted `GetConfigurationDefinitions` so the new check also sees hidden keys. The `md`, `cs` and `severity` suffixes are skipped — page/source links and editorconfig severities, not options.

**Second instance found by that check** — `docs/Rules/MA0060.md` documented `dotnet_diagnostic.MA0060.enable_tryparse_pattern`, but key lookup is exact (`AnalyzerConfigOptions.TryGetValue`) and the declared key has no prefix, so that documented line did nothing either. The forward check passed it because the wrong key contains the right one as a substring. Fixed. (MA0048's `dotnet_diagnostic.MA0048.excluded_symbol_names` is genuine — that key literally includes the prefix.)

## Compatibility

Both defaults stay `true`, so default behaviour is unchanged. Only a consumer explicitly setting MA0075's or MA0076's key sees MA0107 decoupled from them — which is the point of the fix.

## Notes for reviewers

- I verified the new validation catches the reported bug: pointing MA0107's field back at MA0075 makes `check_documentation` fail with `Configuration key 'MA0107.exclude_tostring_methods' in docs/Rules/MA0107.md is not declared by any ConfigurationDefinition`.
- `README.md` and `docs/README.md` are regenerated output — MA0107 now shows as configurable with its key.

## Verification

- `dotnet build` — clean, 0 warnings.
- `dotnet run --project src/DocumentationGenerator` — regenerated the two READMEs, then re-ran to exit 0 with no further changes.
- 6 new tests covering both report sites: default exclusion, `MA0107.exclude_tostring_methods=false`, and that MA0075's / MA0076's keys no longer affect MA0107. Confirmed they ran via a filtered run (`total: 6`).
- Analyzer tests on all five Roslyn versions: 197 passed on 4.8/4.14/5.0/5.6, 207 on 5.9 (the extra 10 are version-gated).
- Full default-version suite: 3915 passed, 0 failed.