### PR TITLE
Clear the pooled queue of UseLangwordInXmlCommentAnalyzer on return

### DIFF
--- a/src/Meziantou.Analyzer/Internals/ObjectPool.cs
+++ b/src/Meziantou.Analyzer/Internals/ObjectPool.cs
@@ -41,6 +41,12 @@ internal static class ObjectPool
         var provider = new DefaultObjectPoolProvider();
         return provider.Create(new StringBuilderPooledObjectPolicy());
     }
+
+    public static ObjectPool<Queue<T>> CreateQueuePool<T>()
+    {
+        var provider = new DefaultObjectPoolProvider();
+        return provider.Create(new QueuePooledObjectPolicy<T>());
+    }
 }
 
 /// <summary>
@@ -342,6 +348,40 @@ internal sealed class StringBuilderPooledObjectPolicy : PooledObjectPolicy<Strin
             return false;
         }
 
+        obj.Clear();
+        return true;
+    }
+}
+
+/// <summary>
+/// A policy for pooling <see cref="Queue{T}"/> instances.
+/// </summary>
+/// <typeparam name="T">The type of the items of the pooled queues.</typeparam>
+internal sealed class QueuePooledObjectPolicy<T> : PooledObjectPolicy<Queue<T>>
+{
+    /// <summary>
+    /// Gets or sets the maximum number of items a <see cref="Queue{T}"/> can contain to be retained,
+    /// when <see cref="Return(Queue{T})"/> is invoked.
+    /// </summary>
+    /// <value>Defaults to <c>1024</c>.</value>
+    public int MaximumRetainedCount { get; set; } = 1024;
+
+    /// <inheritdoc />
+    public override Queue<T> Create()
+    {
+        return new Queue<T>();
+    }
+
+    /// <inheritdoc />
+    public override bool Return(Queue<T> obj)
+    {
+        if (obj.Count > MaximumRetainedCount)
+        {
+            // Too big. Discard this one.
+            return false;
+        }
+
+        // Clear the queue so the pool does not keep the items alive
         obj.Clear();
         return true;
     }

--- a/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
@@ -6,7 +6,7 @@ namespace Meziantou.Analyzer.Rules;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly ObjectPool<Queue<SyntaxNode>> NodeQueuePool = ObjectPool.Create<Queue<SyntaxNode>>();
+    private static readonly ObjectPool<Queue<SyntaxNode>> NodeQueuePool = ObjectPool.CreateQueuePool<SyntaxNode>();
 
     private static readonly HashSet<string> CSharpKeywords = new(StringComparer.Ordinal)
     {
@@ -158,43 +158,48 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
                 // <code>{keyword}</code>
 
                 var queue = NodeQueuePool.Get();
-                foreach (var item in documentation.ChildNodes())
+                try
                 {
-                    queue.Enqueue(item);
-                }
-
-                while (queue.TryDequeue(out var childNode))
-                {
-                    if (childNode is XmlElementSyntax elementSyntax)
+                    foreach (var item in documentation.ChildNodes())
                     {
-                        var elementName = elementSyntax.StartTag.Name.LocalName.Text;
-                        if (string.Equals(elementName, "c", StringComparison.OrdinalIgnoreCase) || string.Equals(elementName, "code", StringComparison.OrdinalIgnoreCase))
-                        {
-                            if (elementSyntax.StartTag.Attributes.Count == 0)
-                            {
-                                var item = elementSyntax.Content.SingleOrDefaultIfMultiple();
-                                if (item is XmlTextSyntax { TextTokens: [var codeText] } && CSharpKeywords.Contains(codeText.Text))
-                                {
-                                    // The langword attribute is the way to document a keyword, so the language is not needed
-                                    var properties = ImmutableDictionary<string, string?>.Empty.Add("keyword", codeText.Text);
-                                    context.ReportDiagnostic(Rule, properties, elementSyntax);
-                                    continue;
-                                }
-                            }
+                        queue.Enqueue(item);
+                    }
 
-                            AnalyzeLanguageAttributes(context, elementSyntax);
-                        }
-                        else
+                    while (queue.TryDequeue(out var childNode))
+                    {
+                        if (childNode is XmlElementSyntax elementSyntax)
                         {
-                            foreach (var child in elementSyntax.Content)
+                            var elementName = elementSyntax.StartTag.Name.LocalName.Text;
+                            if (string.Equals(elementName, "c", StringComparison.OrdinalIgnoreCase) || string.Equals(elementName, "code", StringComparison.OrdinalIgnoreCase))
                             {
-                                queue.Enqueue(child);
+                                if (elementSyntax.StartTag.Attributes.Count == 0)
+                                {
+                                    var item = elementSyntax.Content.SingleOrDefaultIfMultiple();
+                                    if (item is XmlTextSyntax { TextTokens: [var codeText] } && CSharpKeywords.Contains(codeText.Text))
+                                    {
+                                        // The langword attribute is the way to document a keyword, so the language is not needed
+                                        var properties = ImmutableDictionary<string, string?>.Empty.Add("keyword", codeText.Text);
+                                        context.ReportDiagnostic(Rule, properties, elementSyntax);
+                                        continue;
+                                    }
+                                }
+
+                                AnalyzeLanguageAttributes(context, elementSyntax);
+                            }
+                            else
+                            {
+                                foreach (var child in elementSyntax.Content)
+                                {
+                                    queue.Enqueue(child);
+                                }
                             }
                         }
                     }
                 }
-
-                NodeQueuePool.Return(queue);
+                finally
+                {
+                    NodeQueuePool.Return(queue);
+                }
             }
         }
     }

--- a/tests/Meziantou.Analyzer.Test/Internals/ObjectPoolTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Internals/ObjectPoolTests.cs
@@ -1,0 +1,39 @@
+using Meziantou.Analyzer.Internals;
+
+namespace Meziantou.Analyzer.Test.Internals;
+
+public sealed class ObjectPoolTests
+{
+    [Fact]
+    public void QueuePooledObjectPolicy_ClearsTheQueueOnReturn()
+    {
+        var policy = new QueuePooledObjectPolicy<object>();
+        var queue = policy.Create();
+        queue.Enqueue(new object());
+
+        Assert.True(policy.Return(queue));
+        Assert.Empty(queue);
+    }
+
+    [Fact]
+    public void QueuePooledObjectPolicy_DoesNotRetainOversizedQueues()
+    {
+        var policy = new QueuePooledObjectPolicy<object> { MaximumRetainedCount = 1 };
+        var queue = policy.Create();
+        queue.Enqueue(new object());
+        queue.Enqueue(new object());
+
+        Assert.False(policy.Return(queue));
+    }
+
+    [Fact]
+    public void QueuePool_DoesNotKeepTheItemsAlive()
+    {
+        var pool = ObjectPool.CreateQueuePool<object>();
+        var queue = pool.Get();
+        queue.Enqueue(new object());
+        pool.Return(queue);
+
+        Assert.Empty(pool.Get());
+    }
+}


### PR DESCRIPTION
`UseLangwordInXmlCommentAnalyzer` keeps an assembly-static `ObjectPool<Queue<SyntaxNode>>`. It was created with `DefaultPooledObjectPolicy<T>`, whose `Return` only resets the object when it implements `IResettable`. `Queue<SyntaxNode>` does not, so the policy returned `true` without clearing the queue.

## What was wrong

**The pool could park `SyntaxNode` instances in a static.** This was latent rather than live: the `while (queue.TryDequeue(...))` traversal always drained the queue before returning it, so nothing was actually retained. But the "empty on return" invariant was enforced only by the shape of the loop — a future `break`, early `return`, or `continue` would silently have turned the static into a `SyntaxNode` -> `SyntaxTree` -> `Compilation` pin, retaining hundreds of MB per solution reload in Visual Studio and invisible in tests.

**The rent/return pair was not exception safe.** `context.ReportDiagnostic` routes through `syntaxTree.IsGeneratedCode(...)` -> `GetRoot(cancellationToken)`, which throws `OperationCanceledException` when the IDE cancels the analysis on a keystroke. On that path the queue was never returned to the pool at all.

## What changed

- Added `QueuePooledObjectPolicy<T>` in `ObjectPool.cs`, mirroring the existing `StringBuilderPooledObjectPolicy`. It clears the queue on return, so the pool never keeps the items alive, and rejects the queues holding more than `MaximumRetainedCount` (1024) items so an oversized backing array is not retained. Added `ObjectPool.CreateQueuePool<T>()` next to `CreateStringBuilderPool()`.
- `UseLangwordInXmlCommentAnalyzer` uses that pool, and its traversal is wrapped in `try`/`finally`. On the cancellation path the queue is now returned *and* cleared.
- Added `ObjectPoolTests`: the policy clears on return, rejects the oversized queues, and a rented-then-returned queue comes back empty from the pool. No existing test file covered the pool.

The invariant is now enforced by the policy instead of the shape of the loop, so a later edit to the traversal cannot reintroduce the pin.

## Notes for the reviewer

The pool is kept rather than replaced by a plain local: the fixed policy preserves the original allocation-avoidance intent at no correctness cost. Dropping the pool here would also be reasonable, as the queue is per-documentation-comment and small.

There is no behavior change for the reported diagnostics, so no documentation update: `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown change.

## Validation

- `dotnet build` of the analyzer succeeds for both target frameworks (`net10.0`, `netstandard2.0`), 0 warnings.
- Tests pass on the five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9): 29 tests each — the 26 existing `UseLangwordInXmlComment` tests plus the 3 new pool tests, 0 failures.