### PR TITLE
Remove the dnceng dotnet-tools NuGet source

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,5 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dnceng-dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
## What

Removes the `dnceng-dotnet-tools` package source (`https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json`) from `nuget.config`, leaving nuget.org as the only source.

## Why

The source was added in #948 for the `Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing` dependency, but that package — and every other package this repository uses — is published on nuget.org, so the extra source only slows restore down and adds a feed the build does not need.

## Verification

- Checked every direct dependency against the nuget.org flat container: the `Microsoft.CodeAnalysis.*.Testing` 1.1.4 packages, `Microsoft.CodeAnalysis.*` for all five supported Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9), and the `Meziantou.NET.Sdk*` 1.0.161 MSBuild SDKs of `global.json`.
- Checked every package the test harness downloads at runtime through `Microsoft.CodeAnalysis.Testing`, including the .NET 11 preview reference packs `Microsoft.NETCore.App.Ref`, `Microsoft.AspNetCore.App.Ref` and `Microsoft.JSInterop.WebAssembly` 11.0.0-preview.7.26381.103.
- `dotnet restore` of the whole solution with `NUGET_PACKAGES` pointing at an **empty** folder and the source removed: all 19 projects restored from nuget.org alone.
- `dotnet build`: succeeded, 0 warnings, 0 errors.
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn5.9.csproj`: 3909 passed, 0 failed.

No other reference to the feed exists in the repository — no CI step, script or documentation mentions `dotnet-tools`, `dnceng` or `pkgs.dev.azure.com`. The CI builds and tests all Roslyn versions, which covers the other four.