### PR TITLE
Avoid walking the whole operation tree in IsInExpressionContext

### DIFF
--- a/src/Meziantou.Analyzer/Internals/OperationUtilities.cs
+++ b/src/Meziantou.Analyzer/Internals/OperationUtilities.cs
@@ -9,25 +9,20 @@ internal sealed class OperationUtilities(Compilation compilation)
         if (_expressionSymbol is null)
             return false;
 
-        foreach (var op in operation.Ancestors())
+        for (var op = operation.Parent; op is not null; op = op.Parent)
         {
-            if (op is IArgumentOperation argumentOperation)
+            switch (op)
             {
-                if (argumentOperation.Parameter is null)
-                    continue;
-
-                var type = argumentOperation.Parameter.Type;
-                if (type.InheritsFrom(_expressionSymbol))
+                case IArgumentOperation { Parameter: { } parameter } when parameter.Type.InheritsFrom(_expressionSymbol):
                     return true;
-            }
-            else if (op is IConversionOperation conversionOperation)
-            {
-                var type = conversionOperation.Type;
-                if (type is null)
-                    continue;
 
-                if (type.InheritsFrom(_expressionSymbol))
+                case IConversionOperation { Type: { } type } when type.InheritsFrom(_expressionSymbol):
                     return true;
+
+                // An expression tree can only be entered by converting a lambda, so the search can stop at the first
+                // enclosing body that is not the body of a lambda (method body, local function body, nested block, ...)
+                case IBlockOperation when op.Parent is not IAnonymousFunctionOperation:
+                    return false;
             }
         }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
@@ -25,6 +25,21 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
             using System.Linq;
             using System.Linq.Expressions;
             _ = (Expression<Func<int, bool>>)(item => item == 0);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task DisabledInExpression_NestedInBlocks()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Linq;
+            if (args.Length > 0)
+            {
+                _ = Enumerable.Empty<int>().AsQueryable().Where(item => item == 0);
+            }
             """;
 
         return test.RunAsync();


### PR DESCRIPTION
## What

`OperationUtilities.IsInExpressionContext` now walks `operation.Parent` directly instead of the `Ancestors()` iterator, and stops at the first enclosing `IBlockOperation` that is not the body of a lambda.

```csharp
for (var op = operation.Parent; op is not null; op = op.Parent)
{
    switch (op)
    {
        case IArgumentOperation { Parameter: { } parameter } when parameter.Type.InheritsFrom(_expressionSymbol):
            return true;

        case IConversionOperation { Type: { } type } when type.InheritsFrom(_expressionSymbol):
            return true;

        // An expression tree can only be entered by converting a lambda, so the search can stop at the first
        // enclosing body that is not the body of a lambda (method body, local function body, nested block, ...)
        case IBlockOperation when op.Parent is not IAnonymousFunctionOperation:
            return false;
    }
}
```

## Why

The previous implementation enumerated `operation.Ancestors()` all the way to the root of the operation tree, allocating a `yield return` state machine on every call and calling `InheritsFrom(System.Linq.Expressions.Expression)` on every `IArgumentOperation` and `IConversionOperation` it passed. Ten analyzers call it — `UseStringComparer`, `UseStringComparison`, `UseStringEquals`, `UsePatternMatchingForEqualityComparisons`, `DoNotUseEqualityOperatorsForSpanOfChar`, `AwaitAwaitableMethodInSyncMethod`, `NamedParameter`, `UseAwaitInsteadOfReturningTask`, `UsePatternMatchingInsteadOfHasValue` — several of them on the densest operation kinds (`Invocation`, `Binary`), and the common answer is `false`, which meant walking the full depth every time.

## Note for reviewers

The lambda-body exception is what keeps the early exit correct. `IAnonymousFunctionOperation.Body` is always an `IBlockOperation`, even for the expression-bodied lambdas that expression trees require, so the walk must pass through that one block to reach the `Expression<>`-typed conversion or argument above it. Every other block — method body, local function body, nested statement block — cannot sit under an expression tree, so it terminates the walk. No separate `IMethodBodyOperation` case is needed: the body's block is reached first and stops there.

## Tests

- Added `DisabledInExpression_NestedInBlocks` to `UsePatternMatchingForEqualityComparisonsAnalyzerTests`, covering the `IArgumentOperation` path (`IQueryable.Where(item => item == 0)`) nested inside a statement block. The existing `DisabledInExpression` only covered the cast/conversion path.
- Confirmed the guard has teeth: replacing the case with a naive `case IBlockOperation:` makes both `DisabledInExpression` tests fail, because MA0140 is then reported inside the expression tree.
- Full suite across all five Roslyn versions: 19263 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.