### PR TITLE
Cache the culture sensitivity of the types

### DIFF
--- a/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
+++ b/src/Meziantou.Analyzer/Internals/CultureSensitiveFormattingContext.cs
@@ -1,9 +1,14 @@
+using System.Collections.Concurrent;
+
 namespace Meziantou.Analyzer.Internals;
 
 internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
 {
     private readonly HashSet<ISymbol> _excludedMethods = CreateExcludedMethods(compilation);
     private readonly HashSet<ISymbol> _cultureInsensitiveMembers = CreateCultureInsensitiveMembers(compilation);
+
+    // The culture sensitivity of a type only depends on the type and the options, both of which are stable for a compilation
+    private readonly ConcurrentDictionary<CultureSensitivityCacheKey, CultureSensitivity> _cultureSensitivityCache = new();
 
     public INamedTypeSymbol? FormatProviderSymbol { get; } = compilation.GetBestTypeByMetadataName("System.IFormatProvider");
     public INamedTypeSymbol? CultureInfoSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Globalization.CultureInfo");
@@ -524,6 +529,17 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
         if (typeSymbol is null)
             return CultureSensitivity.MaybeCultureSensitiveOpaqueRuntimeType;
 
+        var key = new CultureSensitivityCacheKey(typeSymbol, options);
+        if (_cultureSensitivityCache.TryGetValue(key, out var cachedCultureSensitivity))
+            return cachedCultureSensitivity;
+
+        var cultureSensitivity = GetCultureSensitivityCore(typeSymbol, options);
+        _cultureSensitivityCache[key] = cultureSensitivity;
+        return cultureSensitivity;
+    }
+
+    private CultureSensitivity GetCultureSensitivityCore(ITypeSymbol typeSymbol, CultureSensitiveOptions options)
+    {
         if (MustUnwrapNullableOfT(options))
         {
             typeSymbol = typeSymbol.GetUnderlyingNullableTypeOrSelf();
@@ -633,7 +649,18 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
         }
 
         bool HasToStringWithFormatProvider(ITypeSymbol type)
-            => type.GetAllMembers().OfType<IMethodSymbol>().Any(m => m is { Name: "ToString", IsStatic: false, ReturnType: { SpecialType: SpecialType.System_String }, Parameters: [var param1] } && param1.Type.IsOrInheritsFrom(FormatProviderSymbol) && m.DeclaredAccessibility is Accessibility.Public);
+        {
+            for (ITypeSymbol? currentType = type; currentType is not null; currentType = currentType.BaseType)
+            {
+                foreach (var member in currentType.GetMembers(nameof(ToString)))
+                {
+                    if (member is IMethodSymbol { IsStatic: false, DeclaredAccessibility: Accessibility.Public, ReturnType.SpecialType: SpecialType.System_String, Parameters: [var param1] } && param1.Type.IsOrInheritsFrom(FormatProviderSymbol))
+                        return true;
+                }
+            }
+
+            return false;
+        }
     }
 
     private CultureSensitivity GetCultureSensitivity(ITypeParameterSymbol typeParameter, CultureSensitiveOptions options)
@@ -951,5 +978,17 @@ internal sealed class CultureSensitiveFormattingContext(Compilation compilation)
             return true;
 
         return false;
+    }
+
+    private readonly struct CultureSensitivityCacheKey(ITypeSymbol typeSymbol, CultureSensitiveOptions options) : IEquatable<CultureSensitivityCacheKey>
+    {
+        public ITypeSymbol TypeSymbol { get; } = typeSymbol;
+        public CultureSensitiveOptions Options { get; } = options;
+
+        public bool Equals(CultureSensitivityCacheKey other) => Options == other.Options && SymbolEqualityComparer.Default.Equals(TypeSymbol, other.TypeSymbol);
+
+        public override bool Equals(object? obj) => obj is CultureSensitivityCacheKey other && Equals(other);
+
+        public override int GetHashCode() => (SymbolEqualityComparer.Default.GetHashCode(TypeSymbol) * 397) ^ (int)Options;
     }
 }


### PR DESCRIPTION
## What

`CultureSensitiveFormattingContext.GetCultureSensitivity(ITypeSymbol, CultureSensitiveOptions)` is a pure function of the type symbol and the options, but nothing was cached: it was fully recomputed for every node.

Each call runs about twenty symbol comparisons plus several `IsOrInheritsFrom` / `IsOrImplements` hierarchy walks, and reaches `HasToStringWithFormatProvider`, which was `type.GetAllMembers().OfType<IMethodSymbol>().Any(...)` — a `yield return` iterator enumerating every member of every type in the base chain, wrapped in two more LINQ iterators, with a per-member `IsOrInheritsFrom` on the parameter type.

Four analyzers enabled by default drive this (`UseIFormatProviderAnalyzer`, `DoNotUseImplicitCultureSensitiveToStringAnalyzer`, `DoNotUseToStringIfObjectAnalyzer`, `SimplifyStringCreateWhenAllParametersAreCultureInvariantAnalyzer`), so it ran on every invocation, interpolated string and binary operation of a compilation, and it is worst on codebases with deep type hierarchies where the member walk is longest.

Two changes:

- **Memoize the result** in a `ConcurrentDictionary` keyed by the type symbol and the options, the same way `AwaitableTypes` caches `IsAwaitable`. The body was split into a cached front door plus `GetCultureSensitivityCore`.
- **Replace the LINQ chain** in `HasToStringWithFormatProvider` with a plain loop over `GetMembers(nameof(ToString))` up the base chain.

## Notes for the reviewer

- **Purity.** The only input besides `(typeSymbol, options)` is `compilation`, which is fixed for the lifetime of a context instance, so the answer is stable for a compilation. `IsCultureSensitiveTypeUsingAttribute` reads `compilation.Assembly.GetAttributes()` and is pure for the same reason.
- **The cache key uses the full options flags**, not only the `UnwrapNullableOfT` flag the method reads today. The flags are bounded to sixteen combinations, so the extra entries cost nothing, and the cache stays correct if another flag starts to matter. `UnwrapNullableOfT` genuinely has to be part of the key: with it, `int?` returns the sensitivity of `int`, without it the one of `Nullable<int>`.
- **`TryGetValue` + indexer rather than `GetOrAdd(key, factory)`**, to avoid a delegate allocation on every lookup — the `GetOrAdd<TArg>` overload that would avoid a closure is not available on `netstandard2.0`. The computation is idempotent, so a race just recomputes.
- **The `HasToStringWithFormatProvider` rewrite is equivalent, not a behavior change.** The `GetAllMembers()` overload without a name walks the base chain only, so the loop matches it. The `GetAllMembers(name)` overload would *not* have been equivalent: it additionally walks `AllInterfaces` for interface symbols, which would have made an interface inheriting a `ToString(IFormatProvider)` report `CultureSensitive` instead of `MaybeCultureSensitiveOpaqueRuntimeType`, since `IsFormattableType` is checked before `IsOpaqueRuntimeType`.
- Sharing a single context across the four analyzers was considered and left out: it would need a compilation-keyed static cache with its own lifetime concerns, for about 116 `GetBestTypeByMetadataName` calls per compilation — negligible next to the per-node work this removes.

## Testing

- All five Roslyn versions build (4.8, 4.14, 5.0, 5.6, 5.9), 0 warnings and 0 errors.
- `dotnet test --max-parallel-test-modules 2` over the five test projects: **19258 passed, 0 failed**.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown change: the change is internal and does not affect any rule behavior or documentation.