### PR TITLE
Resolve the NuGet packages of the tests from the global packages folder

### DIFF
--- a/tests/Meziantou.Analyzer.Test/Harness/NuGetPackages.cs
+++ b/tests/Meziantou.Analyzer.Test/Harness/NuGetPackages.cs
@@ -8,8 +8,10 @@ using Meziantou.Analyzer.Test.Helpers;
 namespace Meziantou.Analyzer.Test.Harness;
 
 /// <summary>
-/// Downloads the NuGet packages the tests reference, and caches them for the whole test run. The tests use it for
+/// Resolves the NuGet packages the tests reference, and caches them for the whole test run. The tests use it for
 /// the analyzers they run besides the ones of this repository, which the testing library cannot resolve itself.
+/// The packages the build already restored are read from the NuGet global packages folder, so that the tests
+/// only download the ones that are not there yet.
 /// </summary>
 internal static class NuGetPackages
 {
@@ -19,12 +21,22 @@ internal static class NuGetPackages
     // The result is shared by all the tests through Cache, so it would hang the whole test run.
     private static readonly TimeSpan NuGetDownloadTimeout = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    /// The folder NuGet extracts the restored packages to, which the testing library also uses for the packages
+    /// referenced by <see cref="Microsoft.CodeAnalysis.Testing.ReferenceAssemblies"/>. It is resolved the way NuGet
+    /// does when no NuGet.config sets 'globalPackagesFolder', which is enough as the packages that are not found
+    /// there are downloaded.
+    /// </summary>
+    private static readonly string GlobalPackagesFolder = Environment.GetEnvironmentVariable("NUGET_PACKAGES") is { Length: > 0 } folder
+        ? folder
+        : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+
     public static async Task<string[]> GetReferencesAsync(string packageName, string version, string[] includedPaths)
     {
         var bytes = Encoding.UTF8.GetBytes("v2:" + packageName + '@' + version + ':' + string.Join(',', includedPaths));
         var hash = SHA256.HashData(bytes);
         var key = Convert.ToBase64String(hash).Replace('/', '_');
-        var task = Cache.GetOrAdd(key, _ => new Lazy<Task<string[]>>(Download));
+        var task = Cache.GetOrAdd(key, _ => new Lazy<Task<string[]>>(Resolve));
         try
         {
             return await task.Value.ConfigureAwait(false);
@@ -35,49 +47,46 @@ internal static class NuGetPackages
             throw;
         }
 
-        async Task<string[]> Download()
+        async Task<string[]> Resolve()
+        {
+            var packageFolder = GetRestoredPackageFolder(packageName, version) ?? await DownloadPackageWithRetries().ConfigureAwait(false);
+            return GetAssemblies(packageFolder, includedPaths);
+        }
+
+        async Task<string> DownloadPackageWithRetries()
         {
             var cacheFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Meziantou.AnalyzerTests", "ref", key);
             var completionFile = Path.Combine(cacheFolder, ".complete");
-            bool IsCacheValid()
+
+            // A folder without the completion marker was left behind by an interrupted download,
+            // so it holds an incomplete package and must be downloaded again.
+            bool IsCacheValid() => File.Exists(completionFile);
+
+            if (IsCacheValid())
+                return cacheFolder;
+
+            const int MaxAttempts = 5;
+            for (var attempt = 1; ; attempt++)
             {
-                if (!Directory.Exists(cacheFolder))
-                    return false;
-
-                if (File.Exists(completionFile))
-                    return true;
-
-                return Directory.EnumerateFileSystemEntries(cacheFolder).Any();
-            }
-
-            if (!IsCacheValid())
-            {
-                await DownloadPackageWithRetries().ConfigureAwait(false);
-            }
-
-            async Task DownloadPackageWithRetries()
-            {
-                const int MaxAttempts = 5;
-                for (var attempt = 1; ; attempt++)
+                try
                 {
-                    try
-                    {
-                        await DownloadPackage().ConfigureAwait(false);
-                        return;
-                    }
-                    catch (Exception ex) when (!IsLastAttempt(attempt) && IsTransientException(ex))
-                    {
-                        await Task.Delay(100 * attempt).ConfigureAwait(false);
-                    }
+                    await DownloadPackage().ConfigureAwait(false);
+                    return cacheFolder;
                 }
-
-                static bool IsLastAttempt(int attempt) => attempt >= MaxAttempts;
-                static bool IsTransientException(Exception exception) => exception is HttpRequestException or IOException or InvalidDataException or OperationCanceledException or TimeoutException;
+                catch (Exception ex) when (!IsLastAttempt(attempt) && IsTransientException(ex))
+                {
+                    await Task.Delay(100 * attempt).ConfigureAwait(false);
+                }
             }
+
+            static bool IsLastAttempt(int attempt) => attempt >= MaxAttempts;
+            static bool IsTransientException(Exception exception) => exception is HttpRequestException or IOException or InvalidDataException or OperationCanceledException or TimeoutException;
 
             async Task DownloadPackage()
             {
-                var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+                // The temporary folder is a sibling of the cache folder, so that moving it is a rename.
+                // Directory.Move cannot move a folder to another volume, which the temp folder may be on.
+                var tempFolder = Path.Combine(Path.GetDirectoryName(cacheFolder)!, Guid.NewGuid().ToString("N"));
                 try
                 {
                     Directory.CreateDirectory(tempFolder);
@@ -113,11 +122,16 @@ internal static class NuGetPackages
 
                     try
                     {
-                        Directory.CreateDirectory(Path.GetDirectoryName(cacheFolder)!);
+                        if (Directory.Exists(cacheFolder) && !IsCacheValid())
+                        {
+                            Directory.Delete(cacheFolder, recursive: true);
+                        }
+
                         Directory.Move(tempFolder, cacheFolder);
                     }
                     catch (Exception ex)
                     {
+                        // Another test run may have downloaded the package at the same time
                         if (!IsCacheValid())
                         {
                             throw new InvalidOperationException("Cannot download NuGet package " + packageName + "@" + version + "\n" + ex);
@@ -132,32 +146,48 @@ internal static class NuGetPackages
                     }
                 }
             }
+        }
+    }
 
-            var dlls = Directory.GetFiles(cacheFolder, "*.dll", SearchOption.AllDirectories);
+    [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "NuGet names the folders of the global packages folder in lowercase")]
+    private static string? GetRestoredPackageFolder(string packageName, string version)
+    {
+        // NuGet extracts a package to a folder named after the lowercase package name and version,
+        // and writes '.nupkg.metadata' in it once the extraction is complete
+        var packageFolder = Path.Combine(GlobalPackagesFolder, packageName.ToLowerInvariant(), version.ToLowerInvariant());
+        return File.Exists(Path.Combine(packageFolder, ".nupkg.metadata")) ? packageFolder : null;
+    }
+
+    private static string[] GetAssemblies(string packageFolder, string[] includedPaths)
+    {
+        var result = new List<string>();
+        foreach (var dll in Directory.EnumerateFiles(packageFolder, "*.dll", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(packageFolder, dll).Replace(Path.DirectorySeparatorChar, '/');
+            if (!includedPaths.Any(path => relativePath.StartsWith(path, StringComparison.Ordinal)))
+                continue;
 
             // Filter invalid .NET assembly
-            var result = new List<string>();
-            foreach (var dll in dlls)
+            if (Path.GetFileName(dll) is "System.EnterpriseServices.Wrapper.dll")
+                continue;
+
+            if (Path.GetFileName(dll).EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            try
             {
-                if (Path.GetFileName(dll) == "System.EnterpriseServices.Wrapper.dll")
-                    continue;
-
-                if (Path.GetFileName(dll).EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                try
-                {
-                    using var stream = File.OpenRead(dll);
-                    using var peFile = new PEReader(stream);
-                    var metadataReader = peFile.GetMetadataReader();
-                    result.Add(dll);
-                }
-                catch
-                {
-                }
+                using var stream = File.OpenRead(dll);
+                using var peFile = new PEReader(stream);
+                _ = peFile.GetMetadataReader();
+            }
+            catch
+            {
+                continue;
             }
 
-            return [.. result];
+            result.Add(dll);
         }
+
+        return [.. result];
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Helpers/SharedHttpClient.cs
+++ b/tests/Meziantou.Analyzer.Test/Helpers/SharedHttpClient.cs
@@ -3,19 +3,6 @@ internal static class SharedHttpClient
 {
     public static HttpClient Instance { get; } = CreateHttpClient();
 
-    public static async Task<bool> IsUrlAccessible(this HttpClient httpClient, Uri url, CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-            return response.IsSuccessStatusCode;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
     private static HttpClient CreateHttpClient()
     {


### PR DESCRIPTION
## What

`NuGetPackages` downloaded every package it resolves straight from `nuget.org` at test time, so the suppressor tests and the tests using the framework source generators needed the network on a cold cache. On top of that, `IsCacheValid` accepted any non-empty cache directory *without* the `.complete` marker, so a directory left behind by a failed `Directory.Move` looked like a complete cache and produced a confusing missing-reference failure instead of a re-download.

- **Prefer the NuGet global packages folder.** Before downloading, `GetRestoredPackageFolder` looks for `<global packages>/<id>/<version>/` and accepts it only when NuGet's own `.nupkg.metadata` completion marker is there. The extraction path and the global packages folder now share `GetAssemblies`, which applies the `includedPaths` prefix filter to the path relative to the package folder — the same semantics the zip extraction used, where `analyzers/dotnet/Microsoft.` is a file name prefix and not a directory.
- **Require the `.complete` marker** to consider the download cache valid, and delete the folder and download it again otherwise.
- **Create the temporary folder of a download next to the cache folder**, so that moving it is a rename. `Directory.Move` cannot move a folder to another volume, which the temp folder may be on — that is what left those stale folders behind in the first place.
- **Remove the unused `SharedHttpClient.IsUrlAccessible`**, which had no callers.

## Effect

Measured on a cold download cache, running the suppressor and the regex source generator tests: `Microsoft.CodeAnalysis.NetAnalyzers@10.0.100` and `Microsoft.NETCore.App.Ref@7.0.0` now resolve locally with no network at all.

Three packages still download: `Microsoft.CodeAnalysis.CSharp.CodeStyle@5.9.0` and `Microsoft.Bcl.AsyncInterfaces@9.0.7` are not in the folder, and `Microsoft.NETCore.App.Ref@11.0.0-preview.7.26381.103` is there but was extracted by the roslyn-sdk testing library rather than by a restore, so it has no `.nupkg.metadata`. Accepting an unmarked folder would reintroduce exactly the "trust a directory that may be incomplete" bug this change fixes, so it is downloaded and cached instead.

## Notes for the reviewer

The stale cache fix is worth checking by hand: emptying the cached folders of their DLLs and removing the `.complete` markers makes 23 of the 67 suppressor and regex source generator tests fail with missing-reference errors on `main`; with this change all 67 pass and the folders are repaired.

A `PackageDownload` item per package would remove the remaining test time downloads entirely, but those versions are chosen per Roslyn version in `AnalyzerTestExtensions.cs` (`#if ROSLYN_5_0_OR_GREATER` and friends), so the props would have to duplicate five sets of version strings with nothing linking them to the C#. Left out for now; the fallback keeps working if they ever drift.

## Testing

| | |
|---|---|
| `dotnet build` (all Roslyn versions) | 0 warnings, 0 errors |
| roslyn4.8 / 4.14 / 5.0 / 5.6 / 5.9 | 3797 / 3824 / 3852 / 3876 / 3909 passed, 0 failed |
| `dotnet run --project src/DocumentationGenerator` | exit 0, no markdown changes |