### PR TITLE
Discover the regex-valued options validated by MA0220

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ When you change any file under `src/Meziantou.Analyzer.Annotations`, you MUST:
 - The analyzers must be under `src/Meziantou.Analyzer/Rules/`
 - The code fixers must be under `src/Meziantou.Analyzer.CodeFixers/Rules`
 - The tests must be under `tests/Meziantou.Analyzer.Test/Rules`
+- When the value of a configuration option is a regular expression, set the `RegexOptions` of its `ConfigurationDefinition<string>` and use them to create the `Regex`. `InvalidRegexConfigurationAnalyzer` (MA0220) discovers these options from the assembly and reports the invalid patterns, so the option is validated with the options it is used with. Also add the option to [`docs/Rules/MA0220.md`](/docs/Rules/MA0220.md).
 
 The analyzer must use `IOperation` or `ISymbol` to analyze the content. Only fallback to `SyntaxNode` when the other ways are not supported.
 

--- a/docs/Rules/MA0048.md
+++ b/docs/Rules/MA0048.md
@@ -167,7 +167,7 @@ MA0048.excluded_file_name_parts = razor,.
 # Same as MA0048.excluded_file_name_parts, but every match of the pattern is removed. default: none
 # A single case-insensitive regular expression, not a list: use "|" to remove multiple parts.
 # It is applied before MA0048.excluded_file_name_parts, so it can match the dots of the file name.
-# An invalid pattern removes nothing.
+# An invalid pattern removes nothing and is reported by MA0220.
 MA0048.excluded_file_name_parts_regex = \.(razor\.)?
 
 # Ignore certain symbols. default: none

--- a/docs/Rules/MA0220.md
+++ b/docs/Rules/MA0220.md
@@ -13,4 +13,5 @@ MA0104.namespaces_regex = [
 The following options are validated by this rule:
 
 - [`MA0003.excluded_methods_regex`](MA0003.md)
+- [`MA0048.excluded_file_name_parts_regex`](MA0048.md)
 - [`MA0104.namespaces_regex`](MA0104.md)

--- a/src/Meziantou.Analyzer/Configurations/ConfigurationDefinition.cs
+++ b/src/Meziantou.Analyzer/Configurations/ConfigurationDefinition.cs
@@ -1,7 +1,11 @@
+using System.Text.RegularExpressions;
+
 namespace Meziantou.Analyzer.Configurations;
 
 public sealed class ConfigurationDefinition<T>
 {
+    private RegexOptions? _regexOptions;
+
     public ConfigurationDefinition(string key)
     {
         Key = key;
@@ -19,4 +23,21 @@ public sealed class ConfigurationDefinition<T>
     public bool HasDefaultValue { get; }
     public T DefaultValue { get; } = default!;
     public bool IsHidden { get; set; }
+
+    /// <summary>
+    /// Indicates the value of the option is a regular expression. It is set by assigning <see cref="RegexOptions"/>,
+    /// even when the assigned value is <see cref="System.Text.RegularExpressions.RegexOptions.None"/>. MA0220 reports
+    /// the configured values of these options when they are not valid regular expressions.
+    /// </summary>
+    public bool IsRegex => _regexOptions is not null;
+
+    /// <summary>
+    /// The options used to create the <see cref="Regex"/> from the value of the option. Setting it marks the option
+    /// as a regular expression (<see cref="IsRegex"/>), so it must be set by the rules that use the value as a pattern.
+    /// </summary>
+    public RegexOptions RegexOptions
+    {
+        get => _regexOptions.GetValueOrDefault();
+        set => _regexOptions = value;
+    }
 }

--- a/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
@@ -18,8 +18,8 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
 
     private static readonly ConfigurationDefinition<bool> OnlyConsiderPublicSymbolsConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".only_consider_public_symbols", defaultValue: true);
     private static readonly ConfigurationDefinition<bool> UsePreviewTypesConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".use_preview_types", defaultValue: false);
-    internal static readonly ConfigurationDefinition<string> NamespacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namespaces_regex", defaultValue: "^System($|\\.)");
-    internal static readonly ConfigurationDefinition<string> LegacyNamepacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namepaces_regex", defaultValue: "^System($|\\.)") { IsHidden = true };
+    internal static readonly ConfigurationDefinition<string> NamespacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namespaces_regex", defaultValue: "^System($|\\.)") { RegexOptions = RegexOptions.None };
+    internal static readonly ConfigurationDefinition<string> LegacyNamepacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namepaces_regex", defaultValue: "^System($|\\.)") { IsHidden = true, RegexOptions = RegexOptions.None };
 
     private static Dictionary<string, List<string>>? s_types;
     private static Dictionary<string, List<string>>? s_typesPreview;
@@ -76,11 +76,11 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
             pattern = configuredPattern;
         }
 
-        if (RegexCache.TryGetOrCreate(pattern, RegexOptions.None, out var regex))
+        if (RegexCache.TryGetOrCreate(pattern, NamespacesRegexConfiguration.RegexOptions, out var regex))
             return regex;
 
         // The configured pattern is invalid, so fallback to the default pattern instead of failing the analysis
-        RegexCache.TryGetOrCreate(NamespacesRegexConfiguration.DefaultValue, RegexOptions.None, out regex);
+        RegexCache.TryGetOrCreate(NamespacesRegexConfiguration.DefaultValue, NamespacesRegexConfiguration.RegexOptions, out regex);
         return regex;
     }
 

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -33,7 +33,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
     private static readonly ConfigurationDefinition<bool> AllowTypeNamePrefixConfiguration = new(Rule.Id + ".allow_type_name_prefix", defaultValue: false);
     private static readonly ConfigurationDefinition<bool> UseLongestTypeNamePrefixConfiguration = new(Rule.Id + ".use_longest_type_name_prefix", defaultValue: false);
     private static readonly ConfigurationDefinition<string> ExcludedFileNamePartsConfiguration = new(Rule.Id + ".excluded_file_name_parts", defaultValue: string.Empty);
-    private static readonly ConfigurationDefinition<string> ExcludedFileNamePartsRegexConfiguration = new(Rule.Id + ".excluded_file_name_parts_regex", defaultValue: string.Empty);
+    private static readonly ConfigurationDefinition<string> ExcludedFileNamePartsRegexConfiguration = new(Rule.Id + ".excluded_file_name_parts_regex", defaultValue: string.Empty) { RegexOptions = RegexOptions.CultureInvariant | RegexOptions.IgnoreCase };
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -200,7 +200,7 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
         // The regex is applied first, so it can match the dots that MA0048.excluded_file_name_parts may remove
         if (!string.IsNullOrEmpty(excludedPartsRegex))
         {
-            fileName = RegexCache.Replace(excludedPartsRegex, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, fileName, replacement: "", defaultValue: fileName);
+            fileName = RegexCache.Replace(excludedPartsRegex, ExcludedFileNamePartsRegexConfiguration.RegexOptions, fileName, replacement: "", defaultValue: fileName);
         }
 
         foreach (var part in excludedParts.Split([',', '|'], StringSplitOptions.RemoveEmptyEntries))

--- a/src/Meziantou.Analyzer/Rules/InvalidRegexConfigurationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InvalidRegexConfigurationAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Meziantou.Analyzer.Configurations;
 
@@ -16,18 +17,35 @@ public sealed class InvalidRegexConfigurationAnalyzer : DiagnosticAnalyzer
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InvalidRegexConfiguration));
 
-    /// <summary>
-    /// The options whose value must be a valid regular expression. The rules ignore an invalid value,
-    /// so this rule is the only way for the user to know the option is not applied.
-    /// </summary>
-    private static readonly ConfigurationDefinition<string>[] RegexConfigurations =
-    [
-        NamedParameterAnalyzer.ExcludedMethodsRegexConfiguration,
-        DotNotUseNameFromBCLAnalyzer.NamespacesRegexConfiguration,
-        DotNotUseNameFromBCLAnalyzer.LegacyNamepacesRegexConfiguration,
-    ];
+    private static readonly ConfigurationDefinition<string>[] RegexConfigurations = GetRegexConfigurations();
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <summary>
+    /// Gets the options whose value must be a valid regular expression. The rules ignore an invalid value, so this rule
+    /// is the only way for the user to know the option is not applied. The options are discovered from the assembly, so
+    /// a new option is validated as soon as its <see cref="ConfigurationDefinition{T}.RegexOptions"/> are set.
+    /// </summary>
+    internal static ConfigurationDefinition<string>[] GetRegexConfigurations()
+    {
+        var configurations = new List<ConfigurationDefinition<string>>();
+        foreach (var type in typeof(InvalidRegexConfigurationAnalyzer).Assembly.GetTypes())
+        {
+            foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (field.FieldType != typeof(ConfigurationDefinition<string>))
+                    continue;
+
+                if (field.GetValue(null) is ConfigurationDefinition<string> { IsRegex: true } configuration)
+                {
+                    configurations.Add(configuration);
+                }
+            }
+        }
+
+        // The order of the fields is not deterministic, so sort the configurations to report the diagnostics in a stable order
+        return [.. configurations.OrderBy(configuration => configuration.Key, StringComparer.Ordinal)];
+    }
 
     public override void Initialize(AnalysisContext context)
     {
@@ -40,7 +58,7 @@ public sealed class InvalidRegexConfigurationAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeCompilation(CompilationAnalysisContext context)
     {
         // The options can be different for each syntax tree, but a value must be reported only once
-        HashSet<(string Key, string Value)>? reportedValues = null;
+        HashSet<(string Key, string Value, RegexOptions Options)>? reportedValues = null;
 
         foreach (var syntaxTree in context.Compilation.SyntaxTrees)
         {
@@ -53,10 +71,10 @@ public sealed class InvalidRegexConfigurationAnalyzer : DiagnosticAnalyzer
                     continue;
 
                 reportedValues ??= [];
-                if (!reportedValues.Add((configuration.Key, value)))
+                if (!reportedValues.Add((configuration.Key, value, configuration.RegexOptions)))
                     continue;
 
-                if (!RegexCache.IsValidPattern(value, RegexOptions.None, out var errorMessage))
+                if (!RegexCache.IsValidPattern(value, configuration.RegexOptions, out var errorMessage))
                 {
                     context.ReportDiagnostic(Rule, Location.None, configuration.Key, errorMessage);
                 }

--- a/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
@@ -22,7 +22,7 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseNamedParameter));
 
-    internal static readonly ConfigurationDefinition<string> ExcludedMethodsRegexConfiguration = new(RuleIdentifiers.UseNamedParameter + ".excluded_methods_regex");
+    internal static readonly ConfigurationDefinition<string> ExcludedMethodsRegexConfiguration = new(RuleIdentifiers.UseNamedParameter + ".excluded_methods_regex") { RegexOptions = RegexOptions.None };
     private static readonly ConfigurationDefinition<string> ExcludedMethodsConfiguration = new(RuleIdentifiers.UseNamedParameter + ".excluded_methods");
     private static readonly ConfigurationDefinition<string> MinimumMethodParametersConfiguration = new(RuleIdentifiers.UseNamedParameter + ".minimum_method_parameters", defaultValue: string.Empty);
     private static readonly ConfigurationDefinition<string> ExpressionKindsConfiguration = new(RuleIdentifiers.UseNamedParameter + ".expression_kinds", defaultValue: string.Empty);
@@ -265,7 +265,7 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
                         if (syntaxContext.Options.TryGetConfigurationValue(expression.SyntaxTree, ExcludedMethodsRegexConfiguration, out var excludedMethodsRegex))
                         {
                             var declarationId = DocumentationCommentId.CreateDeclarationId(invokedMethodSymbol);
-                            if (declarationId is not null && RegexCache.IsMatch(excludedMethodsRegex, RegexOptions.None, declarationId, defaultValue: false))
+                            if (declarationId is not null && RegexCache.IsMatch(excludedMethodsRegex, ExcludedMethodsRegexConfiguration.RegexOptions, declarationId, defaultValue: false))
                                 return;
                         }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/InvalidRegexConfigurationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InvalidRegexConfigurationAnalyzerTests.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using Meziantou.Analyzer.Configurations;
+using Meziantou.Analyzer.Rules;
 using Microsoft.CodeAnalysis;
 using DiagnosticResult = Microsoft.CodeAnalysis.Testing.DiagnosticResult;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
@@ -28,6 +31,7 @@ public sealed class InvalidRegexConfigurationAnalyzerTests
     [InlineData("MA0003.excluded_methods_regex")]
     [InlineData("MA0104.namespaces_regex")]
     [InlineData("MA0104.namepaces_regex")]
+    [InlineData("MA0048.excluded_file_name_parts_regex")]
     public Task ValidRegex_DoNotReportDiagnostic(string key)
     {
         var test = CreateTest();
@@ -41,6 +45,7 @@ public sealed class InvalidRegexConfigurationAnalyzerTests
     [InlineData("MA0003.excluded_methods_regex")]
     [InlineData("MA0104.namespaces_regex")]
     [InlineData("MA0104.namepaces_regex")]
+    [InlineData("MA0048.excluded_file_name_parts_regex")]
     public Task InvalidRegex_ReportDiagnostic(string key)
     {
         var test = CreateTest();
@@ -73,5 +78,36 @@ public sealed class InvalidRegexConfigurationAnalyzerTests
         test.ExpectedDiagnostics.Add(ExpectedInvalidRegex());
 
         return test.RunAsync();
+    }
+
+    /// <summary>
+    /// The rule validates the options discovered from the assembly, so an option whose value is a regular expression
+    /// must set its <see cref="ConfigurationDefinition{T}.RegexOptions"/> to be validated by this rule.
+    /// </summary>
+    [Fact]
+    public void AllOptionsEndingWithRegexAreValidatedByTheRule()
+    {
+        var validatedKeys = InvalidRegexConfigurationAnalyzer.GetRegexConfigurations().Select(configuration => configuration.Key).ToArray();
+
+        var missingKeys = new List<string>();
+        foreach (var type in typeof(InvalidRegexConfigurationAnalyzer).Assembly.GetTypes())
+        {
+            foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (field.FieldType != typeof(ConfigurationDefinition<string>))
+                    continue;
+
+                if (field.GetValue(null) is ConfigurationDefinition<string> { IsRegex: false } configuration && configuration.Key.EndsWith("_regex", StringComparison.Ordinal))
+                {
+                    missingKeys.Add(configuration.Key);
+                }
+            }
+        }
+
+        Assert.Empty(missingKeys);
+        Assert.Contains("MA0048.excluded_file_name_parts_regex", validatedKeys, StringComparer.Ordinal);
+        Assert.Contains("MA0003.excluded_methods_regex", validatedKeys, StringComparer.Ordinal);
+        Assert.Contains("MA0104.namespaces_regex", validatedKeys, StringComparer.Ordinal);
+        Assert.Contains("MA0104.namepaces_regex", validatedKeys, StringComparer.Ordinal);
     }
 }


### PR DESCRIPTION
## What

MA0220 (*The configured regular expression is not valid*) kept the options whose value must be a valid regular expression in a hand-maintained array. `ConfigurationDefinition<T>` now carries the `RegexOptions` used to create the `Regex` from the value of the option, and MA0220 discovers those options from the assembly instead of listing them.

## Why

The array was missing `MA0048.excluded_file_name_parts_regex`, added in 6e449a65. An invalid pattern there made `RegexCache.Replace` return the unmodified file name, so MA0048 silently behaved as if the option was not set — with no MA0220 to tell the user. That is exactly the failure mode MA0220 exists to prevent, reproduced on the next regex-valued option added.

The array also validated every pattern with `RegexOptions.None`, while MA0048 compiles its pattern with `CultureInvariant | IgnoreCase`. Since `RegexCache` keys on (pattern, options), a listed option could be validated under options it is not used with.

## How

- `ConfigurationDefinition<T>` gets `RegexOptions` and a derived `IsRegex`. Assigning `RegexOptions` (even `RegexOptions.None`) is what marks the option, so there is no separate flag that can disagree with it.
- `InvalidRegexConfigurationAnalyzer.GetRegexConfigurations()` reflects over the static `ConfigurationDefinition<string>` fields of the assembly and keeps the ones with `IsRegex`, sorted by key so the diagnostics are reported in a stable order. The pattern is validated with `configuration.RegexOptions`, and the deduplication of the reported values includes the options.
- MA0003, MA0048 and MA0104 declare the options of their pattern and pass `Configuration.RegexOptions` to `RegexCache` instead of repeating the literals. An invalid `MA0048.excluded_file_name_parts_regex` is now reported.
- `docs/Rules/MA0220.md` lists the MA0048 option, `docs/Rules/MA0048.md` mentions that an invalid pattern is reported by MA0220, and `AGENTS.md` records the convention for the next regex-valued option.

## Tests

`MA0048.excluded_file_name_parts_regex` is added to the valid/invalid theories, and a new test asserts that no `ConfigurationDefinition<string>` whose key ends with `_regex` is left out of the rule. I checked the test fails as intended by temporarily removing the `RegexOptions` of the MA0048 option (2 failures), then restored it.

- `dotnet build` (every Roslyn version): succeeded, 0 warning.
- `dotnet test` on roslyn5.9: 3912 passed, 0 failed.
- The 4 affected test classes on roslyn4.8, roslyn4.14, roslyn5.0 and roslyn5.6: 164 to 166 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator`: exit code 0, no markdown file changed.

## Note for the reviewer

The discovery reads the static fields reflectively, which runs the type initializers of the analyzers. Roslyn instantiates every analyzer of the assembly anyway and those initializers only build descriptors and configuration definitions, so this is a one-time assembly scan. A static `ConfigurationDefinition<string>` field on an open generic type would make `GetValue(null)` throw; there is no such field, and both the documentation generator (which scans the same way) and the new test would fail in CI before it could reach a user, so I did not add a guard for it.