### PR TITLE
Report MA0060 on ignored return values behind a conditional access

### DIFF
--- a/docs/Rules/MA0060.md
+++ b/docs/Rules/MA0060.md
@@ -100,6 +100,7 @@ class Test
         var bytes = new byte[10];
 
         stream.Read(bytes, 0, bytes.Length);   // Non-compliant: return value ignored
+        stream?.Read(bytes, 0, bytes.Length);  // Non-compliant: return value ignored
 
         var read = stream.Read(bytes, 0, bytes.Length); // Compliant
         var data = bytes.AsSpan(0, read);

--- a/src/Meziantou.Analyzer/Rules/DoNotIgnoreReturnValueAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotIgnoreReturnValueAnalyzer.cs
@@ -134,7 +134,15 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
 
         private static bool IsReturnValueIgnored(IInvocationOperation invocation)
         {
-            var parent = invocation.Parent;
+            // Walk up the conditional accesses the invocation is the right-hand side of ('a?.M()'),
+            // as the value of the whole conditional access is the value of the invocation
+            IOperation operation = invocation;
+            while (operation.Parent is IConditionalAccessOperation conditionalAccess && conditionalAccess.WhenNotNull == operation)
+            {
+                operation = conditionalAccess;
+            }
+
+            var parent = operation.Parent;
             if (parent is IAwaitOperation)
             {
                 parent = parent.Parent;

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotIgnoreReturnValueAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotIgnoreReturnValueAnalyzerTests.cs
@@ -91,6 +91,97 @@ public sealed class DoNotIgnoreReturnValueAnalyzerTests
     }
 
     [Fact]
+    public Task Stream_Read_ConditionalAccess_ReturnValueNotUsed()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.IO;
+            class Test
+            {
+                void A(Stream stream)
+                {
+                    stream?{|MA0060:.Read(null, 0, 0)|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Stream_Read_NestedConditionalAccess_ReturnValueNotUsed()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.IO;
+            class Test
+            {
+                void A(Test test)
+                {
+                    test?.GetStream()?{|MA0060:.Read(null, 0, 0)|};
+                }
+
+                Stream GetStream() => null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Stream_ReadAsync_ConditionalAccess_ReturnValueNotUsed()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.IO;
+            class Test
+            {
+                async void A(Stream stream)
+                {
+                    await stream?{|MA0060:.ReadAsync(null, 0, 0)|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Stream_Read_ConditionalAccess_ReturnValueUsed_DiscardOperator()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.IO;
+            class Test
+            {
+                void A(Stream stream)
+                {
+                    _ = stream?.Read(null, 0, 0);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task String_Trim_IsReceiverOfConditionalAccess_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                void A(string value)
+                {
+                    value.Trim()?.ToString();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Stream_ReadByte_ReturnValueNotUsed_NoDiagnostic()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

MA0060 missed ignored return values reached through a null-conditional access:

```csharp
void M(Stream stream, byte[] buffer)
{
    stream.Read(buffer, 0, buffer.Length);    // reported
    stream?.Read(buffer, 0, buffer.Length);   // NOT reported (before this change)
}
```

## Why

`IsReturnValueIgnored` tested `invocation.Parent` against `null or IBlockOperation or IExpressionStatementOperation`. For `stream?.Read(...)` the invocation's parent is an `IConditionalAccessOperation`, so the value was treated as used. `?.` on a stream or a collection call is common defensive code, and a discarded `Read` return value is exactly the bug the rule exists to catch.

## How

`IsReturnValueIgnored` now walks up the conditional accesses the invocation is the `WhenNotNull` of, before testing the parent kind — the same hop the method already did for `IAwaitOperation`:

```csharp
IOperation operation = invocation;
while (operation.Parent is IConditionalAccessOperation conditionalAccess && conditionalAccess.WhenNotNull == operation)
{
    operation = conditionalAccess;
}
```

The `WhenNotNull == operation` guard is what keeps this from introducing a false positive in the mirror case. When the invocation is the *receiver* of the `?.` (`value.Trim()?.ToString()`), its parent is also an `IConditionalAccessOperation`, but there the return value genuinely is used — by the null test and by the member access — so it must not be reported. The loop also covers chains such as `test?.GetStream()?.Read(...)`, where the invocation sits under two nested conditional accesses.

## Tests

5 tests added to `DoNotIgnoreReturnValueAnalyzerTests`:

- `stream?.Read(...)` → reported
- `test?.GetStream()?.Read(...)` (nested conditional accesses) → reported
- `await stream?.ReadAsync(...)` → reported
- `_ = stream?.Read(...)` → not reported
- `value.Trim()?.ToString()` (invocation is the receiver) → not reported

The last two are regression guards for the `WhenNotNull` condition.

## Verification

- Reverting the analyzer change and re-running makes exactly the 3 positive tests fail (52/55), confirming they exercise the fix.
- MA0060 tests pass on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9), 55/55 each.
- Full suite on the default version: 3914/3914 passed. `dotnet build` clean, 0 warnings.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no generated markdown changes.

## Docs

Added the `stream?.Read(...)` line to the example in `docs/Rules/MA0060.md`, which previously only showed the plain-call form.