### PR TITLE
Avoid the control flow analysis of MA0004 when the context is irrelevant

### DIFF
--- a/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Meziantou.Analyzer.Configurations;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -30,10 +31,7 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
         context.RegisterCompilationStartAction(ctx =>
         {
             var analyzerContext = new AnalyzerContext(ctx.Compilation);
-            ctx.RegisterOperationAction(analyzerContext.AnalyzeAwaitOperation, OperationKind.Await);
-            ctx.RegisterOperationAction(analyzerContext.AnalyzeForEachStatement, OperationKind.Loop);
-            ctx.RegisterOperationAction(analyzerContext.AnalyzeUsingOperation, OperationKind.Using);
-            ctx.RegisterOperationAction(analyzerContext.AnalyzeUsingDeclarationOperation, OperationKind.UsingDeclaration);
+            ctx.RegisterOperationBlockStartAction(analyzerContext.AnalyzeOperationBlockStart);
         });
     }
 
@@ -56,6 +54,56 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
         private INamedTypeSymbol? AspNetCore_ITagHelperComponent { get; } = compilation.GetBestTypeByMetadataName("Microsoft.AspNetCore.Razor.TagHelpers.ITagHelperComponent");
         private INamedTypeSymbol? AspNetCore_IFilterMetadata { get; } = compilation.GetBestTypeByMetadataName("Microsoft.AspNetCore.Mvc.Filters.IFilterMetadata");
         private INamedTypeSymbol? AspNetCore_IComponent { get; } = compilation.GetBestTypeByMetadataName("Microsoft.AspNetCore.Components.IComponent");
+
+        public void AnalyzeOperationBlockStart(OperationBlockStartAnalysisContext context)
+        {
+            // The containing type is the same for all the operations of the block, so the framework types
+            // are only checked once per operation block instead of once per await
+            var blockContext = new OperationBlockContext(this, HasSynchronizationContext(context.OwningSymbol.ContainingType));
+            context.RegisterOperationAction(blockContext.AnalyzeAwaitOperation, OperationKind.Await);
+            context.RegisterOperationAction(blockContext.AnalyzeForEachStatement, OperationKind.Loop);
+            context.RegisterOperationAction(blockContext.AnalyzeUsingOperation, OperationKind.Using);
+            context.RegisterOperationAction(blockContext.AnalyzeUsingDeclarationOperation, OperationKind.UsingDeclaration);
+        }
+
+        private bool HasSynchronizationContext(INamedTypeSymbol? containingType)
+        {
+            if (containingType is null)
+                return false;
+
+            return containingType.InheritsFrom(WPF_DispatcherObject) ||
+                   containingType.Implements(WPF_ICommand) ||
+                   containingType.InheritsFrom(WinForms_Control) || // WinForms
+                   containingType.InheritsFrom(WebForms_WebControl) || // ASP.NET (Webforms)
+                   containingType.InheritsFrom(AspNetCore_ControllerBase) || // ASP.NET Core (as there is no SynchronizationContext, ConfigureAwait(false) is useless)
+                   containingType.Implements(AspNetCore_IRazorPage) || // ASP.NET Core
+                   containingType.Implements(AspNetCore_ITagHelper) || // ASP.NET Core
+                   containingType.Implements(AspNetCore_ITagHelperComponent) || // ASP.NET Core
+                   containingType.Implements(AspNetCore_IFilterMetadata) ||
+                   containingType.Implements(AspNetCore_IComponent); // Blazor has a synchronization context, see https://github.com/meziantou/Meziantou.Analyzer/issues/96
+        }
+
+        public bool IsConfiguredAsyncDisposable(ITypeSymbol type) => type.IsEqualTo(ConfiguredAsyncDisposableSymbol);
+
+        public bool IsConfiguredCancelableAsyncEnumerable(ITypeSymbol type) => type.OriginalDefinition.IsEqualTo(ConfiguredCancelableAsyncEnumerableSymbol);
+
+        public bool IsAsyncEnumerable(ITypeSymbol? type) => type.IsEqualTo(IAsyncEnumerableSymbol);
+
+        public bool IsConfiguredTaskAwaitable(SemanticModel semanticModel, AwaitExpressionSyntax awaitSyntax, CancellationToken cancellationToken)
+        {
+            var awaitExpressionType = semanticModel.GetTypeInfo(awaitSyntax.Expression, cancellationToken).ConvertedType;
+            if (awaitExpressionType is null)
+                return false;
+
+            return ConfiguredTaskAwaitableSymbol.IsEqualTo(awaitExpressionType) ||
+                   ConfiguredTaskAwaitableOfTSymbol.IsEqualTo(awaitExpressionType.OriginalDefinition);
+        }
+    }
+
+    private sealed class OperationBlockContext(AnalyzerContext analyzerContext, bool hasSynchronizationContext)
+    {
+        private ConfiguredAwaits? _configuredAwaits;
+        private ConcurrentDictionary<StatementSyntax, bool>? _endPointIsReachable;
 
         public void AnalyzeAwaitOperation(OperationAnalysisContext context)
         {
@@ -90,7 +138,7 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
             if (collectionType is null)
                 return;
 
-            if (collectionType.OriginalDefinition.IsEqualTo(ConfiguredCancelableAsyncEnumerableSymbol))
+            if (analyzerContext.IsConfiguredCancelableAsyncEnumerable(collectionType))
             {
                 // Enumerable().WithCancellation(ct) or Enumerable().ConfigureAwait(false)
                 if (HasConfigureAwait(operation.Collection) && HasPartOfTypeIAsyncEnumerable(operation.Collection))
@@ -131,7 +179,7 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
 
             bool HasPartOfTypeIAsyncEnumerable(IOperation operation)
             {
-                if (operation.Type.IsEqualTo(IAsyncEnumerableSymbol))
+                if (analyzerContext.IsAsyncEnumerable(operation.Type))
                     return true;
 
                 foreach (var child in operation.GetChildOperations())
@@ -193,7 +241,7 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
 
                     // ConfiguredCancelableAsyncEnumerable
                     var variableType = declarator.Initializer.Value.GetActualType(context.CancellationToken);
-                    if (variableType is null || variableType.IsEqualTo(ConfiguredAsyncDisposableSymbol))
+                    if (variableType is null || analyzerContext.IsConfiguredAsyncDisposable(variableType))
                         return;
 
                     if (!CanAddConfigureAwait(variableType, declarator.Initializer.Value))
@@ -216,87 +264,102 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
                     return true;
             }
 
-            if (HasPreviousConfigureAwait(semanticModel, node, cancellationToken))
+            // The context detection can only prevent the diagnostic from being reported, and a previous
+            // ConfigureAwait(false) in the same method overrides it. So, when the code is not in a context that
+            // has a SynchronizationContext, the result is the same whatever the previous awaits are, and there is
+            // no need to run the expensive control flow analysis of HasPreviousConfigureAwait.
+            if (!hasSynchronizationContext && !IsInUnitTestMethod(semanticModel, node, cancellationToken))
                 return true;
 
-            var containingClass = GetParentSymbol<INamedTypeSymbol>(semanticModel, node, cancellationToken);
-            if (containingClass is not null)
-            {
-                if (containingClass.InheritsFrom(WPF_DispatcherObject) ||
-                    containingClass.Implements(WPF_ICommand) ||
-                    containingClass.InheritsFrom(WinForms_Control) || // WinForms
-                    containingClass.InheritsFrom(WebForms_WebControl) || // ASP.NET (Webforms)
-                    containingClass.InheritsFrom(AspNetCore_ControllerBase) || // ASP.NET Core (as there is no SynchronizationContext, ConfigureAwait(false) is useless)
-                    containingClass.Implements(AspNetCore_IRazorPage) || // ASP.NET Core
-                    containingClass.Implements(AspNetCore_ITagHelper) || // ASP.NET Core
-                    containingClass.Implements(AspNetCore_ITagHelperComponent) || // ASP.NET Core
-                    containingClass.Implements(AspNetCore_IFilterMetadata) ||
-                    containingClass.Implements(AspNetCore_IComponent))  // Blazor has a synchronization context, see https://github.com/meziantou/Meziantou.Analyzer/issues/96
-                {
-                    return false;
-                }
-            }
+            // If ConfigureAwait(false) is used somewhere in the method, all the following awaits should use it too
+            return HasPreviousConfigureAwait(semanticModel, node, cancellationToken);
+        }
 
+        private static bool IsInUnitTestMethod(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
+        {
             var containingMethod = GetParentSymbol<IMethodSymbol>(semanticModel, node, cancellationToken);
-            if (containingMethod is not null && containingMethod.IsUnitTestMethod())
-                return false;
-
-            return true;
+            return containingMethod is not null && containingMethod.IsUnitTestMethod();
         }
 
         private bool HasPreviousConfigureAwait(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
         {
             // Find all previous awaits with ConfiguredAwait(false)
-            // Use context.SemanticModel.AnalyzeControlFlow to check if the current await is accessible from one of the previous await
+            // Use semanticModel.AnalyzeControlFlow to check if the current await is accessible from one of the previous await
             // https://joshvarty.com/2015/03/24/learn-roslyn-now-control-flow-analysis/
             var method = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-            if (method is not null)
+            if (method is null)
+                return false;
+
+            var configuredAwaits = GetConfiguredAwaits(semanticModel, method, cancellationToken);
+            if (configuredAwaits.Length == 0)
+                return false;
+
+            var nodeStart = node.SpanStart;
+            var nodeStatement = node.FirstAncestorOrSelf<StatementSyntax>();
+            foreach (var otherAwaitExpression in configuredAwaits)
             {
-                var otherAwaitExpressions = method.DescendantNodes(_ => true).OfType<AwaitExpressionSyntax>();
-                foreach (var expr in otherAwaitExpressions)
-                {
-                    if (HasPreviousConfigureAwait(expr))
-                        return true;
+                // The awaits are ordered by position, so the next ones cannot be before the current node
+                if (otherAwaitExpression.SpanStart > nodeStart)
+                    break;
 
-                    bool HasPreviousConfigureAwait(AwaitExpressionSyntax otherAwaitExpression)
-                    {
-                        if (otherAwaitExpression == node)
-                            return false;
+                if (otherAwaitExpression == node)
+                    continue;
 
-                        if (otherAwaitExpression.GetLocation().SourceSpan.Start > node.GetLocation().SourceSpan.Start)
-                            return false;
-
-                        if (!IsConfiguredTaskAwaitable(semanticModel, otherAwaitExpression, cancellationToken))
-                            return false;
-
-                        var nodeStatement = node.FirstAncestorOrSelf<StatementSyntax>();
-                        var parentStatement = otherAwaitExpression.Ancestors().OfType<StatementSyntax>().FirstOrDefault();
-                        while (parentStatement is not null && nodeStatement != parentStatement)
-                        {
-                            if (!IsEndPointReachable(semanticModel, parentStatement))
-                                return false;
-
-                            parentStatement = parentStatement.Ancestors().OfType<StatementSyntax>().FirstOrDefault();
-                        }
-
-                        return true;
-                    }
-                }
+                if (IsReachableFrom(semanticModel, otherAwaitExpression, nodeStatement))
+                    return true;
             }
 
             return false;
         }
 
-        private static bool IsEndPointReachable(SemanticModel semanticModel, StatementSyntax statementSyntax)
+        private bool IsReachableFrom(SemanticModel semanticModel, AwaitExpressionSyntax otherAwaitExpression, StatementSyntax? nodeStatement)
         {
-            var result = semanticModel.AnalyzeControlFlow(statementSyntax);
-            if (result is null || !result.Succeeded)
-                return false;
+            var parentStatement = otherAwaitExpression.Ancestors().OfType<StatementSyntax>().FirstOrDefault();
+            while (parentStatement is not null && nodeStatement != parentStatement)
+            {
+                if (!IsEndPointReachable(semanticModel, parentStatement))
+                    return false;
 
-            if (!result.EndPointIsReachable)
-                return false;
+                parentStatement = parentStatement.Ancestors().OfType<StatementSyntax>().FirstOrDefault();
+            }
 
             return true;
+        }
+
+        private AwaitExpressionSyntax[] GetConfiguredAwaits(SemanticModel semanticModel, MethodDeclarationSyntax method, CancellationToken cancellationToken)
+        {
+            // All the operations of a block belong to the same method, so the awaits of the method are only
+            // enumerated once instead of once per await
+            var cached = _configuredAwaits;
+            if (cached is not null && cached.Method == method)
+                return cached.Awaits;
+
+            List<AwaitExpressionSyntax>? awaits = null;
+            foreach (var awaitExpression in method.DescendantNodes(_ => true).OfType<AwaitExpressionSyntax>())
+            {
+                if (analyzerContext.IsConfiguredTaskAwaitable(semanticModel, awaitExpression, cancellationToken))
+                {
+                    awaits ??= [];
+                    awaits.Add(awaitExpression);
+                }
+            }
+
+            var result = awaits is null ? [] : awaits.ToArray();
+            _configuredAwaits = new ConfiguredAwaits(method, result);
+            return result;
+        }
+
+        private bool IsEndPointReachable(SemanticModel semanticModel, StatementSyntax statementSyntax)
+        {
+            // The same statements are walked over and over while looking for the awaits of a method
+            var cache = _endPointIsReachable ??= new ConcurrentDictionary<StatementSyntax, bool>();
+            if (cache.TryGetValue(statementSyntax, out var isReachable))
+                return isReachable;
+
+            var result = semanticModel.AnalyzeControlFlow(statementSyntax);
+            isReachable = result is not null && result.Succeeded && result.EndPointIsReachable;
+            cache[statementSyntax] = isReachable;
+            return isReachable;
         }
 
         private static bool CanAddConfigureAwait(ITypeSymbol awaitedType, IOperation operation)
@@ -306,22 +369,12 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
 
         private static bool CanAddConfigureAwait(ITypeSymbol awaitedType, SemanticModel semanticModel, SyntaxNode node)
         {
-            var location = node.GetLocation().SourceSpan.End;
+            var location = node.Span.End;
             var result = semanticModel.LookupSymbols(location, container: awaitedType, name: "ConfigureAwait", includeReducedExtensionMethods: true);
             if (result.Length > 0)
                 return true;
 
             return false;
-        }
-
-        private bool IsConfiguredTaskAwaitable(SemanticModel semanticModel, AwaitExpressionSyntax awaitSyntax, CancellationToken cancellationToken)
-        {
-            var awaitExpressionType = semanticModel.GetTypeInfo(awaitSyntax.Expression, cancellationToken).ConvertedType;
-            if (awaitExpressionType is null)
-                return false;
-
-            return ConfiguredTaskAwaitableSymbol.IsEqualTo(awaitExpressionType) ||
-                   ConfiguredTaskAwaitableOfTSymbol.IsEqualTo(awaitExpressionType.OriginalDefinition);
         }
 
         private static T? GetParentSymbol<T>(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken) where T : class, ISymbol
@@ -338,10 +391,16 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
             return default;
         }
 
-        private enum ReportMode
+        private sealed class ConfiguredAwaits(MethodDeclarationSyntax method, AwaitExpressionSyntax[] awaits)
         {
-            DetectContext,
-            Always,
+            public MethodDeclarationSyntax Method { get; } = method;
+            public AwaitExpressionSyntax[] Awaits { get; } = awaits;
         }
+    }
+
+    private enum ReportMode
+    {
+        DetectContext,
+        Always,
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
@@ -850,4 +850,184 @@ public sealed class UseConfigureAwaitAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task LocalFunction_ShouldReportError()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                void Test()
+                {
+                    async Task LocalAsync()
+                    {
+                        {|MA0004:await Task.Delay(1)|};
+                    }
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                void Test()
+                {
+                    async Task LocalAsync()
+                    {
+                        await Task.Delay(1).ConfigureAwait(false);
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Lambda_InFieldInitializer_ShouldReportError()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                Func<Task> _value = async () => {|MA0004:await Task.Delay(1)|};
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                Func<Task> _value = async () => await Task.Delay(1).ConfigureAwait(false);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Lambda_InWpfWindowClass_ShouldNotReportError()
+    {
+        var test = CreateTest();
+        test.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net48.Wpf;
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class MyClass : System.Windows.Window
+            {
+                void Test()
+                {
+                    Func<Task> value = async () => await Task.Delay(1);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AfterConfigureAwaitFalse_InLambda_InWpfWindowClass_ShouldReportError()
+    {
+        var test = CreateTest();
+        test.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net48.Wpf;
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class MyClass : System.Windows.Window
+            {
+                async Task Test()
+                {
+                    await Task.Delay(1).ConfigureAwait(false);
+                    Func<Task> value = async () => {|MA0004:await Task.Delay(1)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Threading.Tasks;
+            class MyClass : System.Windows.Window
+            {
+                async Task Test()
+                {
+                    await Task.Delay(1).ConfigureAwait(false);
+                    Func<Task> value = async () => await Task.Delay(1).ConfigureAwait(false);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AfterConfigureAwaitFalse_InUnitTestMethod_ShouldReportError()
+    {
+        var test = CreateTest();
+        test.ReferenceAssemblies = test.ReferenceAssemblies.AddXunitV3();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                [Xunit.Fact]
+                async Task Test()
+                {
+                    await Task.Delay(1).ConfigureAwait(false);
+                    {|MA0004:await Task.Delay(1)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                [Xunit.Fact]
+                async Task Test()
+                {
+                    await Task.Delay(1).ConfigureAwait(false);
+                    await Task.Delay(1).ConfigureAwait(false);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AwaitInPropertyAccessorLocalFunction_ShouldReportError()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                Task Value
+                {
+                    get
+                    {
+                        async Task LocalAsync() => {|MA0004:await Task.Delay(1)|};
+                        return LocalAsync();
+                    }
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                Task Value
+                {
+                    get
+                    {
+                        async Task LocalAsync() => await Task.Delay(1).ConfigureAwait(false);
+                        return LocalAsync();
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## What

`UseConfigureAwaitAnalyzer` (MA0004) called `HasPreviousConfigureAwait` — which walks the whole enclosing method and calls `SemanticModel.AnalyzeControlFlow` — **before** the far cheaper containing-type and unit-test-method checks. For a method with N awaits that meant N full syntax traversals, O(N²) `GetTypeInfo` calls, and O(N × nesting depth) `AnalyzeControlFlow` calls, plus a `Location` allocation per comparison.

`AnalyzeControlFlow` is one of the most expensive `SemanticModel` APIs (it rebinds the statement and builds a region CFG), and MA0004 is enabled by default, so await-dense business logic paid the full cost on every keystroke in the IDE.

## Why the obvious reorder does not work

The checks are **not** independent filters. A previous `ConfigureAwait(false)` in the method *overrides* the context detection: `AfterConfigureAwaitFalse_AllAwaitShouldUseConfigureAwait` asserts that inside a WPF `Window`, an await following a `ConfigureAwait(false)` **is** reported. Simply moving the containing-type check first would silence it.

The equivalent-but-cheap reordering is different: run the context checks first, and when *neither* matches, return `true` immediately — both branches yield `true` in that case, so the control-flow analysis is provably redundant.

```csharp
// The context detection can only prevent the diagnostic from being reported, and a previous
// ConfigureAwait(false) in the same method overrides it. So, when the code is not in a context that
// has a SynchronizationContext, the result is the same whatever the previous awaits are, and there is
// no need to run the expensive control flow analysis of HasPreviousConfigureAwait.
if (!hasSynchronizationContext && !IsInUnitTestMethod(semanticModel, node, cancellationToken))
    return true;

return HasPreviousConfigureAwait(semanticModel, node, cancellationToken);
```

This removes `AnalyzeControlFlow` entirely from code that is not a WPF, WinForms, ASP.NET, Blazor or unit-test type — the common case.

## Changes

- Switched to `RegisterOperationBlockStartAction` with a per-block `OperationBlockContext` holding the hoisted state.
- **Containing-type check hoisted to the block** (`OwningSymbol.ContainingType`): the ~10 `InheritsFrom`/`Implements` calls now run once per method instead of once per await.
- **Configured awaits computed once per method** and cached: the `DescendantNodes` walk plus `GetTypeInfo` per await went from O(N) walks / O(N²) `GetTypeInfo` to one walk / O(N) `GetTypeInfo`.
- **`AnalyzeControlFlow` results memoized** per block — the statement-ancestor chains overlap heavily across the awaits of a method.
- **Early `break`** once the candidate list passes the node's position (the list is in document order), instead of scanning every await and rejecting it.
- **`GetLocation()` replaced by `SpanStart` / `Span.End`** in the hot comparisons and in `CanAddConfigureAwait`.

The unit-test check still uses per-node `GetEnclosingSymbol`, deliberately: it resolves to the *lambda* for an await inside a lambda, and hoisting it to `OwningSymbol` would have changed reporting there.

## Notes for the reviewer

Behavior is unchanged; no documentation update was needed (`dotnet run --project src/DocumentationGenerator` reports no changes).

Six tests were added covering the constructs the switch to operation blocks touches — local functions, lambdas in field initializers, lambdas in a WPF class, a lambda after a `ConfigureAwait(false)` in a WPF class, a unit-test method after a `ConfigureAwait(false)`, and an async local function in a property accessor. **All six were verified to pass against the previous implementation as well**, so they pin existing behavior rather than encoding the refactor's.

The full suite passes on every supported Roslyn version: 19288 tests, 0 failures (4.8, 4.14, 5.0, 5.6, 5.9), and the solution builds with 0 warnings.