### PR TITLE
Share the diagnostic property keys between the analyzers and the fixers

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidComparisonWithBoolConstantFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidComparisonWithBoolConstantFixer.cs
@@ -19,28 +19,35 @@ public sealed class AvoidComparisonWithBoolConstantFixer : CodeFixProvider
         if (nodeToFix is not BinaryExpressionSyntax)
             return;
 
-        var diagnostic = context.Diagnostics[0];
+        var properties = context.Diagnostics[0].Properties;
+        if (!properties.TryGetValue(AvoidComparisonWithBoolConstantAnalyzerCommon.NodeToKeepSpanStartKey, out var nodeToKeepSpanStartValue) ||
+            !int.TryParse(nodeToKeepSpanStartValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nodeToKeepSpanStart))
+            return;
+
+        if (!properties.TryGetValue(AvoidComparisonWithBoolConstantAnalyzerCommon.NodeToKeepSpanLengthKey, out var nodeToKeepSpanLengthValue) ||
+            !int.TryParse(nodeToKeepSpanLengthValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nodeToKeepSpanLength))
+            return;
+
+        if (!properties.TryGetValue(AvoidComparisonWithBoolConstantAnalyzerCommon.LogicalNotOperatorNeededKey, out var logicalNotOperatorNeededValue) ||
+            !bool.TryParse(logicalNotOperatorNeededValue, out var logicalNotOperatorNeeded))
+            return;
 
         var title = "Remove comparison with bool constant";
         var codeAction = CodeAction.Create(
             title,
-            ct => RemoveComparisonWithBoolConstant(context.Document, diagnostic, nodeToFix, ct),
+            ct => RemoveComparisonWithBoolConstant(context.Document, nodeToFix, new TextSpan(nodeToKeepSpanStart, nodeToKeepSpanLength), logicalNotOperatorNeeded, ct),
             equivalenceKey: title);
 
         context.RegisterCodeFix(codeAction, context.Diagnostics);
     }
 
-    private static async Task<Document> RemoveComparisonWithBoolConstant(Document document, Diagnostic diagnostic, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static async Task<Document> RemoveComparisonWithBoolConstant(Document document, SyntaxNode nodeToFix, TextSpan nodeToKeepSpan, bool logicalNotOperatorNeeded, CancellationToken cancellationToken)
     {
-        var nodeToKeepSpanStart = int.Parse(diagnostic.Properties["NodeToKeepSpanStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var nodeToKeepSpanLength = int.Parse(diagnostic.Properties["NodeToKeepSpanLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var logicalNotOperatorNeeded = bool.Parse(diagnostic.Properties["LogicalNotOperatorNeeded"]!);
-
         var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         if (syntaxRoot is null)
             return document;
 
-        var nodeToKeep = syntaxRoot.FindNode(new TextSpan(nodeToKeepSpanStart, nodeToKeepSpanLength), getInnermostNodeForTie: true);
+        var nodeToKeep = syntaxRoot.FindNode(nodeToKeepSpan, getInnermostNodeForTie: true);
         if (nodeToKeep.Parent.IsKind(SyntaxKind.ParenthesizedExpression))
         {
             nodeToKeep = nodeToKeep.Parent;

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseBlockingCallInAsyncContextFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseBlockingCallInAsyncContextFixer.cs
@@ -15,7 +15,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextFixer : CodeFixProvider
             return;
 
         var properties = context.Diagnostics[0].Properties;
-        if (!properties.TryGetValue("Data", out var dataStr) || !Enum.TryParse<DoNotUseBlockingCallInAsyncContextData>(dataStr, ignoreCase: false, out var data))
+        if (!properties.TryGetValue(DoNotUseBlockingCallInAsyncContextAnalyzerCommon.DataKey, out var dataStr) || !Enum.TryParse<DoNotUseBlockingCallInAsyncContextData>(dataStr, ignoreCase: false, out var data))
             return;
 
         switch (data)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MethodOverridesShouldNotChangeParameterDefaultsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MethodOverridesShouldNotChangeParameterDefaultsFixer.cs
@@ -17,7 +17,7 @@ public sealed class MethodOverridesShouldNotChangeParameterDefaultsFixer : CodeF
         if (nodeToFix is not ParameterSyntax parameterSyntax)
             return;
 
-        if (!context.Diagnostics[0].Properties.TryGetValue("HasDefaultValue", out var hasValue))
+        if (!context.Diagnostics[0].Properties.TryGetValue(MethodOverridesShouldNotChangeParameterDefaultsAnalyzerCommon.HasDefaultValueKey, out var hasValue))
             return;
 
         if (hasValue == "false")
@@ -31,7 +31,7 @@ public sealed class MethodOverridesShouldNotChangeParameterDefaultsFixer : CodeF
         }
         else
         {
-            if (!context.Diagnostics[0].Properties.TryGetValue("DefaultValue", out var value))
+            if (!context.Diagnostics[0].Properties.TryGetValue(MethodOverridesShouldNotChangeParameterDefaultsAnalyzerCommon.DefaultValueKey, out var value))
                 return;
 
             var title = "Use parent's default value";

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
@@ -41,7 +41,7 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
             return;
         }
 
-        if (!Enum.TryParse(diagnostic.Properties.GetValueOrDefault("Data", ""), ignoreCase: false, out OptimizeLinqUsageData data) || data is OptimizeLinqUsageData.None)
+        if (!Enum.TryParse(diagnostic.Properties.GetValueOrDefault(OptimizeLinqUsageAnalyzerCommon.DataKey, ""), ignoreCase: false, out OptimizeLinqUsageData data) || data is OptimizeLinqUsageData.None)
             return;
 
         // If the so-called nodeToFix is a Name (most likely a method name such as 'Select' or 'Count'),
@@ -101,20 +101,30 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
                 break;
 
             case OptimizeLinqUsageData.DuplicatedOrderBy:
-                var useThenByTitle = "Use " + diagnostic.Properties["ExpectedMethodName"];
-                var removeOrderByTitle = "Remove " + diagnostic.Properties["MethodName"];
-                context.RegisterCodeFix(CodeAction.Create(useThenByTitle, ct => UseThenBy(context.Document, diagnostic, ct), equivalenceKey: "UseThenBy"), context.Diagnostics);
-                context.RegisterCodeFix(CodeAction.Create(removeOrderByTitle, ct => RemoveDuplicatedOrderBy(context.Document, diagnostic, ct), equivalenceKey: "RemoveOrderBy"), context.Diagnostics);
+                if (!TryGetFirstOperationSpan(diagnostic, out var orderByFirstSpan) || !TryGetLastOperationSpan(diagnostic, out var orderByLastSpan))
+                    return;
+
+                if (!diagnostic.Properties.TryGetValue(OptimizeLinqUsageAnalyzerCommon.ExpectedMethodNameKey, out var expectedMethodName) || expectedMethodName is null)
+                    return;
+
+                if (!diagnostic.Properties.TryGetValue(OptimizeLinqUsageAnalyzerCommon.MethodNameKey, out var methodName) || methodName is null)
+                    return;
+
+                context.RegisterCodeFix(CodeAction.Create("Use " + expectedMethodName, ct => UseThenBy(context.Document, orderByLastSpan, expectedMethodName, ct), equivalenceKey: "UseThenBy"), context.Diagnostics);
+                context.RegisterCodeFix(CodeAction.Create("Remove " + methodName, ct => RemoveDuplicatedOrderBy(context.Document, orderByFirstSpan, orderByLastSpan, ct), equivalenceKey: "RemoveOrderBy"), context.Diagnostics);
                 break;
 
             case OptimizeLinqUsageData.CombineWhereWithNextMethod:
+                if (!TryGetFirstOperationSpan(diagnostic, out var whereFirstSpan) || !TryGetLastOperationSpan(diagnostic, out var whereLastSpan))
+                    return;
+
                 if (diagnostic.Id == RuleIdentifiers.OptimizeEnumerable_WhereBeforeOrderBy)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(title, ct => ReorderWhereBeforeOrderBy(context.Document, diagnostic, ct), equivalenceKey: title), context.Diagnostics);
+                    context.RegisterCodeFix(CodeAction.Create(title, ct => ReorderWhereBeforeOrderBy(context.Document, whereFirstSpan, whereLastSpan, ct), equivalenceKey: title), context.Diagnostics);
                 }
                 else
                 {
-                    context.RegisterCodeFix(CodeAction.Create(title, ct => CombineWhereWithNextMethod(context.Document, diagnostic, ct), equivalenceKey: title), context.Diagnostics);
+                    context.RegisterCodeFix(CodeAction.Create(title, ct => CombineWhereWithNextMethod(context.Document, whereFirstSpan, whereLastSpan, ct), equivalenceKey: title), context.Diagnostics);
                 }
 
                 break;
@@ -128,23 +138,27 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
                 break;
 
             case OptimizeLinqUsageData.UseNotAny:
-                context.RegisterCodeFix(CodeAction.Create(title, ct => UseAny(context.Document, diagnostic, nodeToFix, constantValue: false, ct), equivalenceKey: title), context.Diagnostics);
-                break;
-
             case OptimizeLinqUsageData.UseAny:
-                context.RegisterCodeFix(CodeAction.Create(title, ct => UseAny(context.Document, diagnostic, nodeToFix, constantValue: true, ct), equivalenceKey: title), context.Diagnostics);
+                if (!TryGetCountOperationSpan(diagnostic, out var anyCountSpan))
+                    return;
+
+                context.RegisterCodeFix(CodeAction.Create(title, ct => UseAny(context.Document, anyCountSpan, nodeToFix, constantValue: data is OptimizeLinqUsageData.UseAny, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
             case OptimizeLinqUsageData.UseTakeAndCount:
-                context.RegisterCodeFix(CodeAction.Create(title, ct => UseTakeAndCount(context.Document, diagnostic, ct), equivalenceKey: title), context.Diagnostics);
+                if (!TryGetCountOperationSpan(diagnostic, out var takeCountSpan) || !TryGetOperandOperationSpan(diagnostic, out var takeOperandSpan))
+                    return;
+
+                context.RegisterCodeFix(CodeAction.Create(title, ct => UseTakeAndCount(context.Document, takeCountSpan, takeOperandSpan, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
             case OptimizeLinqUsageData.UseSkipAndAny:
-                context.RegisterCodeFix(CodeAction.Create(title, ct => UseSkipAndAny(context.Document, diagnostic, nodeToFix, comparandValue: true, ct), equivalenceKey: title), context.Diagnostics);
-                break;
-
             case OptimizeLinqUsageData.UseSkipAndNotAny:
-                context.RegisterCodeFix(CodeAction.Create(title, ct => UseSkipAndAny(context.Document, diagnostic, nodeToFix, comparandValue: false, ct), equivalenceKey: title), context.Diagnostics);
+                if (!TryGetCountOperationSpan(diagnostic, out var skipCountSpan) || !TryGetOperandOperationSpan(diagnostic, out var skipOperandSpan))
+                    return;
+
+                var skipMinusOne = diagnostic.Properties.ContainsKey(OptimizeLinqUsageAnalyzerCommon.SkipMinusOneKey);
+                context.RegisterCodeFix(CodeAction.Create(title, ct => UseSkipAndAny(context.Document, skipCountSpan, skipOperandSpan, skipMinusOne, nodeToFix, comparandValue: data is OptimizeLinqUsageData.UseSkipAndAny, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
             case OptimizeLinqUsageData.UseCastInsteadOfSelect:
@@ -155,6 +169,31 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
                 context.RegisterCodeFix(CodeAction.Create(title, ct => UseOrderInsteadOfOrderBy(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
                 break;
         }
+    }
+
+    private static bool TryGetFirstOperationSpan(Diagnostic diagnostic, out TextSpan span)
+        => TryGetSpan(diagnostic, OptimizeLinqUsageAnalyzerCommon.FirstOperationStartKey, OptimizeLinqUsageAnalyzerCommon.FirstOperationLengthKey, out span);
+
+    private static bool TryGetLastOperationSpan(Diagnostic diagnostic, out TextSpan span)
+        => TryGetSpan(diagnostic, OptimizeLinqUsageAnalyzerCommon.LastOperationStartKey, OptimizeLinqUsageAnalyzerCommon.LastOperationLengthKey, out span);
+
+    private static bool TryGetCountOperationSpan(Diagnostic diagnostic, out TextSpan span)
+        => TryGetSpan(diagnostic, OptimizeLinqUsageAnalyzerCommon.CountOperationStartKey, OptimizeLinqUsageAnalyzerCommon.CountOperationLengthKey, out span);
+
+    private static bool TryGetOperandOperationSpan(Diagnostic diagnostic, out TextSpan span)
+        => TryGetSpan(diagnostic, OptimizeLinqUsageAnalyzerCommon.OperandOperationStartKey, OptimizeLinqUsageAnalyzerCommon.OperandOperationLengthKey, out span);
+
+    private static bool TryGetSpan(Diagnostic diagnostic, string startKey, string lengthKey, out TextSpan span)
+    {
+        if (diagnostic.Properties.TryGetValue(startKey, out var startValue) && int.TryParse(startValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var start) &&
+            diagnostic.Properties.TryGetValue(lengthKey, out var lengthValue) && int.TryParse(lengthValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var length))
+        {
+            span = new TextSpan(start, length);
+            return true;
+        }
+
+        span = default;
+        return false;
     }
 
     private static bool TryGetInvocationExpressionAncestor(ref SyntaxNode nodeToFix)
@@ -174,13 +213,10 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         return false;
     }
 
-    private static async Task<Document> UseAny(Document document, Diagnostic diagnostic, SyntaxNode nodeToFix, bool constantValue, CancellationToken cancellationToken)
+    private static async Task<Document> UseAny(Document document, TextSpan countOperationSpan, SyntaxNode nodeToFix, bool constantValue, CancellationToken cancellationToken)
     {
-        var countOperationStart = int.Parse(diagnostic.Properties["CountOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var countOperationLength = int.Parse(diagnostic.Properties["CountOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var countNode = root?.FindNode(new TextSpan(countOperationStart, countOperationLength), getInnermostNodeForTie: true);
+        var countNode = root?.FindNode(countOperationSpan, getInnermostNodeForTie: true);
         if (countNode is null)
             return document;
 
@@ -225,16 +261,11 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
-    private static async Task<Document> UseTakeAndCount(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+    private static async Task<Document> UseTakeAndCount(Document document, TextSpan countOperationSpan, TextSpan operandOperationSpan, CancellationToken cancellationToken)
     {
-        var countOperationStart = int.Parse(diagnostic.Properties["CountOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var countOperationLength = int.Parse(diagnostic.Properties["CountOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var operandOperationStart = int.Parse(diagnostic.Properties["OperandOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var operandOperationLength = int.Parse(diagnostic.Properties["OperandOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var countNode = root?.FindNode(new TextSpan(countOperationStart, countOperationLength), getInnermostNodeForTie: true);
-        var operandNode = root?.FindNode(new TextSpan(operandOperationStart, operandOperationLength), getInnermostNodeForTie: true);
+        var countNode = root?.FindNode(countOperationSpan, getInnermostNodeForTie: true);
+        var operandNode = root?.FindNode(operandOperationSpan, getInnermostNodeForTie: true);
         if (countNode is null || operandNode is null)
             return document;
 
@@ -274,17 +305,11 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
-    private static async Task<Document> UseSkipAndAny(Document document, Diagnostic diagnostic, SyntaxNode nodeToFix, bool comparandValue, CancellationToken cancellationToken)
+    private static async Task<Document> UseSkipAndAny(Document document, TextSpan countOperationSpan, TextSpan operandOperationSpan, bool skipMinusOne, SyntaxNode nodeToFix, bool comparandValue, CancellationToken cancellationToken)
     {
-        var countOperationStart = int.Parse(diagnostic.Properties["CountOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var countOperationLength = int.Parse(diagnostic.Properties["CountOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var operandOperationStart = int.Parse(diagnostic.Properties["OperandOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var operandOperationLength = int.Parse(diagnostic.Properties["OperandOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var skipMinusOne = diagnostic.Properties.ContainsKey("SkipMinusOne");
-
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var countNode = root?.FindNode(new TextSpan(countOperationStart, countOperationLength), getInnermostNodeForTie: true);
-        var operandNode = root?.FindNode(new TextSpan(operandOperationStart, operandOperationLength), getInnermostNodeForTie: true);
+        var countNode = root?.FindNode(countOperationSpan, getInnermostNodeForTie: true);
+        var operandNode = root?.FindNode(operandOperationSpan, getInnermostNodeForTie: true);
         if (countNode is null || operandNode is null)
             return document;
 
@@ -565,18 +590,13 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         }
     }
 
-    private static async Task<Document> RemoveDuplicatedOrderBy(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+    private static async Task<Document> RemoveDuplicatedOrderBy(Document document, TextSpan firstOperationSpan, TextSpan lastOperationSpan, CancellationToken cancellationToken)
     {
         // a."b()".c()
         // a.c()
-        var firstOperationStart = int.Parse(diagnostic.Properties["FirstOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var firstOperationLength = int.Parse(diagnostic.Properties["FirstOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var lastOperationStart = int.Parse(diagnostic.Properties["LastOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var lastOperationLength = int.Parse(diagnostic.Properties["LastOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var firstNode = root?.FindNode(new TextSpan(firstOperationStart, firstOperationLength), getInnermostNodeForTie: true);
-        var lastNode = root?.FindNode(new TextSpan(lastOperationStart, lastOperationLength), getInnermostNodeForTie: true);
+        var firstNode = root?.FindNode(firstOperationSpan, getInnermostNodeForTie: true);
+        var lastNode = root?.FindNode(lastOperationSpan, getInnermostNodeForTie: true);
         if (firstNode is null || lastNode is null)
             return document;
 
@@ -592,14 +612,10 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
-    private static async Task<Document> UseThenBy(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+    private static async Task<Document> UseThenBy(Document document, TextSpan lastOperationSpan, string expectedMethodName, CancellationToken cancellationToken)
     {
-        var lastOperationStart = int.Parse(diagnostic.Properties["LastOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var lastOperationLength = int.Parse(diagnostic.Properties["LastOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var expectedMethodName = diagnostic.Properties["ExpectedMethodName"]!;
-
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var nodeToFix = root?.FindNode(new TextSpan(lastOperationStart, lastOperationLength), getInnermostNodeForTie: true);
+        var nodeToFix = root?.FindNode(lastOperationSpan, getInnermostNodeForTie: true);
         if (nodeToFix is null)
             return document;
 
@@ -615,19 +631,14 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
-    private static async Task<Document> CombineWhereWithNextMethod(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+    private static async Task<Document> CombineWhereWithNextMethod(Document document, TextSpan firstOperationSpan, TextSpan lastOperationSpan, CancellationToken cancellationToken)
     {
         // enumerable.Where(x=> x).C() => enumerable.C(x=> x)
         // enumerable.Where(x=> x).C(y=>y) => enumerable.C(y=> y && y)
         // enumerable.Where(Condition).C(y=>y) => enumerable.C(y=> Condition(y) && y)
-        var firstOperationStart = int.Parse(diagnostic.Properties["FirstOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var firstOperationLength = int.Parse(diagnostic.Properties["FirstOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var lastOperationStart = int.Parse(diagnostic.Properties["LastOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var lastOperationLength = int.Parse(diagnostic.Properties["LastOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var firstNode = root?.FindNode(new TextSpan(firstOperationStart, firstOperationLength), getInnermostNodeForTie: true);
-        var lastNode = root?.FindNode(new TextSpan(lastOperationStart, lastOperationLength), getInnermostNodeForTie: true);
+        var firstNode = root?.FindNode(firstOperationSpan, getInnermostNodeForTie: true);
+        var lastNode = root?.FindNode(lastOperationSpan, getInnermostNodeForTie: true);
         if (firstNode is null || lastNode is null)
             return document;
 
@@ -702,16 +713,11 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         }
     }
 
-    private static async Task<Document> ReorderWhereBeforeOrderBy(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+    private static async Task<Document> ReorderWhereBeforeOrderBy(Document document, TextSpan firstOperationSpan, TextSpan lastOperationSpan, CancellationToken cancellationToken)
     {
-        var firstOperationStart = int.Parse(diagnostic.Properties["FirstOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var firstOperationLength = int.Parse(diagnostic.Properties["FirstOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var lastOperationStart = int.Parse(diagnostic.Properties["LastOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-        var lastOperationLength = int.Parse(diagnostic.Properties["LastOperationLength"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
-
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var firstNode = root?.FindNode(new TextSpan(firstOperationStart, firstOperationLength), getInnermostNodeForTie: true);
-        var lastNode = root?.FindNode(new TextSpan(lastOperationStart, lastOperationLength), getInnermostNodeForTie: true);
+        var firstNode = root?.FindNode(firstOperationSpan, getInnermostNodeForTie: true);
+        var lastNode = root?.FindNode(lastOperationSpan, getInnermostNodeForTie: true);
         if (firstNode is null || lastNode is null)
             return document;
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
@@ -23,7 +23,7 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
         if (diagnostic is null)
             return;
 
-        if (!Enum.TryParse(diagnostic.Properties.GetValueOrDefault("Data", ""), ignoreCase: false, out OptimizeStringBuilderUsageData data) || data == OptimizeStringBuilderUsageData.None)
+        if (!Enum.TryParse(diagnostic.Properties.GetValueOrDefault(OptimizeStringBuilderUsageAnalyzerCommon.DataKey, ""), ignoreCase: false, out OptimizeStringBuilderUsageData data) || data == OptimizeStringBuilderUsageData.None)
             return;
 
         var title = "Optimize StringBuilder usage";
@@ -38,7 +38,10 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
                 break;
 
             case OptimizeStringBuilderUsageData.ReplaceWithChar:
-                context.RegisterCodeFix(CodeAction.Create(title, ct => ReplaceArgWithCharacter(context.Document, diagnostic, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
+                if (diagnostic.Properties.GetValueOrDefault(OptimizeStringBuilderUsageAnalyzerCommon.ConstantValueKey) is not [var constValue, ..])
+                    return;
+
+                context.RegisterCodeFix(CodeAction.Create(title, ct => ReplaceArgWithCharacter(context.Document, constValue, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
             case OptimizeStringBuilderUsageData.SplitStringInterpolation:
@@ -383,9 +386,8 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
-    private static async Task<Document> ReplaceArgWithCharacter(Document document, Diagnostic diagnostic, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static async Task<Document> ReplaceArgWithCharacter(Document document, char constValue, SyntaxNode nodeToFix, CancellationToken cancellationToken)
     {
-        var constValue = diagnostic.Properties["ConstantValue"]![0];
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
         var argument = nodeToFix.FirstAncestorOrSelf<ArgumentSyntax>();

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs
@@ -16,16 +16,16 @@ public sealed class UseAnOverloadThatHasCancellationTokenFixer_Argument : CodeFi
 
         if (nodeToFix.IsKind(SyntaxKind.InvocationExpression))
         {
-            if (!int.TryParse(context.Diagnostics[0].Properties["ParameterIndex"], NumberStyles.None, CultureInfo.InvariantCulture, out var parameterIndex))
+            if (!int.TryParse(context.Diagnostics[0].Properties.GetValueOrDefault(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterIndexKey), NumberStyles.None, CultureInfo.InvariantCulture, out var parameterIndex))
                 return;
 
-            if (!context.Diagnostics[0].Properties.TryGetValue("ParameterName", out var parameterName) || parameterName is null)
+            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterNameKey, out var parameterName) || parameterName is null)
                 return;
 
-            if (!context.Diagnostics[0].Properties.TryGetValue("ParameterIsEnumeratorCancellation", out var parameterIsEnumeratorCancellation) || !bool.TryParse(parameterIsEnumeratorCancellation, out var isEnumeratorCancellation))
+            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterIsEnumeratorCancellationKey, out var parameterIsEnumeratorCancellation) || !bool.TryParse(parameterIsEnumeratorCancellation, out var isEnumeratorCancellation))
                 return;
 
-            if (!context.Diagnostics[0].Properties.TryGetValue("CancellationTokens", out var cancellationTokens) || cancellationTokens is null)
+            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.CancellationTokensKey, out var cancellationTokens) || cancellationTokens is null)
                 return;
 
             foreach (var cancellationToken in cancellationTokens.Split(','))

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_AwaitForEach.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_AwaitForEach.cs
@@ -14,7 +14,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenFixer_AwaitForEach : Co
         if (nodeToFix is not ExpressionSyntax expressionSyntax)
             return;
 
-        if (!context.Diagnostics[0].Properties.TryGetValue("CancellationTokens", out var cancellationTokens) || cancellationTokens is null)
+        if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.CancellationTokensKey, out var cancellationTokens) || cancellationTokens is null)
             return;
 
         foreach (var cancellationToken in cancellationTokens.Split(','))

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasTimeProviderFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasTimeProviderFixer.cs
@@ -16,13 +16,13 @@ public sealed class UseAnOverloadThatHasTimeProviderFixer : CodeFixProvider
 
         if (nodeToFix.IsKind(SyntaxKind.InvocationExpression))
         {
-            if (!int.TryParse(context.Diagnostics[0].Properties["ParameterIndex"], NumberStyles.None, CultureInfo.InvariantCulture, out var parameterIndex))
+            if (!int.TryParse(context.Diagnostics[0].Properties.GetValueOrDefault(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterIndexKey), NumberStyles.None, CultureInfo.InvariantCulture, out var parameterIndex))
                 return;
 
-            if (!context.Diagnostics[0].Properties.TryGetValue("ParameterName", out var parameterName) || parameterName is null)
+            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterNameKey, out var parameterName) || parameterName is null)
                 return;
 
-            if (!context.Diagnostics[0].Properties.TryGetValue("Paths", out var paths) || paths is null)
+            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasTimeProviderAnalyzerCommon.PathsKey, out var paths) || paths is null)
                 return;
 
             foreach (var cancellationToken in paths.Split(','))

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
@@ -37,7 +37,7 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
         var editor = await DocumentEditor.CreateAsync(context.Document, cancellationToken).ConfigureAwait(false);
         var generator = editor.Generator;
 
-        if (context.Diagnostics[0].Properties.TryGetValue("kind", out var kind))
+        if (context.Diagnostics[0].Properties.TryGetValue(UseConfigureAwaitAnalyzerCommon.KindKey, out var kind))
         {
             if (kind is "foreach")
             {

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseLangwordInXmlCommentFixer.cs
@@ -16,7 +16,7 @@ public sealed class UseLangwordInXmlCommentFixer : CodeFixProvider
         if (nodeToFix is null)
             return;
 
-        if (!context.Diagnostics[0].Properties.TryGetValue("keyword", out var keyword) || keyword is null)
+        if (!context.Diagnostics[0].Properties.TryGetValue(UseLangwordInXmlCommentAnalyzerCommon.KeywordKey, out var keyword) || keyword is null)
             return;
 
         var title = $"Use <see langword=\"{keyword}\" />";

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateArgumentsCorrectlyFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateArgumentsCorrectlyFixer.cs
@@ -30,23 +30,24 @@ public sealed class ValidateArgumentsCorrectlyFixer : CodeFixProvider
         if (semanticModel?.GetDeclaredSymbol(nodeToFix, cancellationToken: context.CancellationToken) is not IMethodSymbol)
             return;
 
-        var diagnostic = context.Diagnostics[0];
+        if (!context.Diagnostics[0].Properties.TryGetValue(ValidateArgumentsCorrectlyAnalyzerCommon.IndexKey, out var indexValue) ||
+            !int.TryParse(indexValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index))
+            return;
 
         var title = "Use local function";
         var codeAction = CodeAction.Create(
             title,
-            ct => Refactor(context.Document, diagnostic, nodeToFix, ct),
+            ct => Refactor(context.Document, index, nodeToFix, ct),
             equivalenceKey: title);
 
         context.RegisterCodeFix(codeAction, context.Diagnostics);
     }
 
-    private static async Task<Document> Refactor(Document document, Diagnostic diagnostic, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static async Task<Document> Refactor(Document document, int index, SyntaxNode nodeToFix, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         var generator = editor.Generator;
 
-        var index = int.Parse(diagnostic.Properties["Index"]!, CultureInfo.InvariantCulture);
         var symbol = (IMethodSymbol?)editor.SemanticModel.GetDeclaredSymbol(nodeToFix, cancellationToken);
         if (symbol is null)
             return document;

--- a/src/Meziantou.Analyzer/Rules/AvoidComparisonWithBoolConstantAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidComparisonWithBoolConstantAnalyzer.cs
@@ -69,9 +69,9 @@ public sealed class AvoidComparisonWithBoolConstantAnalyzer : DiagnosticAnalyzer
             binaryOperation.OperatorKind == BinaryOperatorKind.Equals;
 
         var properties = ImmutableDictionary.Create<string, string?>(StringComparer.Ordinal)
-            .Add("NodeToKeepSpanStart", nodeToKeep.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-            .Add("NodeToKeepSpanLength", nodeToKeep.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
-            .Add("LogicalNotOperatorNeeded", logicalNotOperatorNeeded.ToString());
+            .Add(AvoidComparisonWithBoolConstantAnalyzerCommon.NodeToKeepSpanStartKey, nodeToKeep.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
+            .Add(AvoidComparisonWithBoolConstantAnalyzerCommon.NodeToKeepSpanLengthKey, nodeToKeep.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
+            .Add(AvoidComparisonWithBoolConstantAnalyzerCommon.LogicalNotOperatorNeededKey, logicalNotOperatorNeeded.ToString());
 
         var operatorTokenLocation = ((BinaryExpressionSyntax)binaryOperation.Syntax).OperatorToken.GetLocation();
         context.ReportDiagnostic(Rule, properties, operatorTokenLocation);

--- a/src/Meziantou.Analyzer/Rules/AvoidComparisonWithBoolConstantAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidComparisonWithBoolConstantAnalyzerCommon.cs
@@ -1,0 +1,8 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class AvoidComparisonWithBoolConstantAnalyzerCommon
+{
+    internal const string NodeToKeepSpanStartKey = "NodeToKeepSpanStart";
+    internal const string NodeToKeepSpanLengthKey = "NodeToKeepSpanLength";
+    internal const string LogicalNotOperatorNeededKey = "LogicalNotOperatorNeeded";
+}

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -820,8 +820,8 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
         public ImmutableDictionary<string, string?> CreateProperties()
         {
             return ImmutableDictionary<string, string?>.Empty
-                .Add("Data", Data.ToString())
-                .Add("MethodName", AsyncMethodName);
+                .Add(DoNotUseBlockingCallInAsyncContextAnalyzerCommon.DataKey, Data.ToString())
+                .Add(DoNotUseBlockingCallInAsyncContextAnalyzerCommon.MethodNameKey, AsyncMethodName);
         }
     }
 }

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzerCommon.cs
@@ -1,0 +1,7 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class DoNotUseBlockingCallInAsyncContextAnalyzerCommon
+{
+    internal const string DataKey = "Data";
+    internal const string MethodNameKey = "MethodName";
+}

--- a/src/Meziantou.Analyzer/Rules/MethodOverridesShouldNotChangeParameterDefaultsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MethodOverridesShouldNotChangeParameterDefaultsAnalyzer.cs
@@ -78,8 +78,8 @@ public sealed class MethodOverridesShouldNotChangeParameterDefaultsAnalyzer : Di
             }
 
             return ImmutableDictionary<string, string?>.Empty
-                .Add("HasDefaultValue", parameter.HasExplicitDefaultValue ? "true" : "false")
-                .Add("DefaultValue", value: parameter.HasExplicitDefaultValue ? (defaultExpressionSyntax?.ToString() ?? parameter.ExplicitDefaultValue?.ToString() ?? null) : null);
+                .Add(MethodOverridesShouldNotChangeParameterDefaultsAnalyzerCommon.HasDefaultValueKey, parameter.HasExplicitDefaultValue ? "true" : "false")
+                .Add(MethodOverridesShouldNotChangeParameterDefaultsAnalyzerCommon.DefaultValueKey, value: parameter.HasExplicitDefaultValue ? (defaultExpressionSyntax?.ToString() ?? parameter.ExplicitDefaultValue?.ToString() ?? null) : null);
         }
     }
 

--- a/src/Meziantou.Analyzer/Rules/MethodOverridesShouldNotChangeParameterDefaultsAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/MethodOverridesShouldNotChangeParameterDefaultsAnalyzerCommon.cs
@@ -1,0 +1,7 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class MethodOverridesShouldNotChangeParameterDefaultsAnalyzerCommon
+{
+    internal const string HasDefaultValueKey = "HasDefaultValue";
+    internal const string DefaultValueKey = "DefaultValue";
+}

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -187,41 +187,41 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
         private static ImmutableDictionary<string, string?> CreateProperties(OptimizeLinqUsageData data)
         {
             var builder = ImmutableDictionary.CreateBuilder<string, string?>(StringComparer.Ordinal);
-            builder.Add("Data", data.ToString());
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.DataKey, data.ToString());
             return builder.ToImmutable();
         }
 
         private static ImmutableDictionary<string, string?> CreateLinqChainProperties(OptimizeLinqUsageData data, IInvocationOperation firstOperation, IInvocationOperation lastOperation, string methodName)
         {
             var builder = ImmutableDictionary.CreateBuilder<string, string?>(StringComparer.Ordinal);
-            builder.Add("Data", data.ToString());
-            builder.Add("FirstOperationStart", firstOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
-            builder.Add("FirstOperationLength", firstOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
-            builder.Add("LastOperationStart", lastOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
-            builder.Add("LastOperationLength", lastOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
-            builder.Add("MethodName", methodName);
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.DataKey, data.ToString());
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.FirstOperationStartKey, firstOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.FirstOperationLengthKey, firstOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.LastOperationStartKey, lastOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.LastOperationLengthKey, lastOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.MethodNameKey, methodName);
             return builder.ToImmutable();
         }
 
         private static ImmutableDictionary<string, string?> CreateSingleOperationProperties(OptimizeLinqUsageData data, IInvocationOperation operation)
         {
             var builder = ImmutableDictionary.CreateBuilder<string, string?>(StringComparer.Ordinal);
-            builder.Add("Data", data.ToString());
-            builder.Add("FirstOperationStart", operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
-            builder.Add("FirstOperationLength", operation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.DataKey, data.ToString());
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.FirstOperationStartKey, operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.FirstOperationLengthKey, operation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
             return builder.ToImmutable();
         }
 
         private static ImmutableDictionary<string, string?> CreateDuplicateOrderByProperties(OptimizeLinqUsageData data, IInvocationOperation firstOperation, IInvocationOperation lastOperation, string expectedMethodName, string methodName)
         {
             var builder = ImmutableDictionary.CreateBuilder<string, string?>(StringComparer.Ordinal);
-            builder.Add("Data", data.ToString());
-            builder.Add("FirstOperationStart", firstOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
-            builder.Add("FirstOperationLength", firstOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
-            builder.Add("LastOperationStart", lastOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
-            builder.Add("LastOperationLength", lastOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
-            builder.Add("ExpectedMethodName", expectedMethodName);
-            builder.Add("MethodName", methodName);
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.DataKey, data.ToString());
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.FirstOperationStartKey, firstOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.FirstOperationLengthKey, firstOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.LastOperationStartKey, lastOperation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.LastOperationLengthKey, lastOperation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.ExpectedMethodNameKey, expectedMethodName);
+            builder.Add(OptimizeLinqUsageAnalyzerCommon.MethodNameKey, methodName);
             return builder.ToImmutable();
         }
 
@@ -664,7 +664,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                             // expr.Count() < 10
                             message = string.Create(CultureInfo.InvariantCulture, $"Replace 'Count() < {value}' with 'Skip({value - 1}).Any() == false'");
                             properties = CreateProperties(OptimizeLinqUsageData.UseSkipAndNotAny)
-                                .Add("SkipMinusOne", value: "");
+                                .Add(OptimizeLinqUsageAnalyzerCommon.SkipMinusOneKey, value: "");
                         }
 
                         break;
@@ -731,7 +731,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                             // expr.Count() >= 2
                             message = string.Create(CultureInfo.InvariantCulture, $"Replace 'Count() >= {value}' with 'Skip({value - 1}).Any()'");
                             properties = CreateProperties(OptimizeLinqUsageData.UseSkipAndAny)
-                                .Add("SkipMinusOne", value: "");
+                                .Add(OptimizeLinqUsageAnalyzerCommon.SkipMinusOneKey, value: "");
                         }
 
                         break;
@@ -765,7 +765,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                         // expr.Count() < 10
                         message = "Replace 'Count() < n' with 'Skip(n - 1).Any() == false'";
                         properties = CreateProperties(OptimizeLinqUsageData.UseSkipAndNotAny)
-                            .Add("SkipMinusOne", value: "");
+                            .Add(OptimizeLinqUsageAnalyzerCommon.SkipMinusOneKey, value: "");
                         break;
 
                     case BinaryOperatorKind.LessThanOrEqual:
@@ -784,7 +784,7 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                         // expr.Count() >= 2
                         message = "Replace 'Count() >= n' with 'Skip(n - 1).Any()'";
                         properties = CreateProperties(OptimizeLinqUsageData.UseSkipAndAny)
-                            .Add("SkipMinusOne", value: "");
+                            .Add(OptimizeLinqUsageAnalyzerCommon.SkipMinusOneKey, value: "");
                         break;
                 }
             }
@@ -792,10 +792,10 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (message is not null)
             {
                 properties = properties
-                       .Add("OperandOperationStart", otherOperand.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-                       .Add("OperandOperationLength", otherOperand.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
-                       .Add("CountOperationStart", operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
-                       .Add("CountOperationLength", operation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
+                       .Add(OptimizeLinqUsageAnalyzerCommon.OperandOperationStartKey, otherOperand.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
+                       .Add(OptimizeLinqUsageAnalyzerCommon.OperandOperationLengthKey, otherOperand.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture))
+                       .Add(OptimizeLinqUsageAnalyzerCommon.CountOperationStartKey, operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture))
+                       .Add(OptimizeLinqUsageAnalyzerCommon.CountOperationLengthKey, operation.Syntax.Span.Length.ToString(CultureInfo.InvariantCulture));
 
                 context.ReportDiagnostic(OptimizeCountRule, properties, binaryOperation, message);
             }

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzerCommon.cs
@@ -1,0 +1,17 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class OptimizeLinqUsageAnalyzerCommon
+{
+    internal const string DataKey = "Data";
+    internal const string MethodNameKey = "MethodName";
+    internal const string ExpectedMethodNameKey = "ExpectedMethodName";
+    internal const string FirstOperationStartKey = "FirstOperationStart";
+    internal const string FirstOperationLengthKey = "FirstOperationLength";
+    internal const string LastOperationStartKey = "LastOperationStart";
+    internal const string LastOperationLengthKey = "LastOperationLength";
+    internal const string CountOperationStartKey = "CountOperationStart";
+    internal const string CountOperationLengthKey = "CountOperationLength";
+    internal const string OperandOperationStartKey = "OperandOperationStart";
+    internal const string OperandOperationLengthKey = "OperandOperationLength";
+    internal const string SkipMinusOneKey = "SkipMinusOne";
+}

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
@@ -110,7 +110,7 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
 
         private static ImmutableDictionary<string, string?> CreateProperties(OptimizeStringBuilderUsageData data)
         {
-            return ImmutableDictionary.Create<string, string?>(StringComparer.Ordinal).Add("Data", data.ToString());
+            return ImmutableDictionary.Create<string, string?>(StringComparer.Ordinal).Add(OptimizeStringBuilderUsageAnalyzerCommon.DataKey, data.ToString());
         }
 
         private void AnalyzeAppendFormat(OperationAnalysisContext context, IInvocationOperation operation)
@@ -162,7 +162,7 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
                     else if (constValue.Length == 1)
                     {
                         var properties = CreateProperties(OptimizeStringBuilderUsageData.ReplaceWithChar)
-                            .Add("ConstantValue", constValue);
+                            .Add(OptimizeStringBuilderUsageAnalyzerCommon.ConstantValueKey, constValue);
                         context.ReportDiagnostic(Rule, properties, argument, $"Replace {methodName}(string) with {methodName}(char)");
                         return true;
                     }
@@ -201,7 +201,7 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
                     if (string.Equals(methodName, nameof(StringBuilder.Append), System.StringComparison.Ordinal) || string.Equals(methodName, nameof(StringBuilder.Insert), System.StringComparison.Ordinal))
                     {
                         var properties = CreateProperties(OptimizeStringBuilderUsageData.ReplaceWithChar)
-                            .Add("ConstantValue", constValue);
+                            .Add(OptimizeStringBuilderUsageAnalyzerCommon.ConstantValueKey, constValue);
                         context.ReportDiagnostic(Rule, properties, argument, $"Replace {methodName}(string) with {methodName}(char)");
                         return true;
                     }

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzerCommon.cs
@@ -2,6 +2,9 @@ namespace Meziantou.Analyzer.Rules;
 
 internal static class OptimizeStringBuilderUsageAnalyzerCommon
 {
+    internal const string DataKey = "Data";
+    internal const string ConstantValueKey = "ConstantValue";
+
     public static string? GetConstStringValue(IOperation operation)
     {
         var sb = ObjectPool.SharedStringBuilderPool.Get();

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
@@ -262,10 +262,10 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
         private static ImmutableDictionary<string, string?> CreateProperties(string[] cancellationTokens, AdditionalParameterInfo parameterInfo)
         {
             return ImmutableDictionary.Create<string, string?>(StringComparer.Ordinal)
-                .Add("ParameterIndex", parameterInfo.ParameterIndex.ToString(CultureInfo.InvariantCulture))
-                .Add("ParameterName", parameterInfo.Name)
-                .Add("ParameterIsEnumeratorCancellation", parameterInfo.HasEnumeratorCancellationAttribute.ToString())
-                .Add("CancellationTokens", string.Join(',', cancellationTokens));
+                .Add(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterIndexKey, parameterInfo.ParameterIndex.ToString(CultureInfo.InvariantCulture))
+                .Add(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterNameKey, parameterInfo.Name)
+                .Add(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterIsEnumeratorCancellationKey, parameterInfo.HasEnumeratorCancellationAttribute.ToString())
+                .Add(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.CancellationTokensKey, string.Join(',', cancellationTokens));
         }
 
         private List<ISymbol[]>? GetMembers(ITypeSymbol symbol, int maxDepth)

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerCommon.cs
@@ -1,0 +1,9 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class UseAnOverloadThatHasCancellationTokenAnalyzerCommon
+{
+    internal const string ParameterIndexKey = "ParameterIndex";
+    internal const string ParameterNameKey = "ParameterName";
+    internal const string ParameterIsEnumeratorCancellationKey = "ParameterIsEnumeratorCancellation";
+    internal const string CancellationTokensKey = "CancellationTokens";
+}

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
@@ -130,9 +130,9 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
         private static ImmutableDictionary<string, string?> CreateProperties(string[] cancellationTokens, AdditionalParameterInfo parameterInfo)
         {
             return ImmutableDictionary.Create<string, string?>(StringComparer.Ordinal)
-                .Add("ParameterIndex", parameterInfo.ParameterIndex.ToString(CultureInfo.InvariantCulture))
-                .Add("ParameterName", parameterInfo.Name)
-                .Add("Paths", string.Join(',', cancellationTokens));
+                .Add(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterIndexKey, parameterInfo.ParameterIndex.ToString(CultureInfo.InvariantCulture))
+                .Add(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterNameKey, parameterInfo.Name)
+                .Add(UseAnOverloadThatHasTimeProviderAnalyzerCommon.PathsKey, string.Join(',', cancellationTokens));
         }
 
         private List<ISymbol[]>? GetMembers(ITypeSymbol symbol, int maxDepth)

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzerCommon.cs
@@ -1,0 +1,8 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class UseAnOverloadThatHasTimeProviderAnalyzerCommon
+{
+    internal const string ParameterIndexKey = "ParameterIndex";
+    internal const string ParameterNameKey = "ParameterName";
+    internal const string PathsKey = "Paths";
+}

--- a/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
@@ -108,7 +108,7 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
 
             if (MustUseConfigureAwait(operation.SemanticModel!, context.Options, operation.Syntax, context.CancellationToken))
             {
-                var data = ImmutableDictionary<string, string?>.Empty.Add("kind", "foreach");
+                var data = ImmutableDictionary<string, string?>.Empty.Add(UseConfigureAwaitAnalyzerCommon.KindKey, "foreach");
                 context.ReportDiagnostic(Rule, data, operation.Collection);
             }
 
@@ -167,7 +167,7 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
 
                 if (MustUseConfigureAwait(resources.SemanticModel!, context.Options, resources.Syntax, context.CancellationToken))
                 {
-                    var properties = ImmutableDictionary<string, string?>.Empty.Add("kind", "using");
+                    var properties = ImmutableDictionary<string, string?>.Empty.Add(UseConfigureAwaitAnalyzerCommon.KindKey, "using");
                     context.ReportDiagnostic(Rule, properties, resources);
                 }
             }

--- a/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzerCommon.cs
@@ -1,0 +1,6 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class UseConfigureAwaitAnalyzerCommon
+{
+    internal const string KindKey = "kind";
+}

--- a/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
@@ -176,7 +176,7 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
                                 if (item is XmlTextSyntax { TextTokens: [var codeText] } && CSharpKeywords.Contains(codeText.Text))
                                 {
                                     // The langword attribute is the way to document a keyword, so the language is not needed
-                                    var properties = ImmutableDictionary<string, string?>.Empty.Add("keyword", codeText.Text);
+                                    var properties = ImmutableDictionary<string, string?>.Empty.Add(UseLangwordInXmlCommentAnalyzerCommon.KeywordKey, codeText.Text);
                                     context.ReportDiagnostic(Rule, properties, elementSyntax);
                                     continue;
                                 }

--- a/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzerCommon.cs
@@ -1,0 +1,6 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class UseLangwordInXmlCommentAnalyzerCommon
+{
+    internal const string KeywordKey = "keyword";
+}

--- a/src/Meziantou.Analyzer/Rules/ValidateArgumentsCorrectlyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ValidateArgumentsCorrectlyAnalyzer.cs
@@ -84,7 +84,7 @@ public sealed class ValidateArgumentsCorrectlyAnalyzer : DiagnosticAnalyzer
             if (lastThrowIndex is not null && firstYieldIndex is not null && lastThrowIndex < firstYieldIndex)
             {
                 var properties = ImmutableDictionary.Create<string, string?>(StringComparer.Ordinal)
-                    .Add("Index", lastThrowIndex.Value.ToString(CultureInfo.InvariantCulture));
+                    .Add(ValidateArgumentsCorrectlyAnalyzerCommon.IndexKey, lastThrowIndex.Value.ToString(CultureInfo.InvariantCulture));
 
                 context.ReportDiagnostic(Rule, properties, methodSymbol);
             }

--- a/src/Meziantou.Analyzer/Rules/ValidateArgumentsCorrectlyAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/ValidateArgumentsCorrectlyAnalyzerCommon.cs
@@ -1,0 +1,6 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class ValidateArgumentsCorrectlyAnalyzerCommon
+{
+    internal const string IndexKey = "Index";
+}


### PR DESCRIPTION
## What

The contract binding the code fixers to the analyzers was ~31 string literals duplicated across two projects. An analyzer wrote:

```csharp
builder.Add("CountOperationStart", operation.Syntax.Span.Start.ToString(CultureInfo.InvariantCulture));
```

and its fixer, in a different project, read it back as:

```csharp
var countOperationStart = int.Parse(diagnostic.Properties["CountOperationStart"]!, NumberStyles.Integer, CultureInfo.InvariantCulture);
```

Every written key currently matched every read key, so there was no live bug — but nothing enforced that. Renaming a property was a two-file change with no compile-time or CI signal.

This moves those keys into `Rules/*Common.cs` files, which `src/Meziantou.Analyzer.CodeFixers/Directory.Build.props` already links into the code fixers project via a wildcard. Both sides now reference the same `const string`, so a rename is a compile error. `ArgumentExceptionShouldSpecifyArgumentName` and `UseRegexSourceGenerator` already worked this way; the other ten rules now follow.

| Common file | Keys |
|---|---|
| `OptimizeLinqUsageAnalyzerCommon` (new) | 12 |
| `UseAnOverloadThatHasCancellationTokenAnalyzerCommon` (new) | 4 |
| `AvoidComparisonWithBoolConstantAnalyzerCommon` (new) | 3 |
| `UseAnOverloadThatHasTimeProviderAnalyzerCommon` (new) | 3 |
| `DoNotUseBlockingCallInAsyncContextAnalyzerCommon` (new) | 2 |
| `MethodOverridesShouldNotChangeParameterDefaultsAnalyzerCommon` (new) | 2 |
| `OptimizeStringBuilderUsageAnalyzerCommon` (extended) | 2 |
| `UseConfigureAwaitAnalyzerCommon`, `UseLangwordInXmlCommentAnalyzerCommon`, `ValidateArgumentsCorrectlyAnalyzerCommon` (new) | 1 each |

## Why it mattered

The failure mode was silent and user-visible. These reads run inside `RegisterCodeFixesAsync` or the code action, so a mismatch would leave the analyzer happily reporting a diagnostic while its fix threw `KeyNotFoundException` — the IDE shows "error applying code fix" and the rule looks broken rather than the fixer.

## Validate before registering

The reads that cannot fail gracefully moved out of the code actions and into `RegisterCodeFixesAsync`, per the convention in `AGENTS.md`. A missing or malformed property now means the fix is never offered, instead of throwing once the user invokes it.

- **`OptimizeLinqUsageFixer`** — 20 `int.Parse` calls across five span pairs collapsed into one `TryGetSpan` helper with four named wrappers; the seven fix methods take `TextSpan`/`string`/`bool` parameters instead of a `Diagnostic`. `UseAny`/`UseNotAny` and `UseSkipAndAny`/`UseSkipAndNotAny` differed only by a bool, so they share a case body now.
- **`OptimizeStringBuilderUsageFixer`** — `diagnostic.Properties["ConstantValue"]![0]` also indexed into a possibly-empty string; a list pattern validates it before registering, and the method takes a `char`.
- **`AvoidComparisonWithBoolConstantFixer`**, **`ValidateArgumentsCorrectlyFixer`** — same treatment.
- **`UseAnOverloadThatHasCancellationTokenFixer_Argument`**, **`UseAnOverloadThatHasTimeProviderFixer`** — the last throwing indexer (`Properties["ParameterIndex"]`) became `GetValueOrDefault`, joining the `TryParse` already there.

The `"kind"` read in `UseConfigureAwaitFixer` deliberately stays inside its code action: it is genuinely optional, and the fixer has a working fallback path for the `AwaitExpressionSyntax` case.

## Notes for the reviewer

- No rule behavior changes — this is a refactor. `dotnet run --project src/DocumentationGenerator` exits 0 and changes no markdown, as expected.
- `grep` for `Properties["…"]`, `TryGetValue("…"`, `ContainsKey("…"` and `.Add("<Key>"` now returns nothing across `src/`.
- The new files need no project changes: `Directory.Build.props:45` already globs `Rules/*Common.cs`.
- **Not covered:** nothing stops a *new* rule from reintroducing raw literals — the compile-time link only protects keys once they live in a `*Common.cs`. A `BannedSymbols.txt`-style guard or a convention test could close that; happy to add one if you want it in this PR.

## Testing

Built and tested against all five supported Roslyn versions, all green:

| Version | Tests |
|---|---|
| roslyn4.8 | 3797 passed |
| roslyn4.14 | 3824 passed |
| roslyn5.0 | 3852 passed |
| roslyn5.6 | 3876 passed |
| roslyn5.9 | 3909 passed |

`dotnet build` across every version: 0 warnings, 0 errors.

One caveat worth flagging: `dotnet test` reported "Zero tests ran" (exit 5) in my local sandbox regardless of filters, including with no filter at all. That looks like an environment issue rather than anything in this branch — running each `Meziantou.Analyzer.Test.dll` directly produced the counts above. CI should be the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)