### PR TITLE
Apply the syntactic filter of MA0003 before binding the arguments

### DIFF
--- a/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
@@ -56,6 +56,11 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
             var expressionType = context.Compilation.GetBestTypeByMetadataName("System.Linq.Expressions.Expression");
             var operationUtilities = new OperationUtilities(context.Compilation);
 
+            // The attribute can be defined in multiple assemblies, so all the types with that name are considered.
+            // When the compilation doesn't contain the attribute, no parameter can be annotated with it,
+            // so the arguments don't need to be bound to look for it.
+            var hasRequireNamedArgumentAttribute = !context.Compilation.GetTypesByMetadataName("Meziantou.Analyzer.Annotations.RequireNamedArgumentAttribute").IsEmpty;
+
             context.RegisterSyntaxNodeAction(syntaxContext =>
             {
                 var argument = (ArgumentSyntax)syntaxContext.Node;
@@ -65,53 +70,34 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
                 if (argument.Expression is null)
                     return;
 
+                if (argument.Parent.IsKind(SyntaxKind.TupleExpression))
+                    return; // Don't consider tuple
+
+                // Binding the argument is much more expensive than looking at the kind of the expression,
+                // so the syntactic filter runs first and only the remaining candidates are bound.
+                var expression = argument.Expression;
+                var expressionKind = GetExpressionKind(expression);
+                if (expressionKind is ArgumentExpressionKinds.None && !hasRequireNamedArgumentAttribute)
+                    return;
+
                 var argumentOperation = syntaxContext.SemanticModel.GetOperation(argument, syntaxContext.CancellationToken) as IArgumentOperation;
 
                 // Naming an argument that already carries the name of the parameter doesn't improve readability
                 if (argumentOperation is not null && HasSameNameAsParameter(syntaxContext.Options, argumentOperation))
                     return;
 
-                if (IsCallerMustUseNamedArgumentAttribute(argumentOperation))
+                if (hasRequireNamedArgumentAttribute && IsCallerMustUseNamedArgumentAttribute(argumentOperation))
                 {
                     DiagnosticReporter reporter = syntaxContext;
                     reporter.ReportDiagnostic(Diagnostic.Create(Rule, syntaxContext.Node.GetLocation(), effectiveSeverity: DiagnosticSeverity.Warning, additionalLocations: null, properties: null));
                     return;
                 }
 
-                var expression = argument.Expression;
-                if (expression.IsKind(SyntaxKind.NullLiteralExpression))
-                {
-                    if (!MustCheckExpressionKind(syntaxContext, expression, ArgumentExpressionKinds.Null))
-                        return;
-                }
-                else if (expression.IsKind(SyntaxKind.NumericLiteralExpression))
-                {
-                    if (!MustCheckExpressionKind(syntaxContext, expression, ArgumentExpressionKinds.Numeric))
-                        return;
-                }
-                else if (expression.IsKind(SyntaxKind.DefaultLiteralExpression))
-                {
-                    if (!MustCheckExpressionKind(syntaxContext, expression, ArgumentExpressionKinds.Default))
-                        return;
-                }
-                else if (IsBooleanExpression(expression))
-                {
-                    if (!MustCheckExpressionKind(syntaxContext, expression, ArgumentExpressionKinds.Boolean))
-                        return;
-                }
-                else if (IsStringExpression(expression))
-                {
-                    if (!MustCheckExpressionKind(syntaxContext, expression, ArgumentExpressionKinds.String))
-                        return;
-                }
-                else
-                {
+                if (expressionKind is ArgumentExpressionKinds.None)
                     return;
-                }
 
-                if (argument.Parent.IsKind(SyntaxKind.TupleExpression))
-                    return; // Don't consider tuple
-
+                if (!MustCheckExpressionKind(syntaxContext, expression, expressionKind))
+                    return;
 
                 if (argumentOperation?.Parameter is not null)
                 {
@@ -286,12 +272,19 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
                 }
 
                 syntaxContext.ReportDiagnostic(Rule, syntaxContext.Node);
-
-                static bool IsBooleanExpression(SyntaxNode node) => node.IsKind(SyntaxKind.TrueLiteralExpression) || node.IsKind(SyntaxKind.FalseLiteralExpression);
-                static bool IsStringExpression(SyntaxNode node) => node.IsKind(SyntaxKind.StringLiteralExpression) || node.IsKind(SyntaxKind.InterpolatedStringExpression);
             }, SyntaxKind.Argument);
         });
     }
+
+    private static ArgumentExpressionKinds GetExpressionKind(ExpressionSyntax expression) => expression.Kind() switch
+    {
+        SyntaxKind.NullLiteralExpression => ArgumentExpressionKinds.Null,
+        SyntaxKind.NumericLiteralExpression => ArgumentExpressionKinds.Numeric,
+        SyntaxKind.DefaultLiteralExpression => ArgumentExpressionKinds.Default,
+        SyntaxKind.TrueLiteralExpression or SyntaxKind.FalseLiteralExpression => ArgumentExpressionKinds.Boolean,
+        SyntaxKind.StringLiteralExpression or SyntaxKind.InterpolatedStringExpression => ArgumentExpressionKinds.String,
+        _ => ArgumentExpressionKinds.None,
+    };
 
     private static bool IsMethod(ISymbol? method, ITypeSymbol? containingType, string methodName)
     {

--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -1152,6 +1152,30 @@ public sealed class NamedParameterAnalyzerTests
     }
 
     [Fact]
+    public Task CallerMustUseNamedArgument_AttributeDeclaredInCompilation()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            namespace Meziantou.Analyzer.Annotations
+            {
+                internal sealed class RequireNamedArgumentAttribute : System.Attribute { }
+            }
+
+            class Test
+            {
+                public Test([Meziantou.Analyzer.Annotations.RequireNamedArgument]object a) { }
+
+                void A()
+                {
+                    _ = new Test({|MA0003:new object()|});
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task CallerMustUseNamedArgument_False()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Why

`NamedParameterAnalyzer` (MA0003) registers on `SyntaxKind.Argument`, so its callback runs for every argument of every call, constructor, indexer and tuple in the compilation. After two null checks it immediately called `SemanticModel.GetOperation(argument)`, then `HasSameNameAsParameter` (which does an `.editorconfig` lookup) and `IsCallerMustUseNamedArgumentAttribute` (which enumerates the parameter's attributes).

Only *after* all that did it apply the syntactic filter the rule actually depends on: is the expression a null / numeric / default literal, a boolean, or a string. With the default configuration (`Null | Boolean`) the overwhelming majority of arguments are rejected by that `IsKind` check — which costs nanoseconds, after the semantic binding has already been paid. The rule is enabled by default, and arguments are among the densest node kinds in real C#.

## What changed

- **The syntactic filter runs first.** The five `IsKind` branches became a single `GetExpressionKind` switch that runs before any semantic work. Arguments that map to `ArgumentExpressionKinds.None` are rejected without binding.
- **The annotation branch is gated on the compilation.** `RequireNamedArgumentAttribute` is the one check that genuinely needs the operation for every argument. It is now resolved once in the `CompilationStartAction` with `GetTypesByMetadataName`, which matches all referenced assemblies plus the compilation's own source — preserving the "the attribute can be defined in multiple assemblies" contract that `AnnotationAttributes` documents. When the attribute is absent from the compilation, non-candidate arguments return before binding.
- **The tuple check moved up.** It was already purely syntactic but sat below the semantic path. Tuple elements never bind to an `IArgumentOperation`, so neither `HasSameNameAsParameter` nor the annotation check could ever fire for them; hoisting it skips more arguments before binding.

The relative ordering of the semantic checks is unchanged: `HasSameNameAsParameter` still short-circuits ahead of the `RequireNamedArgument` report, and `MustCheckExpressionKind` (the `.editorconfig` lookup) still runs after it.

## For the reviewer

One behavior difference worth calling out: if a referenced library annotates its parameters with `[RequireNamedArgument]` but the consuming compilation references no assembly declaring that attribute, the attribute type is unresolved and the branch is now skipped. That configuration does not compile cleanly anyway, but it is the only case where the gate changes what is reported.

Added `CallerMustUseNamedArgument_AttributeDeclaredInCompilation`, which declares the attribute in the test source without referencing the annotations assembly, covering the source-declared arm of the new gate. The 18 existing annotation tests call `AddMeziantouAnnotations()` and cover the referenced-assembly arm; the other tests cover the fast path where the attribute is absent.

## Testing

- MA0003 tests: 75 passed on roslyn5.0 / 5.6 / 5.9, 73 on roslyn4.8 / 4.14 (two tests are behind `#if` version guards).
- Full suite on the default Roslyn version: 3910 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.