### PR TITLE
Fix MA0183 false positive and missed diagnostic when named arguments are reordered

### DIFF
--- a/src/Meziantou.Analyzer/Rules/StringFormatShouldBeConstantAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/StringFormatShouldBeConstantAnalyzer.cs
@@ -39,16 +39,16 @@ public sealed class StringFormatShouldBeConstantAnalyzer : DiagnosticAnalyzer
         if (operation.Arguments.Length == 0)
             return;
 
-        // Determine if this is a known format method, what the format arg index is,
+        // Determine if this is a known format method, which parameter is the format string,
         // and whether to report when there are no formatting arguments.
-        int formatArgumentIndex;
+        int formatParameterOrdinal;
         bool reportWhenNoFormattingArgs;
 
         if (method.ContainingType.SpecialType == SpecialType.System_String && method.Name == "Format")
         {
             // string.Format - report even when called with no args (e.g. string.Format("abc"))
             reportWhenNoFormattingArgs = true;
-            formatArgumentIndex = GetFormatArgIndex(operation, formatProviderType);
+            formatParameterOrdinal = GetFormatParameterOrdinal(method, formatProviderType);
         }
         else if (consoleType is not null && method.ContainingType.IsEqualTo(consoleType) &&
                  (method.Name == "Write" || method.Name == "WriteLine"))
@@ -59,27 +59,28 @@ public sealed class StringFormatShouldBeConstantAnalyzer : DiagnosticAnalyzer
                 return;
 
             reportWhenNoFormattingArgs = false;
-            formatArgumentIndex = 0;
+            formatParameterOrdinal = 0;
         }
         else if (stringBuilderType is not null && method.ContainingType.IsEqualTo(stringBuilderType) &&
                  method.Name == "AppendFormat")
         {
             // StringBuilder.AppendFormat - report even when called with no args
             reportWhenNoFormattingArgs = true;
-            formatArgumentIndex = GetFormatArgIndex(operation, formatProviderType);
+            formatParameterOrdinal = GetFormatParameterOrdinal(method, formatProviderType);
         }
         else
         {
             return;
         }
 
-        if (formatArgumentIndex < 0 || formatArgumentIndex >= operation.Arguments.Length)
+        // Named arguments can be written in any order, so the argument of a parameter must be
+        // located using the parameter ordinal instead of the position in the argument list.
+        var formatArgument = GetArgumentForParameter(operation, formatParameterOrdinal);
+        if (formatArgument is null)
             return;
 
-        var formatArgument = operation.Arguments[formatArgumentIndex];
-
         // Check if there are any formatting arguments after the format string
-        var hasFormattingArguments = HasFormattingArguments(operation, formatArgumentIndex);
+        var hasFormattingArguments = HasFormattingArguments(operation, formatParameterOrdinal);
 
         // Case 1: No formatting arguments at all
         if (!hasFormattingArguments)
@@ -102,19 +103,31 @@ public sealed class StringFormatShouldBeConstantAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static int GetFormatArgIndex(IInvocationOperation operation, ITypeSymbol? formatProviderType)
+    private static int GetFormatParameterOrdinal(IMethodSymbol method, ITypeSymbol? formatProviderType)
     {
-        if (operation.Arguments.Length > 0 && operation.Arguments[0].Parameter?.Type.IsEqualTo(formatProviderType) == true)
+        if (method.Parameters.Length > 0 && method.Parameters[0].Type.IsEqualTo(formatProviderType))
             return 1;
 
         return 0;
     }
 
-    private static bool HasFormattingArguments(IInvocationOperation operation, int formatArgumentIndex)
+    private static IArgumentOperation? GetArgumentForParameter(IInvocationOperation operation, int parameterOrdinal)
     {
-        for (var i = formatArgumentIndex + 1; i < operation.Arguments.Length; i++)
+        foreach (var argument in operation.Arguments)
         {
-            var arg = operation.Arguments[i];
+            if (argument.Parameter?.Ordinal == parameterOrdinal)
+                return argument;
+        }
+
+        return null;
+    }
+
+    private static bool HasFormattingArguments(IInvocationOperation operation, int formatParameterOrdinal)
+    {
+        foreach (var arg in operation.Arguments)
+        {
+            if (arg.Parameter is not { } parameter || parameter.Ordinal <= formatParameterOrdinal)
+                continue;
 
             // Check if this is a params array argument
             if (arg.ArgumentKind == ArgumentKind.ParamArray && arg.Value is IArrayCreationOperation arrayCreation)

--- a/tests/Meziantou.Analyzer.Test/Rules/StringFormatShouldBeConstantAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/StringFormatShouldBeConstantAnalyzerTests.cs
@@ -965,4 +965,140 @@ public sealed class StringFormatShouldBeConstantAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task StringFormat_NamedArgumentsOutOfOrderWithPlaceholder_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+
+            class Test
+            {
+                void Method()
+                {
+                    _ = string.Format(arg0: "hello", format: "{0}");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringFormat_NamedArgumentsOutOfOrderWithoutPlaceholder_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+
+            class Test
+            {
+                void Method()
+                {
+                    _ = {|MA0183:string.Format(arg0: "hello", format: "abc")|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringFormat_NamedArgumentsOutOfOrderWithProviderAndPlaceholder_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Globalization;
+
+            class Test
+            {
+                void Method(object obj)
+                {
+                    _ = string.Format(arg0: obj, provider: CultureInfo.InvariantCulture, format: "{0}");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringFormat_NamedArgumentsOutOfOrderWithProviderAndNoPlaceholder_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Globalization;
+
+            class Test
+            {
+                void Method(object obj)
+                {
+                    _ = {|MA0183:string.Format(arg0: obj, provider: CultureInfo.InvariantCulture, format: "abc")|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringBuilderAppendFormat_NamedArgumentsOutOfOrderWithPlaceholder_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Text;
+
+            class Test
+            {
+                void Method(StringBuilder sb)
+                {
+                    sb.AppendFormat(arg0: "hello", format: "{0}");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ConsoleWriteLine_NamedArgumentsOutOfOrderWithPlaceholder_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+
+            class Test
+            {
+                void Method()
+                {
+                    Console.WriteLine(arg0: "hello", format: "{0}");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ConsoleWriteLine_NamedArgumentsOutOfOrderWithoutPlaceholder_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+
+            class Test
+            {
+                void Method()
+                {
+                    {|MA0183:Console.WriteLine(arg0: "hello", format: "abc")|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## What changed

`StringFormatShouldBeConstantAnalyzer` (MA0183) located the format string by indexing `IInvocationOperation.Arguments` positionally. That collection is in evaluation/source order, so when named arguments are written out of parameter order the analyzer picked the wrong operand:

```csharp
_ = string.Format(arg0: "hello", format: "{0}");   // false positive: "hello" treated as the format string
_ = string.Format(arg0: x, provider: c, format: "abc"); // missed diagnostic
```

The same applied to `StringBuilder.AppendFormat` and `Console.Write`/`Console.WriteLine`.

The analyzer now works with parameter ordinals instead of argument positions:

- `GetFormatArgIndex(operation, …)` became `GetFormatParameterOrdinal(method, …)`: the `IFormatProvider` overload is detected from `IMethodSymbol.Parameters`, which is always in declaration order, and the method returns a parameter ordinal rather than an argument index.
- A new `GetArgumentForParameter` helper resolves the format argument by matching `IArgumentOperation.Parameter.Ordinal`, replacing `operation.Arguments[formatArgumentIndex]` and its bounds check.
- `HasFormattingArguments` iterates every argument and keeps the ones whose `Parameter.Ordinal` is greater than the format parameter's ordinal, instead of slicing the array from `formatArgumentIndex + 1`.

## Tests

7 cases added to `StringFormatShouldBeConstantAnalyzerTests`, covering reordered named arguments for `string.Format` (with and without `provider:`), `StringBuilder.AppendFormat` and `Console.WriteLine`, in both the false-positive and the missed-diagnostic direction. 4 of them failed before the fix (3 false positives, 1 missed diagnostic).

## Verification

- `StringFormatShouldBeConstantAnalyzerTests`: 62 tests, green on roslyn4.8, roslyn4.14, roslyn5.0, roslyn5.6 and roslyn5.9.
- Full suite on the default version (roslyn5.9): 3916/3916 passing.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes — this is a behavior fix that does not alter the documented rule.

## Note for the reviewer

The report that prompted this also flagged the same positional assumption in `UseDateTimeUnixEpochAnalyzer.ArgumentsEquals`. That no longer applies: it already matches on `argument.Parameter.Ordinal` and its doc comment states it is order-independent, so it is left untouched here.