### PR TITLE
Load the MA0104 BCL type tables lazily

### DIFF
--- a/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
@@ -21,16 +21,14 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
     internal static readonly ConfigurationDefinition<string> NamespacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namespaces_regex", defaultValue: "^System($|\\.)");
     internal static readonly ConfigurationDefinition<string> LegacyNamepacesRegexConfiguration = new(RuleIdentifiers.DotNotUseNameFromBCL + ".namepaces_regex", defaultValue: "^System($|\\.)") { IsHidden = true };
 
-    private static Dictionary<string, List<string>>? s_types;
-    private static Dictionary<string, List<string>>? s_typesPreview;
+    // The tables are big, so they are only loaded when the rule runs, and only the configured one is loaded
+    private static readonly Lazy<Dictionary<string, string[]>> Types = new(() => LoadTypes(preview: false));
+    private static readonly Lazy<Dictionary<string, string[]>> PreviewTypes = new(() => LoadTypes(preview: true));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {
-        s_types ??= LoadTypes(preview: false);
-        s_typesPreview ??= LoadTypes(preview: true);
-
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
@@ -50,8 +48,8 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
         }
 
         var usePreviewTypes = context.Options.GetConfigurationValue(symbol, UsePreviewTypesConfiguration);
-        var types = usePreviewTypes ? s_typesPreview : s_types;
-        if (types!.TryGetValue(symbol.MetadataName, out var namespaces))
+        var types = usePreviewTypes ? PreviewTypes.Value : Types.Value;
+        if (types.TryGetValue(symbol.MetadataName, out var namespaces))
         {
             var namespaceRegex = GetNamespacesRegex(context, symbol);
             if (namespaceRegex is null)
@@ -84,14 +82,17 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
         return regex;
     }
 
-    private static Dictionary<string, List<string>> LoadTypes(bool preview)
+    private static Dictionary<string, string[]> LoadTypes(bool preview)
     {
-        var types = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var types = new Dictionary<string, string[]>(StringComparer.Ordinal);
 
         var resourceName = preview ? "Meziantou.Analyzer.Resources.bcl-preview.txt" : "Meziantou.Analyzer.Resources.bcl.txt";
         using var stream = typeof(DotNotUseNameFromBCLAnalyzer).Assembly.GetManifestResourceStream(resourceName);
         if (stream is null)
             return types;
+
+        // The same few hundred namespaces are repeated on thousands of lines, so they are deduplicated to keep a single instance of each
+        var knownNamespaces = new Dictionary<string, string>(StringComparer.Ordinal);
 
         using var sr = new StreamReader(stream);
         while (sr.ReadLine() is { } line)
@@ -100,13 +101,17 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
             var ns = line[..index];
             var name = line[(index + 1)..];
 
-            if (!types.TryGetValue(name, out var list))
+            if (knownNamespaces.TryGetValue(ns, out var knownNamespace))
             {
-                list = [];
-                types.Add(name, list);
+                ns = knownNamespace;
+            }
+            else
+            {
+                knownNamespaces.Add(ns, ns);
             }
 
-            list.Add(ns);
+            // Very few names are declared in multiple namespaces, so the arrays are sized exactly instead of using a list
+            types[name] = types.TryGetValue(name, out var existingNamespaces) ? [.. existingNamespaces, ns] : [ns];
         }
 
         return types;


### PR DESCRIPTION
## What

MA0104 (`DotNotUseNameFromBCLAnalyzer`) parsed **both** embedded type tables in `Initialize` and kept them in statics for the life of the process:

```csharp
s_types ??= LoadTypes(preview: false);
s_typesPreview ??= LoadTypes(preview: true);
```

That is ~950 KB of embedded text (`bcl.txt` 468 KB, `bcl-preview.txt` 479 KB) parsed on the analyzer-init path, for a rule that is `isEnabledByDefault: false` and that uses exactly one of the two tables per compilation, selected by `use_preview_types` (default `false`).

## Changes

- **Lazy, on-demand loading.** The eager loads are gone from `Initialize`; the tables are `static readonly Lazy<Dictionary<string, string[]>>` fields, touched only in `AnalyzeSymbol` where the configured table is selected. When the rule is disabled — the default — Roslyn never invokes the symbol action, so neither file is parsed. When it is enabled, only the selected table is built: the preview table stays unloaded unless someone opts in. `Lazy<T>` also gives correct publication in place of the non-atomic `??=`.
- **Exact-sized arrays instead of lists.** `Dictionary<string, List<string>>` → `Dictionary<string, string[]>`. `bcl.txt` has 9 873 lines producing 9 689 distinct names, of which only 173 map to more than one namespace, so the old shape allocated ~9 700 `List<string>` instances (plus their backing arrays) to hold a single string each.
- **Namespace deduplication.** The file contains only 380 distinct namespaces spread over its 9 873 lines, so `LoadTypes` now keeps a single instance of each instead of retaining ~9 900 substrings. The substring is still allocated for the lookup — netstandard2.0 has no span-keyed alternate lookup — but it becomes garbage rather than retained memory.

## Behavior

Unchanged. Namespaces are still appended in file order, so when a name exists in several namespaces the first regex match — and therefore the reported namespace — is the same as before.

## Validation

- `dotnet build` of `Meziantou.Analyzer.roslyn5.9.csproj` and `Meziantou.Analyzer.roslyn4.8.csproj`: succeeded, 0 warnings, for both `net10.0` and `netstandard2.0`.
- `DotNotUseNameFromBCLAnalyzerTests`: 14/14 passed on roslyn5.9 and on roslyn4.8.
- Full `Meziantou.Analyzer.Test.roslyn5.9` suite: 3909/3909 passed.
- `dotnet run --project src/DocumentationGenerator`: exit code 0, no markdown changes.

## Note for the reviewer

Unrelated to this change, `ReportDiagnostic` and `ReportDiagnostic_UsePreviewTypes` in `DotNotUseNameFromBCLAnalyzerTests` look swapped — the first sets `use_preview_types=true` and the second does not. Left alone here.