### PR TITLE
Do not report MA0106 on a lambda already reported by MA0105

### DIFF
--- a/src/Meziantou.Analyzer/Rules/AvoidClosureWhenUsingConcurrentDictionaryAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidClosureWhenUsingConcurrentDictionaryAnalyzer.cs
@@ -73,20 +73,21 @@ public class AvoidClosureWhenUsingConcurrentDictionaryAnalyzer : DiagnosticAnaly
             if (!op.TargetMethod.ContainingSymbol.OriginalDefinition.IsEqualTo(ConcurrentDictionarySymbol))
                 return;
 
-            // Check if the key/value parameter should be used
-            var handled = false;
+            // Check if the key/value parameter should be used.
+            // The lambdas reported by this rule are not reported by RuleFactoryArg, as using the lambda parameter is the right fix.
+            var handledArguments = new List<IArgumentOperation>(capacity: 2);
             if (op.TargetMethod.Name is "GetOrAdd")
             {
                 // a.GetOrAdd(key, (k) => key);
                 if (op.Arguments.Length == 2 && op.Arguments[1].Parameter!.Type.OriginalDefinition.IsEqualTo(Func2Symbol))
                 {
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[1].Value, op.Arguments[0]);
+                    Analyze(op.Arguments[1], op.Arguments[0]);
                 }
                 // a.GetOrAdd(key, (k, arg) => key, arg);
                 else if (op.Arguments.Length == 3 && op.Arguments[1].Parameter!.Type.OriginalDefinition.IsEqualTo(Func3Symbol))
                 {
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[1].Value, op.Arguments[0]);
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[1].Value, op.Arguments[2]);
+                    Analyze(op.Arguments[1], op.Arguments[0]);
+                    Analyze(op.Arguments[1], op.Arguments[2]);
                 }
             }
             else if (op.TargetMethod.Name is "AddOrUpdate")
@@ -94,33 +95,41 @@ public class AvoidClosureWhenUsingConcurrentDictionaryAnalyzer : DiagnosticAnaly
                 // a.AddOrUpdate(key, (k) => k, (k, oldValue) => k + oldValue + 1);
                 if (op.Arguments.Length == 3 && op.Arguments[1].Parameter!.Type.OriginalDefinition.IsEqualTo(Func2Symbol) && op.Arguments[2].Parameter!.Type.OriginalDefinition.IsEqualTo(Func3Symbol))
                 {
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[1].Value, op.Arguments[0]);
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[2].Value, op.Arguments[0]);
+                    Analyze(op.Arguments[1], op.Arguments[0]);
+                    Analyze(op.Arguments[2], op.Arguments[0]);
                 }
                 // a.AddOrUpdate(key, newValue, (k, oldValue) => k + oldValue);
                 else if (op.Arguments.Length == 3 && op.Arguments[2].Parameter!.Type.OriginalDefinition.IsEqualTo(Func3Symbol))
                 {
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[2].Value, op.Arguments[0]);
+                    Analyze(op.Arguments[2], op.Arguments[0]);
                 }
                 // a.AddOrUpdate(key, (k, arg) => k + arg, (k, oldValue, arg) => k + oldValue + arg, factoryArg);
                 else if (op.Arguments.Length == 4 && op.Arguments[1].Parameter!.Type.OriginalDefinition.IsEqualTo(Func3Symbol) && op.Arguments[2].Parameter!.Type.OriginalDefinition.IsEqualTo(Func4Symbol))
                 {
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[1].Value, op.Arguments[0]);
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[1].Value, op.Arguments[3]);
+                    Analyze(op.Arguments[1], op.Arguments[0]);
+                    Analyze(op.Arguments[1], op.Arguments[3]);
 
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[2].Value, op.Arguments[0]);
-                    handled |= DetectPotentialUsageOfLambdaParameter(context, op.Arguments[2].Value, op.Arguments[3]);
+                    Analyze(op.Arguments[2], op.Arguments[0]);
+                    Analyze(op.Arguments[2], op.Arguments[3]);
                 }
             }
 
-            if ((!handled && GetOrAddHasOverloadWithArg && op.TargetMethod.Name is "GetOrAdd") || (AddOrUpdateHasOverloadWithArg && op.TargetMethod.Name is "AddOrUpdate"))
+            if ((GetOrAddHasOverloadWithArg && op.TargetMethod.Name is "GetOrAdd") || (AddOrUpdateHasOverloadWithArg && op.TargetMethod.Name is "AddOrUpdate"))
             {
                 foreach (var arg in op.Arguments)
                 {
-                    if (arg.Parameter!.OriginalDefinition.Type.OriginalDefinition.IsEqualToAny(Func2Symbol, Func3Symbol, Func4Symbol))
+                    if (arg.Parameter!.OriginalDefinition.Type.OriginalDefinition.IsEqualToAny(Func2Symbol, Func3Symbol, Func4Symbol) && !handledArguments.Contains(arg))
                     {
                         DetectClosure(context, arg.Value);
                     }
+                }
+            }
+
+            void Analyze(IArgumentOperation lambdaArgument, IArgumentOperation potentialVariableArgument)
+            {
+                if (DetectPotentialUsageOfLambdaParameter(context, lambdaArgument.Value, potentialVariableArgument) && !handledArguments.Contains(lambdaArgument))
+                {
+                    handledArguments.Add(lambdaArgument);
                 }
             }
         }

--- a/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests.cs
@@ -111,6 +111,39 @@ public sealed class ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAna
     }
 
     [Fact]
+    public Task AddOrUpdate_AddValueFactoryUsingTheKey_ReportsOnlyTheLambdaParameterRule()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, {|MA0105:k => key|}, (k, v) => k + v);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AddOrUpdate_AddValueFactoryUsingTheKey_UpdateValueFactoryUsingAClosure()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var value = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, {|MA0105:k => key|}, {|MA0106:(k, v) => value|});
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task AddOrUpdate_Parameter()
     {
         var test = new CodeFixTest();


### PR DESCRIPTION
## What changed

`AvoidClosureWhenUsingConcurrentDictionaryAnalyzer` tracked its `handled` flag once per invocation, and the guard that keeps MA0106 from firing on a lambda already reported by MA0105 was applied only to the `GetOrAdd` disjunct — the `AddOrUpdate` disjunct had no guard at all:

```csharp
if ((!handled && GetOrAddHasOverloadWithArg && op.TargetMethod.Name is "GetOrAdd") || (AddOrUpdateHasOverloadWithArg && op.TargetMethod.Name is "AddOrUpdate"))
```

`handled` is now `handledArguments`, a list of the lambda arguments MA0105 was reported on. A local `Analyze` function wraps `DetectPotentialUsageOfLambdaParameter` and records the argument on a hit; the MA0106 loop skips arguments in that list.

## Why

Two equivalent calls were reported differently:

```csharp
a.GetOrAdd(key, k => key);                       // MA0105 only
a.AddOrUpdate(key, k => key, (k, v) => k + v);   // MA0105 AND MA0106, on the same span
```

The two diagnostics contradict each other on that lambda: MA0106 suggests moving to an overload with a `factoryArgument` parameter, when the correct fix (MA0105) is to use the lambda's own `k` parameter.

## Note for reviewers

Tracking per lambda rather than just adding the missing `!handled` to the `AddOrUpdate` disjunct is deliberate. With two lambdas, suppressing MA0106 on both because one was handled would hide a genuine closure. The second new test pins that down — `a.AddOrUpdate(key, k => key, (k, v) => value)` still reports MA0105 on the first lambda and MA0106 on the second.

`GetOrAdd` only ever has one lambda, so per-lambda and per-invocation are equivalent there and its behavior is unchanged.

## Verification

- Two regression tests added to `ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests`. Both were confirmed to fail against the analyzer at `HEAD`, reproducing the duplicate exactly (MA0105 and MA0106 both on span 5,20–5,28), then pass with the fix.
- Full test suite across all five Roslyn versions: 19268 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes — this fix does not alter documented behavior, so the MA0105/MA0106 docs needed no update.
