### PR TITLE
Add tests for MA0080

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -843,6 +843,101 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     }
 
     [Fact]
+    public Task AwaitForEach_NoCancellationTokenAvailable_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class Test
+            {
+                public static async Task A(IAsyncEnumerable<int> enumerable)
+                {
+                    await foreach (var item in {|MA0080:enumerable|})
+                    {
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AwaitForEach_Method_NoCancellationTokenAvailable_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class Test
+            {
+                public static async Task A()
+                {
+                    await foreach (var item in {|MA0080:Enumerate()|})
+                    {
+                    }
+                }
+
+                public static IAsyncEnumerable<int> Enumerate() => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AwaitForEach_NoCancellationTokenAvailable_InterfaceImplementation_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            interface ITest
+            {
+                Task A(IAsyncEnumerable<int> enumerable);
+            }
+
+            class Test : ITest
+            {
+                public async Task A(IAsyncEnumerable<int> enumerable)
+                {
+                    await foreach (var item in enumerable)
+                    {
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AwaitForEach_NoCancellationTokenAvailable_ExcludedMethod_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestState.AddMeziantouAnnotations();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            class Test
+            {
+                public static async Task A()
+                {
+                    await foreach (var item in Enumerate())
+                    {
+                    }
+                }
+
+                [Meziantou.Analyzer.Annotations.ExcludeFromCancellationTokenAnalysis]
+                public static IAsyncEnumerable<int> Enumerate() => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task DisposeAsync_NoNeedForCancellationToken()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

Adds four tests for `MA0080` (`FlowCancellationTokenInAwaitForEach`) to `UseAnOverloadThatHasCancellationTokenAnalyzerTests`.

## Why

While auditing which rules the test suite actually exercises, MA0080 turned out to be the only rule of `UseAnOverloadThatHasCancellationTokenAnalyzer` with no test at all — it was not named anywhere under `tests/`.

MA0080 is the branch of `AnalyzeLoop` that reports when **no** `CancellationToken` is available in the scope of the `await foreach`. MA0079, the sibling branch that reports when one **is** available, was already covered, so only the "nothing to flow" path was untested.

## What the tests cover

- The variable form — `await foreach (var item in enumerable)`.
- The invocation form — `await foreach (var item in Enumerate())`, where the method has no `CancellationToken` overload.
- The early return on a method that overrides a member or implements an interface, where the signature cannot be changed to take a token.
- `[ExcludeFromCancellationTokenAnalysis]` on the method producing the enumerable.

None of them sets `FixedCode`: `UseAnOverloadThatHasCancellationTokenFixer_AwaitForEach` only registers for MA0079, which is correct, since there is no token to flow when MA0080 is reported.

## Notes for reviewers

This is a test-only change — no analyzer, code fixer or documentation change, and `dotnet run --project src/DocumentationGenerator` leaves the markdown untouched.

Verified on all five Roslyn versions, full suite, no failures:

| Project | Tests | Failed |
|---|---|---|
| roslyn4.8 | 3802 | 0 |
| roslyn4.14 | 3829 | 0 |
| roslyn5.0 | 3857 | 0 |
| roslyn5.6 | 3881 | 0 |
| roslyn5.9 | 3914 | 0 |
