### PR TITLE
Rename tests that assert no diagnostic but are named *_ShouldReport*

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -421,7 +421,7 @@ public sealed class NamedParameterAnalyzerTests
     }
 
     [Fact]
-    public Task False_ShouldReportDiagnostic()
+    public Task False_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
         test.TestCode = """
@@ -438,7 +438,7 @@ public sealed class NamedParameterAnalyzerTests
     }
 
     [Fact]
-    public Task Null_ShouldReportDiagnostic()
+    public Task Null_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
         test.TestCode = """

--- a/tests/Meziantou.Analyzer.Test/Rules/UseArrayEmptyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseArrayEmptyAnalyzerTests.cs
@@ -39,7 +39,7 @@ public sealed class UseArrayEmptyAnalyzerTests
     [Theory]
     [InlineData("new int[1]")]
     [InlineData("new int[] { 0 }")]
-    public Task NonEmptyArray_ShouldReportError(string code)
+    public Task NonEmptyArray_ShouldNotReportError(string code)
     {
         var test = CreateTest();
         test.TestCode = $$"""

--- a/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseIFormatProviderAnalyzerTests.cs
@@ -42,7 +42,7 @@ public sealed class UseIFormatProviderAnalyzerTests
     }
 
     [Fact]
-    public Task Int32_PositiveToStringWithoutCultureInfo_ShouldReportDiagnostic()
+    public Task Int32_PositiveToStringWithoutCultureInfo_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
         test.TestCode = """


### PR DESCRIPTION
## What changed

Five tests have no diagnostic markup and no `ExpectedDiagnostics`, so they assert that **nothing** is reported — but their names claim the opposite:

| File | Old name | New name |
|---|---|---|
| `NamedParameterAnalyzerTests.cs` | `False_ShouldReportDiagnostic` | `False_ShouldNotReportDiagnostic` |
| `NamedParameterAnalyzerTests.cs` | `Null_ShouldReportDiagnostic` | `Null_ShouldNotReportDiagnostic` |
| `UseArrayEmptyAnalyzerTests.cs` | `NonEmptyArray_ShouldReportError` | `NonEmptyArray_ShouldNotReportError` |
| `UseIFormatProviderAnalyzerTests.cs` | `Int32_PositiveToStringWithoutCultureInfo_ShouldReportDiagnostic` | `Int32_PositiveToStringWithoutCultureInfo_ShouldNotReportDiagnostic` |

(The `NonEmptyArray` entry is a `[Theory]` with two `[InlineData]` cases, hence five tests from four methods.)

## Why

The assertions are already **correct** — no diagnostic is the right expectation for each snippet:

- `object.Equals(false, "")` / `object.Equals(null, "")` — `object.Equals` is excluded by `NamedParameterAnalyzer.cs:200`.
- `new int[1]` / `new int[] { 0 }` — a non-empty array is not replaceable by `Array.Empty`.
- `1.ToString()` — not culture-sensitive, unlike the sibling `(-1).ToString()` test right above it.

Only the names are wrong. A reviewer scanning the test list believes positive coverage exists where it does not, which is the shape of problem that lets a genuinely inverted test survive unnoticed.

## Notes for the reviewer

- Rename only. No snippet, assertion or analyzer code is touched.
- Each file keeps its own local suffix convention (`...Error` in `UseArrayEmptyAnalyzerTests`, `...Diagnostic` in the other two), matching the sibling tests already there.
- Verified with `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn5.9.csproj` filtered to the three classes: 178 passed, 0 failed. The TRX confirms all five renamed tests ran under their new names.
- Test-only change with no analyzer or documentation-comment edits, so `DocumentationGenerator` output is unaffected and the other Roslyn versions are not impacted.