### PR TITLE
Remove the two NuGet audit suppressions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,9 +37,4 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-7jgj-8wvc-jh57" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-cmhx-cq75-c4mj" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## What

Removes the two `NuGetAuditSuppress` entries from the repository root `Directory.Build.props`:

| Advisory | Package | Affected versions | Severity |
|---|---|---|---|
| GHSA-7jgj-8wvc-jh57 | `System.Net.Http` | `< 4.3.4` | High |
| GHSA-cmhx-cq75-c4mj | `System.Text.RegularExpressions` | `4.3.0` | High |

## Why

Both entries were added in f8076852 ("Update .NET SDK 9.0") with no comment naming the dependency that pulled them in or the condition for removing them. They are unconditional exemptions in the file every project imports, so beyond being undocumented they would also silence these two high severity advisories if a new dependency ever reintroduced them — in a repository whose audit is otherwise strict (`NuGetAudit=true`, `NuGetAuditMode=all`, `NuGetAuditLevel=low`, and NU1901-NU1904 promoted to errors).

Neither is needed any more: nothing in the current dependency graph trips either advisory.

## Verification

- Restored the whole solution with `--force`, `NuGetAuditLevel=low` and `NuGetAuditMode=all` after the removal: no NU19xx, no warnings, across all 19 projects and all five Roslyn versions (including `roslyn4.8` with its older Roslyn packages).
- **Positive control**, since a clean restore only means something if the audit is actually running: temporarily referencing `System.Net.Http` 4.3.0 and `System.Text.RegularExpressions` 4.3.0 fails the restore with exactly the two advisories that had been suppressed, as errors:

  ```
  error NU1903: Warning As Error: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, .../GHSA-7jgj-8wvc-jh57
  error NU1903: Warning As Error: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, .../GHSA-cmhx-cq75-c4mj
  ```

  So the audit data is present, the audit is live, and the removal has real teeth: a reappearance now fails the build instead of passing silently. The probe was reverted and is not part of this PR.
- `dotnet build` on the solution: succeeded, 0 warnings, 0 errors, all five Roslyn versions.
- `dotnet run --project src/DocumentationGenerator`: exit 0, no markdown changed.
- `dotnet test` on the default version (roslyn5.9): 3909 passed, 0 failed, 0 skipped.

## Notes for the reviewer

- The diff is only the removed `ItemGroup`. The file's missing final newline is pre-existing and unchanged, so there is no incidental whitespace churn.
- The finding this came from suggested that any future suppression carry a comment naming the dependency and the condition for removal. There is no suppression left to document, so that guidance is recorded in the commit message rather than in the file.