### PR TITLE
Match the annotation attributes by name in MA0060, MA0124 and MA0139

### DIFF
--- a/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
+++ b/src/Meziantou.Analyzer/Internals/AnnotationAttributes.cs
@@ -178,4 +178,26 @@ internal static class AnnotationAttributes
             }
         };
     }
+
+    public static bool IsStructuredLogFieldAttributeSymbol(ITypeSymbol? symbol)
+    {
+        // Meziantou.Analyzer.Annotations.StructuredLogFieldAttribute
+        return symbol is INamedTypeSymbol
+        {
+            Name: "StructuredLogFieldAttribute",
+            ContainingSymbol: INamespaceSymbol
+            {
+                Name: "Annotations",
+                ContainingSymbol: INamespaceSymbol
+                {
+                    Name: "Analyzer",
+                    ContainingSymbol: INamespaceSymbol
+                    {
+                        Name: "Meziantou",
+                        ContainingSymbol: INamespaceSymbol { IsGlobalNamespace: true }
+                    }
+                }
+            }
+        };
+    }
 }

--- a/src/Meziantou.Analyzer/Rules/DoNotIgnoreReturnValueAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotIgnoreReturnValueAnalyzer.cs
@@ -29,13 +29,12 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
         {
             var analyzerContext = new AnalyzerContext(compilationContext.Compilation, compilationContext.Options);
             compilationContext.RegisterOperationAction(analyzerContext.AnalyzeInvocation, OperationKind.Invocation);
-            compilationContext.RegisterOperationAction(analyzerContext.AnalyzeArgument, OperationKind.Argument);
+            compilationContext.RegisterOperationAction(AnalyzerContext.AnalyzeArgument, OperationKind.Argument);
         });
     }
 
     private sealed class AnalyzerContext(Compilation compilation, AnalyzerOptions options)
     {
-        private INamedTypeSymbol? DoNotIgnoreAttributeSymbol { get; } = compilation.GetBestTypeByMetadataName("Meziantou.Analyzer.Annotations.DoNotIgnoreAttribute");
         private INamedTypeSymbol? SystemDiagnosticsContractsPureAttributeSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Diagnostics.Contracts.PureAttribute");
         private INamedTypeSymbol? JetBrainsAnnotationsPureAttributeSymbol { get; } = compilation.GetBestTypeByMetadataName("JetBrains.Annotations.PureAttribute");
         private INamedTypeSymbol? StreamSymbol { get; } = compilation.GetBestTypeByMetadataName("System.IO.Stream");
@@ -56,11 +55,8 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
         private ImmutableHashSet<ISymbol> AssemblyLevelDoNotIgnoreSymbols { get; } = GetAssemblyLevelDoNotIgnoreSymbols(compilation);
         private AnalyzerOptions Options { get; } = options;
 
-        public void AnalyzeArgument(OperationAnalysisContext context)
+        public static void AnalyzeArgument(OperationAnalysisContext context)
         {
-            if (DoNotIgnoreAttributeSymbol is null)
-                return;
-
             var argument = (IArgumentOperation)context.Operation;
             if (argument.Parameter is not { RefKind: RefKind.Out } outParam)
                 return;
@@ -68,12 +64,12 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
             if (argument.Value is not IDiscardOperation)
                 return;
 
-            if (!outParam.HasAttribute(DoNotIgnoreAttributeSymbol))
+            var attr = FindDoNotIgnoreAttribute(outParam.GetAttributes());
+            if (attr is null)
                 return;
 
             var methodName = argument.Parent is IInvocationOperation inv ? inv.TargetMethod.Name : "?";
-            var attr = outParam.GetFirstAttribute(DoNotIgnoreAttributeSymbol);
-            var message = attr is not null ? GetMessageFromAttributeData(attr) : null;
+            var message = GetMessageFromAttributeData(attr);
             context.ReportDiagnostic(Rule, argument, $"The out parameter '{outParam.Name}' of '{methodName}' should not be discarded{GetMessageSuffix(message)}");
         }
 
@@ -90,15 +86,12 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
                 return;
 
             // Check attribute on return value
-            if (DoNotIgnoreAttributeSymbol is not null)
+            var returnValueAttribute = FindDoNotIgnoreAttribute(targetMethod.GetReturnTypeAttributes());
+            if (returnValueAttribute is not null)
             {
-                var attr = targetMethod.GetReturnTypeAttribute(DoNotIgnoreAttributeSymbol);
-                if (attr is not null)
-                {
-                    var message = GetMessageFromAttributeData(attr);
-                    context.ReportDiagnostic(Rule, invocation, $"The return value of '{targetMethod.Name}' should be used{GetMessageSuffix(message)}");
-                    return;
-                }
+                var message = GetMessageFromAttributeData(returnValueAttribute);
+                context.ReportDiagnostic(Rule, invocation, $"The return value of '{targetMethod.Name}' should be used{GetMessageSuffix(message)}");
+                return;
             }
 
             if (AssemblyLevelDoNotIgnoreSymbols.Contains(targetMethod.OriginalDefinition))
@@ -249,6 +242,17 @@ public sealed class DoNotIgnoreReturnValueAnalyzer : DiagnosticAnalyzer
                 method.ReturnType.SpecialType == SpecialType.System_Boolean &&
                 method.Parameters.Length >= 2 &&
                 method.Parameters[method.Parameters.Length - 1].RefKind != RefKind.None;
+        }
+
+        private static AttributeData? FindDoNotIgnoreAttribute(ImmutableArray<AttributeData> attributes)
+        {
+            foreach (var attribute in attributes)
+            {
+                if (AnnotationAttributes.IsDoNotIgnoreAttributeSymbol(attribute.AttributeClass))
+                    return attribute;
+            }
+
+            return null;
         }
 
         private static string GetMessageSuffix(string? message) => message is null ? "" : ": " + message;

--- a/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
@@ -103,7 +103,6 @@ public sealed class LoggerParameterTypeAnalyzer : DiagnosticAnalyzer
             LoggerExtensionsSymbol = compilation.GetBestTypeByMetadataName("Microsoft.Extensions.Logging.LoggerExtensions");
             LoggerMessageSymbol = compilation.GetBestTypeByMetadataName("Microsoft.Extensions.Logging.LoggerMessage");
             LoggerMessageAttributeSymbol = compilation.GetBestTypeByMetadataName("Microsoft.Extensions.Logging.LoggerMessageAttribute");
-            StructuredLogFieldAttributeSymbol = compilation.GetBestTypeByMetadataName("Meziantou.Analyzer.Annotations.StructuredLogFieldAttribute");
 
             SerilogLoggerEnrichmentConfigurationWithPropertySymbol = DocumentationCommentId.GetFirstSymbolForDeclarationId("M:Serilog.Configuration.LoggerEnrichmentConfiguration.WithProperty(System.String,System.Object,System.Boolean)", compilation);
             SerilogLogForContextSymbol = DocumentationCommentId.GetFirstSymbolForDeclarationId("M:Serilog.Log.ForContext(System.String,System.Object,System.Boolean)", compilation);
@@ -201,18 +200,14 @@ public sealed class LoggerParameterTypeAnalyzer : DiagnosticAnalyzer
                     }
                 }
 
-                if (StructuredLogFieldAttributeSymbol is not null)
+                foreach (var attribute in context.Compilation.Assembly.GetAttributes())
                 {
-                    var attributes = context.Compilation.Assembly.GetAttributes();
-                    foreach (var attribute in attributes)
-                    {
-                        if (!attribute.AttributeClass.IsEqualTo(StructuredLogFieldAttributeSymbol))
-                            continue;
+                    if (!AnnotationAttributes.IsStructuredLogFieldAttributeSymbol(attribute.AttributeClass))
+                        continue;
 
-                        if (attribute.ConstructorArguments is [{ Type.SpecialType: SpecialType.System_String, IsNull: false, Value: string name }, TypedConstant { Kind: TypedConstantKind.Array } types])
-                        {
-                            configuration[name] = [.. types.Values.Select(v => v.Value as ITypeSymbol).WhereNotNull()];
-                        }
+                    if (attribute.ConstructorArguments is [{ Type.SpecialType: SpecialType.System_String, IsNull: false, Value: string name }, TypedConstant { Kind: TypedConstantKind.Array } types])
+                    {
+                        configuration[name] = [.. types.Values.Select(v => v.Value as ITypeSymbol).WhereNotNull()];
                     }
                 }
 
@@ -224,8 +219,6 @@ public sealed class LoggerParameterTypeAnalyzer : DiagnosticAnalyzer
                 }
             }
         }
-
-        public INamedTypeSymbol? StructuredLogFieldAttributeSymbol { get; private set; }
 
         public INamedTypeSymbol? LoggerSymbol { get; }
         public INamedTypeSymbol? LoggerExtensionsSymbol { get; }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotIgnoreReturnValueAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotIgnoreReturnValueAnalyzerTests.cs
@@ -983,4 +983,119 @@ public sealed class DoNotIgnoreReturnValueAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task Attribute_ReturnValue_NotUsed_AttributeDefinedInTheProject()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            class Test
+            {
+                [return: Meziantou.Analyzer.Annotations.DoNotIgnore]
+                static int Compute() => 0;
+
+                void A()
+                {
+                    {|MA0060:Compute()|};
+                }
+            }
+
+            namespace Meziantou.Analyzer.Annotations
+            {
+                internal sealed class DoNotIgnoreAttribute : System.Attribute
+                {
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Attribute_OutParameter_Discarded_AttributeDefinedInTheProject()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            class Test
+            {
+                static bool TryGet([Meziantou.Analyzer.Annotations.DoNotIgnore] out int value) { value = 0; return true; }
+
+                void A()
+                {
+                    TryGet({|#0:out _|});
+                }
+            }
+
+            namespace Meziantou.Analyzer.Annotations
+            {
+                internal sealed class DoNotIgnoreAttribute : System.Attribute
+                {
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0060", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("The out parameter 'value' of 'TryGet' should not be discarded"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AssemblyAttribute_SimpleMethod_NotUsed_AttributeDefinedInTheProject()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            [assembly: Meziantou.Analyzer.Annotations.DoNotIgnore("M:Test.Sample")]
+
+            class Test
+            {
+                static int Sample() => 42;
+
+                void A()
+                {
+                    {|MA0060:Sample()|};
+                }
+            }
+
+            namespace Meziantou.Analyzer.Annotations
+            {
+                internal sealed class DoNotIgnoreAttribute : System.Attribute
+                {
+                    public DoNotIgnoreAttribute(string xmlDocumentationId) { }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Attribute_ReturnValue_NotUsed_AttributeDefinedInAReferencedProject()
+    {
+        var test = new AnalyzerTest();
+        test.TestState.AdditionalProjects["Library"].Sources.Add(("Library.cs", """
+            namespace Meziantou.Analyzer.Annotations
+            {
+                internal sealed class DoNotIgnoreAttribute : System.Attribute
+                {
+                }
+            }
+
+            public class Library
+            {
+                [return: Meziantou.Analyzer.Annotations.DoNotIgnore]
+                public static int Compute() => 0;
+            }
+            """));
+        test.TestState.AdditionalProjectReferences.Add("Library");
+        test.TestCode = """
+            class Test
+            {
+                void A()
+                {
+                    {|MA0060:Library.Compute()|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/LoggerParameterTypeAnalyzerTests.cs
@@ -510,6 +510,35 @@ public sealed class LoggerParameterTypeAnalyzerTests
     }
 
     [Fact]
+    public Task ConfigurationFromAttribute_AttributeDefinedInTheProject()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using Microsoft.Extensions.Logging;
+
+            [assembly: Meziantou.Analyzer.Annotations.StructuredLogFieldAttribute("Prop", typeof(string), typeof(long))]
+
+            ILogger logger = null;
+            logger.LogInformation("{Prop}", {|MA0124:2|});
+            logger.LogInformation("{Prop}", 2L);
+            logger.LogInformation("{Prop}", "");
+
+            namespace Meziantou.Analyzer.Annotations
+            {
+                internal sealed class StructuredLogFieldAttribute : System.Attribute
+                {
+                    public StructuredLogFieldAttribute(string parameterName, params System.Type[] allowedTypes) { }
+                }
+            }
+            """;
+        test.TestState.AdditionalFiles.Add(("LoggerParameterTypes.txt", """
+            Prop;System.Int32
+            """));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task LoggerMessageAttribute_ValidParameterTypes()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

`AnnotationAttributes` states that the annotation attributes *"can be defined in multiple assemblies, so it's identified by its full name only"*, and the `Meziantou.Analyzer.Annotations` README documents that users may copy the attribute source into their own project, `public` or `internal`. Two rules did not follow that policy and still resolved the attribute with `GetBestTypeByMetadataName`:

- **MA0060** matched the attribute on a return value or an `out` parameter by symbol equality, while the assembly-level form already went through `AnnotationAttributes` — two matching strategies for one attribute within a single file.
- **MA0124/MA0139** looked up `StructuredLogFieldAttribute` by metadata name; it was the only one of the nine shipped attributes with no name-based matcher.

Changes:

- Added `AnnotationAttributes.IsStructuredLogFieldAttributeSymbol`.
- `DoNotIgnoreReturnValueAnalyzer` drops the `DoNotIgnoreAttributeSymbol` field and its `is null` guards; the out-parameter and return-value paths share a `FindDoNotIgnoreAttribute` helper backed by `AnnotationAttributes.IsDoNotIgnoreAttributeSymbol`, so all three forms of MA0060 now match identically.
- `LoggerParameterTypeAnalyzer` drops `StructuredLogFieldAttributeSymbol` and matches by name.

`AnalyzeArgument` became `static` — CA1822 fires once it no longer touches instance state.

## Why it was a real bug, not only a consistency issue

`GetBestTypeByMetadataName` returns a type declared in the compilation's own source regardless of accessibility, so copying the attribute *into your own project* always worked. The case that actually diverged is a **referenced** assembly that copied the attribute as `internal`: it is invisible to `GetBestTypeByMetadataName`, so MA0060 silently reported nothing on that library's annotated members.

## Tests

Four new tests in `DoNotIgnoreReturnValueAnalyzerTests` and one in `LoggerParameterTypeAnalyzerTests`, all annotating with a hand-copied `internal` attribute instead of the package one.

Note for the reviewer: three of the four in-project tests pass against the old analyzer too, for the reason above — they are kept as coverage of the README-endorsed usage. The test that proves the fix is `Attribute_ReturnValue_NotUsed_AttributeDefinedInAReferencedProject`, which puts the `internal` attribute in an additional referenced project; it fails against the pre-fix analyzer and passes after.

## Verification

- `dotnet build` — clean, 0 warnings.
- `dotnet test --max-parallel-test-modules 2` — 19,283 passed, 0 failed, across all five Roslyn versions.
- `dotnet run --project src/DocumentationGenerator` — exit 0, no markdown changes.

Nothing under `src/Meziantou.Analyzer.Annotations` changed, so no README update or version bump was needed.