### PR TITLE
Return the pooled StringBuilder on every path

### DIFF
--- a/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs
@@ -686,34 +686,39 @@ public sealed class LoggerParameterTypeAnalyzer : DiagnosticAnalyzer
         public LogValuesFormatter(string format)
         {
             var sb = ObjectPool.SharedStringBuilderPool.Get();
-            var scanIndex = 0;
-            var endIndex = format.Length;
-
-            while (scanIndex < endIndex)
+            try
             {
-                var openBraceIndex = FindBraceIndex(format, '{', scanIndex, endIndex);
-                var closeBraceIndex = FindBraceIndex(format, '}', openBraceIndex, endIndex);
+                var scanIndex = 0;
+                var endIndex = format.Length;
 
-                if (closeBraceIndex == endIndex)
+                while (scanIndex < endIndex)
                 {
-                    sb.Append(format, scanIndex, endIndex - scanIndex);
-                    scanIndex = endIndex;
-                }
-                else
-                {
-                    // Format item syntax : { index[,alignment][ :formatString] }.
-                    var formatDelimiterIndex = FindIndexOfAny(format, FormatDelimiters, openBraceIndex, closeBraceIndex);
+                    var openBraceIndex = FindBraceIndex(format, '{', scanIndex, endIndex);
+                    var closeBraceIndex = FindBraceIndex(format, '}', openBraceIndex, endIndex);
 
-                    sb.Append(format, scanIndex, openBraceIndex - scanIndex + 1);
-                    sb.Append(ValueNames.Count.ToString(CultureInfo.InvariantCulture));
-                    ValueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
-                    sb.Append(format, formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1);
+                    if (closeBraceIndex == endIndex)
+                    {
+                        sb.Append(format, scanIndex, endIndex - scanIndex);
+                        scanIndex = endIndex;
+                    }
+                    else
+                    {
+                        // Format item syntax : { index[,alignment][ :formatString] }.
+                        var formatDelimiterIndex = FindIndexOfAny(format, FormatDelimiters, openBraceIndex, closeBraceIndex);
 
-                    scanIndex = closeBraceIndex + 1;
+                        sb.Append(format, scanIndex, openBraceIndex - scanIndex + 1);
+                        sb.Append(ValueNames.Count.ToString(CultureInfo.InvariantCulture));
+                        ValueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
+                        sb.Append(format, formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1);
+
+                        scanIndex = closeBraceIndex + 1;
+                    }
                 }
             }
-
-            ObjectPool.SharedStringBuilderPool.Return(sb);
+            finally
+            {
+                ObjectPool.SharedStringBuilderPool.Return(sb);
+            }
         }
 
         public List<string> ValueNames { get; } = [];

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
@@ -302,15 +302,21 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
         private static bool TryGetConstStringValue(IOperation operation, [NotNullWhen(true)] out string? value)
         {
             var sb = ObjectPool.SharedStringBuilderPool.Get();
-            if (OptimizeStringBuilderUsageAnalyzerCommon.TryGetConstStringValue(operation, sb))
+            try
             {
-                value = sb.ToString();
-                ObjectPool.SharedStringBuilderPool.Return(sb);
-                return true;
-            }
+                if (OptimizeStringBuilderUsageAnalyzerCommon.TryGetConstStringValue(operation, sb))
+                {
+                    value = sb.ToString();
+                    return true;
+                }
 
-            value = default;
-            return false;
+                value = default;
+                return false;
+            }
+            finally
+            {
+                ObjectPool.SharedStringBuilderPool.Return(sb);
+            }
         }
     }
 }

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzerCommon.cs
@@ -5,14 +5,14 @@ internal static class OptimizeStringBuilderUsageAnalyzerCommon
     public static string? GetConstStringValue(IOperation operation)
     {
         var sb = ObjectPool.SharedStringBuilderPool.Get();
-        if (TryGetConstStringValue(operation, sb))
+        try
         {
-            var result = sb.ToString();
-            ObjectPool.SharedStringBuilderPool.Return(sb);
-            return result;
+            return TryGetConstStringValue(operation, sb) ? sb.ToString() : null;
         }
-
-        return null;
+        finally
+        {
+            ObjectPool.SharedStringBuilderPool.Return(sb);
+        }
     }
 
     public static bool TryGetConstStringValue(IOperation operation, StringBuilder sb)


### PR DESCRIPTION
## What

The three call sites of `ObjectPool.SharedStringBuilderPool` called `Get()` unconditionally but `Return()` only on the success path. This wraps each of them in `try`/`finally` so the builder goes back to the pool on every path.

- [`OptimizeStringBuilderUsageAnalyzerCommon.GetConstStringValue`](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzerCommon.cs) — `Return` sat inside the `if`, so the builder was dropped whenever the operation was not a constant string.
- [`OptimizeStringBuilderUsageAnalyzer.TryGetConstStringValue`](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs) — same shape, with the `value = default` branch falling out without returning the builder.
- [`LoggerParameterTypeAnalyzer.LogValuesFormatter`](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/LoggerParameterTypeAnalyzer.cs) — no early return, but `format.Substring` can throw on a malformed format string and lose the builder.

## Why

The failing probe is the common case, not the exception: `IsConstString` runs against arbitrary `StringBuilder.Append` arguments, and most of them are not constants.

`DefaultObjectPool` retains `Environment.ProcessorCount * 2` items and refills only through `Return`, so those misses drain the pool and later `Get()` calls fall through to `_createFunc`. Pooling then costs the interlocked machinery *and* allocates anyway — worse than not pooling at all.

There was no correctness bug. `StringBuilderPooledObjectPolicy.Return` clears the builder, and a partially filled builder was never returned, so a dirty builder could not enter the pool.

## Notes for reviewers

- Behavior-preserving refactor, so no new tests — pool occupancy is not observable through the analyzer test infrastructure.
- I used `try`/`finally` rather than introducing a lease type because `Internals/ObjectPool.cs` is a vendored copy of `Microsoft.Extensions.ObjectPool` and is easier to keep diffable against upstream.
- Unrelated observation, left alone deliberately: in `LogValuesFormatter` the `StringBuilder` is written but never read — the constructor's only output is `ValueNames`. Upstream exposes the built string as a `Format` property; here it is dead work, so the whole `Get`/`Append`/`Return` sequence could arguably be deleted rather than fixed. Happy to do that in a follow-up if you prefer.

## Verification

- `dotnet build src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.9.csproj` — succeeded, 0 warnings.
- `dotnet test --max-parallel-test-modules 2` — 19258 passed, 0 failed, across Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- `dotnet run --project src/DocumentationGenerator` — exit 0, no markdown changes.
