### PR TITLE
Create the configured regexes from the options

### DIFF
--- a/docs/Rules/MA0003.md
+++ b/docs/Rules/MA0003.md
@@ -38,7 +38,7 @@ MA0003.excluded_methods_regex = Sample.*Test
 MA0003.ignore_arguments_matching_parameter_name = true
 ````
 
-If `MA0003.excluded_methods_regex` is not a valid regular expression, no method is excluded and [MA0220](MA0220.md) is reported. No method is excluded either if the evaluation of the regular expression times out.
+If `MA0003.excluded_methods_regex` is empty or is not a valid regular expression, no method is excluded and [MA0220](MA0220.md) is reported for an invalid value. No method is excluded either if the evaluation of the regular expression times out.
 
 You can annotate a parameter with `Meziantou.Analyzer.Annotations.RequireNamedArgumentAttribute`.
 To use this attribute, add the `Meziantou.Analyzer.Annotations` NuGet package (or copy the attribute source into your project). See [Meziantou.Analyzer.Annotations README](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.Annotations/README.md).

--- a/docs/Rules/MA0104.md
+++ b/docs/Rules/MA0104.md
@@ -16,7 +16,7 @@ MA0104.namespaces_regex = ^System($|\.)
 MA0104.use_preview_types = true # use types from preview versions of .NET
 ````
 
-If `MA0104.namespaces_regex` is not a valid regular expression, the default value (`^System($|\.)`) is used and [MA0220](MA0220.md) is reported.
+If `MA0104.namespaces_regex` is not a valid regular expression, the default value (`^System($|\.)`) is used and [MA0220](MA0220.md) is reported. The default value is also used when the value is empty.
 
 By default, the rule only applies to public types. Add the following line to the `.editorconfig` file to consider all types:
 

--- a/src/Meziantou.Analyzer/Configurations/AnalyzerOptionsExtensions.cs
+++ b/src/Meziantou.Analyzer/Configurations/AnalyzerOptionsExtensions.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Meziantou.Analyzer.Configurations;
 
 public static class AnalyzerOptionsExtensions
@@ -63,6 +65,48 @@ public static class AnalyzerOptionsExtensions
         }
 
         return defaultValue;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="Regex"/> of an option whose value is a regular expression (<see cref="ConfigurationDefinition{T}.IsRegex"/>).
+    /// The regex is created with the <see cref="ConfigurationDefinition{T}.RegexOptions"/> of the option and cached, so a value is
+    /// parsed only once. Returns <see langword="false"/> when the option is not configured, when its value is empty, or when its
+    /// value is not a valid pattern. MA0220 reports the invalid patterns, so the rules can ignore them.
+    /// </summary>
+    public static bool TryGetConfigurationRegex(this AnalyzerOptions options, SyntaxTree syntaxTree, ConfigurationDefinition<string> configuration, [NotNullWhen(true)] out Regex? regex)
+    {
+        if (TryGetConfigurationValue(options, syntaxTree, configuration.Key, out var pattern) && pattern.Length > 0)
+            return RegexCache.TryGetOrCreate(pattern, configuration.RegexOptions, out regex);
+
+        regex = null;
+        return false;
+    }
+
+    /// <inheritdoc cref="TryGetConfigurationRegex(AnalyzerOptions, SyntaxTree, ConfigurationDefinition{string}, out Regex?)"/>
+    public static bool TryGetConfigurationRegex(this AnalyzerOptions options, ISymbol symbol, ConfigurationDefinition<string> configuration, [NotNullWhen(true)] out Regex? regex)
+    {
+        if (TryGetConfigurationValue(options, symbol, configuration.Key, out var pattern) && pattern.Length > 0)
+            return RegexCache.TryGetOrCreate(pattern, configuration.RegexOptions, out regex);
+
+        regex = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="Regex"/> of an option whose value is a regular expression, or the <see cref="Regex"/> of the default value
+    /// of the option when it is not configured or when its value is not a valid pattern. Returns <see langword="null"/> when the
+    /// default value itself is not a valid pattern.
+    /// </summary>
+    public static Regex? GetConfigurationRegex(this AnalyzerOptions options, ISymbol symbol, ConfigurationDefinition<string> configuration)
+    {
+        if (!configuration.HasDefaultValue)
+            throw new InvalidOperationException($"Configuration value for '{configuration.Key}' is not set and has no default value.");
+
+        if (TryGetConfigurationRegex(options, symbol, configuration, out var regex))
+            return regex;
+
+        RegexCache.TryGetOrCreate(configuration.DefaultValue, configuration.RegexOptions, out regex);
+        return regex;
     }
 
     public static bool TryGetConfigurationValue(this AnalyzerOptions options, SyntaxTree syntaxTree, string key, [NotNullWhen(true)] out string? value)

--- a/src/Meziantou.Analyzer/Internals/RegexCache.cs
+++ b/src/Meziantou.Analyzer/Internals/RegexCache.cs
@@ -32,18 +32,6 @@ internal static class RegexCache
     }
 
     /// <summary>
-    /// Indicates whether the pattern matches the input. Returns <paramref name="defaultValue"/> when the pattern
-    /// is invalid or when the evaluation times out.
-    /// </summary>
-    public static bool IsMatch(string pattern, RegexOptions options, string input, bool defaultValue)
-    {
-        if (!TryGetOrCreate(pattern, options, out var regex))
-            return defaultValue;
-
-        return IsMatch(regex, input, defaultValue);
-    }
-
-    /// <summary>
     /// Indicates whether the regex matches the input. Returns <paramref name="defaultValue"/> when the evaluation times out.
     /// </summary>
     public static bool IsMatch(Regex regex, string input, bool defaultValue)
@@ -59,14 +47,10 @@ internal static class RegexCache
     }
 
     /// <summary>
-    /// Replaces all the matches of the pattern in the input. Returns <paramref name="defaultValue"/> when the pattern
-    /// is invalid or when the evaluation times out.
+    /// Replaces all the matches of the regex in the input. Returns <paramref name="defaultValue"/> when the evaluation times out.
     /// </summary>
-    public static string Replace(string pattern, RegexOptions options, string input, string replacement, string defaultValue)
+    public static string Replace(Regex regex, string input, string replacement, string defaultValue)
     {
-        if (!TryGetOrCreate(pattern, options, out var regex))
-            return defaultValue;
-
         try
         {
             return regex.Replace(input, replacement);

--- a/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DotNotUseNameFromBCLAnalyzer.cs
@@ -68,18 +68,13 @@ public class DotNotUseNameFromBCLAnalyzer : DiagnosticAnalyzer
 
     private static Regex? GetNamespacesRegex(SymbolAnalysisContext context, ISymbol symbol)
     {
-        var pattern = context.Options.GetConfigurationValue(symbol, LegacyNamepacesRegexConfiguration);
-        if (context.Options.TryGetConfigurationValue(symbol, NamespacesRegexConfiguration, out var configuredPattern))
-        {
-            pattern = configuredPattern;
-        }
+        // The legacy option is only used when the current one is not configured. An invalid pattern falls back to the
+        // default pattern instead of failing the analysis.
+        var configuration = context.Options.TryGetConfigurationValue(symbol, NamespacesRegexConfiguration, out _)
+            ? NamespacesRegexConfiguration
+            : LegacyNamepacesRegexConfiguration;
 
-        if (RegexCache.TryGetOrCreate(pattern, NamespacesRegexConfiguration.RegexOptions, out var regex))
-            return regex;
-
-        // The configured pattern is invalid, so fallback to the default pattern instead of failing the analysis
-        RegexCache.TryGetOrCreate(NamespacesRegexConfiguration.DefaultValue, NamespacesRegexConfiguration.RegexOptions, out regex);
-        return regex;
+        return context.Options.GetConfigurationRegex(symbol, configuration);
     }
 
     private static Dictionary<string, string[]> LoadTypes(bool preview)

--- a/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/FileNameMustMatchTypeNameAnalyzer.cs
@@ -191,16 +191,16 @@ public sealed class FileNameMustMatchTypeNameAnalyzer : DiagnosticAnalyzer
     private static string? GetFileNameWithoutExcludedParts(SymbolAnalysisContext context, SyntaxTree sourceTree, ReadOnlySpan<char> filePath)
     {
         var excludedParts = context.Options.GetConfigurationValue(sourceTree, ExcludedFileNamePartsConfiguration);
-        var excludedPartsRegex = context.Options.GetConfigurationValue(sourceTree, ExcludedFileNamePartsRegexConfiguration);
-        if (string.IsNullOrEmpty(excludedParts) && string.IsNullOrEmpty(excludedPartsRegex))
+        context.Options.TryGetConfigurationRegex(sourceTree, ExcludedFileNamePartsRegexConfiguration, out var excludedPartsRegex);
+        if (string.IsNullOrEmpty(excludedParts) && excludedPartsRegex is null)
             return null;
 
         var fileName = GetFileNameWithoutExtension(filePath).ToString();
 
         // The regex is applied first, so it can match the dots that MA0048.excluded_file_name_parts may remove
-        if (!string.IsNullOrEmpty(excludedPartsRegex))
+        if (excludedPartsRegex is not null)
         {
-            fileName = RegexCache.Replace(excludedPartsRegex, ExcludedFileNamePartsRegexConfiguration.RegexOptions, fileName, replacement: "", defaultValue: fileName);
+            fileName = RegexCache.Replace(excludedPartsRegex, fileName, replacement: "", defaultValue: fileName);
         }
 
         foreach (var part in excludedParts.Split([',', '|'], StringSplitOptions.RemoveEmptyEntries))

--- a/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NamedParameterAnalyzer.cs
@@ -248,10 +248,10 @@ public sealed partial class NamedParameterAnalyzer : DiagnosticAnalyzer
                         if (argumentOperation is not null && !argumentOperation.GetCSharpLanguageVersion().IsCSharp14OrGreater() && operationUtilities.IsInExpressionContext(argumentOperation))
                             return;
 
-                        if (syntaxContext.Options.TryGetConfigurationValue(expression.SyntaxTree, ExcludedMethodsRegexConfiguration, out var excludedMethodsRegex))
+                        if (syntaxContext.Options.TryGetConfigurationRegex(expression.SyntaxTree, ExcludedMethodsRegexConfiguration, out var excludedMethodsRegex))
                         {
                             var declarationId = DocumentationCommentId.CreateDeclarationId(invokedMethodSymbol);
-                            if (declarationId is not null && RegexCache.IsMatch(excludedMethodsRegex, ExcludedMethodsRegexConfiguration.RegexOptions, declarationId, defaultValue: false))
+                            if (declarationId is not null && RegexCache.IsMatch(excludedMethodsRegex, declarationId, defaultValue: false))
                                 return;
                         }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/DotNotUseNameFromBCLAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DotNotUseNameFromBCLAnalyzerTests.cs
@@ -99,4 +99,14 @@ public sealed class DotNotUseNameFromBCLAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task EmptyRegex_UseDefaultRegex()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("MA0104.namespaces_regex", "");
+        test.TestCode = "public class {|MA0104:Action|} { }";
+
+        return test.RunAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NamedParameterAnalyzerTests.cs
@@ -401,6 +401,26 @@ public sealed class NamedParameterAnalyzerTests
     }
 
     [Fact]
+    public Task Int32_ExcludedMethodWithEmptyRegex_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration(("MA0003.expression_kinds", "numeric"), ("MA0003.excluded_methods_regex", ""));
+        test.TestCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    MyMethod({|MA0003:1|}, {|MA0003:1L|}, {|MA0003:3|});
+                }
+
+                void MyMethod(int a, long b, short c) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Int32_ExcludedMethodWithInvalidRegex_ShouldReportDiagnostic()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

The rules that use an option whose value is a regular expression had to pass the `RegexOptions` of the option to `RegexCache` themselves, so a rule could use options different from the ones MA0220 validates the pattern with.

The options now create the `Regex`:

- `AnalyzerOptions.TryGetConfigurationRegex(syntaxTree | symbol, configuration, out Regex?)` reads the value and returns the cached `Regex` created with the `RegexOptions` of the option. It returns `false` when the option is not configured, when its value is empty, or when the pattern is invalid.
- `AnalyzerOptions.GetConfigurationRegex(symbol, configuration)` does the same, and falls back to the `Regex` of the default value of the option.

MA0003, MA0048 and MA0104 use them, so they no longer handle the `RegexOptions`. MA0220 still uses `RegexCache.IsValidPattern` with the `RegexOptions` of the option, as it validates the raw values of the options it enumerates itself, and it is now the only consumer of `ConfigurationDefinition.RegexOptions`.

`RegexCache` lost the pattern-based `IsMatch` and `Replace` overloads, which are not used anymore, and gained `Replace(Regex, ...)`. It now exposes the creation and the validation of the patterns, plus the timeout-safe operations on a `Regex`.

## Behavior change

An explicitly empty pattern is now treated as an option that is not configured, instead of a pattern that matches everything:

- `MA0003.excluded_methods_regex = ` no longer excludes every method, so the rule is not silently disabled.
- `MA0104.namespaces_regex = ` no longer matches every namespace, the default pattern is used instead.

Two tests cover it, and `docs/Rules/MA0003.md` and `docs/Rules/MA0104.md` document it.

## Validation

- `dotnet build src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.9.csproj`: 0 warning, 0 error.
- The MA0003, MA0048, MA0104 and MA0220 tests pass on the 5 Roslyn versions (841 tests, 2 new).
- The full 5.9 test run has 51 failures in `UseRegexSourceGeneratorAnalyzerTests`, `UseRegexOptionsAnalyzerTests`, `UseRegexTimeoutAnalyzerTests` and the suppressor tests. The same 51 tests fail on the branch without these changes, so they are pre-existing and unrelated.
- `dotnet run --project src/DocumentationGenerator` does not change any markdown file.