### PR TITLE
Remove the dead Roslyn 4.4 workaround from MA0099

### DIFF
--- a/src/Meziantou.Analyzer/Rules/DoNotUseZeroToInitializeAnEnumValue.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseZeroToInitializeAnEnumValue.cs
@@ -43,11 +43,6 @@ public class DoNotUseZeroToInitializeAnEnumValue : DiagnosticAnalyzer
         if (operation.Parent is IArgumentOperation { ArgumentKind: ArgumentKind.DefaultValue })
             return;
 
-#if !ROSLYN4_5_OR_GREATER
-        if (operation.Syntax.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.Attribute))
-            return;
-#endif
-
         if (operation.ConstantValue is not { HasValue: true, Value: not null and var value } || !IsZero(enumType, value))
             return;
 


### PR DESCRIPTION
## What

Removes a `#if`-guarded block from `DoNotUseZeroToInitializeAnEnumValue` (MA0099) whose guard used a constant that is never defined.

```csharp
#if !ROSLYN4_5_OR_GREATER
    if (operation.Syntax.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.Attribute))
        return;
#endif
```

## Why

The constants come from the `Meziantou.Framework.Roslyn` package and are named `ROSLYN_<major>_<minor>_OR_GREATER`. `ROSLYN4_5_OR_GREATER` is missing the underscore after `ROSLYN` — it is the only one of the nine `ROSLYN*`/`CSHARP*` identifiers used in a `#if` across `src` and `tests` that is misspelled.

An undefined constant is not an error for the C# compiler, it is simply false, so `!` made the condition always true. The block was therefore **compiled into all five builds** rather than excluded from them — the typo inverted the guard rather than merely disabling it.

The workaround comes from #526 and only applies to Roslyn 4.4 and below, where the conversion of a default parameter value in an attribute had the `Attribute` node as its syntax. The minimum supported version is now 4.8, so spelling the constant correctly would exclude the block from every supported build. The code is dead either way, which is why this removes it rather than repairing the typo.

## For reviewers

Because the block was live rather than skipped, removing it changes the compiled code, so this needed test evidence rather than inspection. `ImplicitParameterInAttribute` — the test added alongside the workaround — covers both the implicit default value the block was meant to ignore and the explicit `0` that must still be reported. It passes on every supported version, confirming the block never matched.

Verified:

- `dotnet build` succeeds with 0 warnings across roslyn4.8, 4.14, 5.0, 5.6 and 5.9.
- The 248 `DoNotUseZeroToInitializeAnEnumValueTests` cases pass on each of the five versions.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.