### PR TITLE
Split the TryGetValue part of MA0186 into a new rule MA0221

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0218](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0218.md)|Design|The language attribute is empty|ℹ️|✔️|❌|❌|
 |[MA0219](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md)|Design|Set the language attribute in XML comment|👻|✔️|✔️|❌|
 |[MA0220](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0220.md)|Design|The configured regular expression is not valid|⚠️|✔️|❌|❌|
+|[MA0221](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0221.md)|Design|TryGetValue method should use \[MaybeNullWhen(false)\] on the value parameter|ℹ️|❌|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -219,6 +219,7 @@
 |[MA0218](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0218.md)|Design|The language attribute is empty|<span title='Info'>ℹ️</span>|✔️|❌|❌|
 |[MA0219](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md)|Design|Set the language attribute in XML comment|<span title='Hidden'>👻</span>|✔️|✔️|❌|
 |[MA0220](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0220.md)|Design|The configured regular expression is not valid|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0221](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0221.md)|Design|TryGetValue method should use \[MaybeNullWhen(false)\] on the value parameter|<span title='Info'>ℹ️</span>|❌|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0186.md
+++ b/docs/Rules/MA0186.md
@@ -5,15 +5,11 @@ Sources: [MissingNotNullWhenAttributeOnEqualsAnalyzer.cs](https://github.com/mez
 
 ## Description
 
-This rule reports missing nullable attributes on method parameters to improve nullable reference type analysis:
+When implementing `Equals(object?)` or `IEquatable<T>.Equals(T?)`, the parameter should be annotated with `[NotNullWhen(true)]` to inform the compiler that when the method returns `true`, the parameter is guaranteed to be non-null.
 
-1. When implementing `Equals(object?)` or `IEquatable<T>.Equals(T?)`, the parameter should be annotated with `[NotNullWhen(true)]` to inform the compiler that when the method returns `true`, the parameter is guaranteed to be non-null.
-
-2. When implementing `IDictionary<TKey, TValue>.TryGetValue`, the `value` parameter should be annotated with `[MaybeNullWhen(false)]` to inform the compiler that when the method returns `false`, the parameter may be null.
+A related rule, [MA0221](MA0221.md), reports missing `[MaybeNullWhen(false)]` on `IDictionary<TKey, TValue>.TryGetValue` implementations.
 
 ## Motivation
-
-### Equals methods
 
 Without the `[NotNullWhen(true)]` attribute, the compiler cannot track that a successful equality comparison means the parameter is non-null. This can lead to unnecessary null checks or null-forgiving operators in code that follows an equality check.
 
@@ -45,33 +41,7 @@ if (myInstance.Equals(someObj))
 }
 ````
 
-### TryGetValue methods
-
-Without the `[MaybeNullWhen(false)]` attribute, the compiler cannot track that when `TryGetValue` returns `false`, the out parameter may be null.
-
-````c#
-// ❌ Without the attribute
-public bool TryGetValue(TKey key, out TValue? value)
-{
-    // Implementation
-}
-
-// ✅ With the attribute
-public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue? value)
-{
-    // Implementation
-}
-
-// Usage
-if (dictionary.TryGetValue(key, out var value))
-{
-    value.ToString(); // Compiler knows value is not null
-}
-````
-
 ## How to fix violations
-
-### For Equals methods
 
 Add the `[NotNullWhen(true)]` attribute to the parameter:
 
@@ -88,23 +58,6 @@ public class MyType : IEquatable<MyType>
     public bool Equals([NotNullWhen(true)] MyType? other)
     {
         return other is not null && /* comparison logic */;
-    }
-}
-````
-
-### For TryGetValue methods
-
-Add the `[MaybeNullWhen(false)]` attribute to the value parameter:
-
-````c#
-using System.Diagnostics.CodeAnalysis;
-using System.Collections.Generic;
-
-public class MyDictionary : IDictionary<string, string?>
-{
-    public bool TryGetValue(string key, [MaybeNullWhen(false)] out string? value)
-    {
-        // Implementation
     }
 }
 ````

--- a/docs/Rules/MA0221.md
+++ b/docs/Rules/MA0221.md
@@ -1,0 +1,65 @@
+# MA0221 - TryGetValue method should use \[MaybeNullWhen(false)\] on the value parameter
+<!-- sources -->
+Sources: [MissingMaybeNullWhenAttributeOnTryGetValueAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/MissingMaybeNullWhenAttributeOnTryGetValueAnalyzer.cs), [MissingMaybeNullWhenAttributeOnTryGetValueFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/MissingMaybeNullWhenAttributeOnTryGetValueFixer.cs)
+<!-- sources -->
+
+## Description
+
+When implementing `IDictionary<TKey, TValue>.TryGetValue`, the `value` parameter should be annotated with `[MaybeNullWhen(false)]` to inform the compiler that the parameter may be null only when the method returns `false`.
+
+A related rule, [MA0186](MA0186.md), reports missing `[NotNullWhen(true)]` on `Equals` parameters.
+
+## Motivation
+
+Without the `[MaybeNullWhen(false)]` attribute, the compiler cannot track that the out parameter is non-null when `TryGetValue` returns `true`.
+
+````c#
+// ❌ Without the attribute
+public bool TryGetValue(TKey key, out TValue? value)
+{
+    // Implementation
+}
+
+// Usage
+if (dictionary.TryGetValue(key, out var value))
+{
+    value.ToString(); // Warning CS8602
+}
+
+// ✅ With the attribute
+public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue? value)
+{
+    // Implementation
+}
+
+// Usage
+if (dictionary.TryGetValue(key, out var value))
+{
+    value.ToString(); // No warning
+}
+````
+
+## How to fix violations
+
+Add the `[MaybeNullWhen(false)]` attribute to the value parameter:
+
+````c#
+using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+
+public class MyDictionary : IDictionary<string, string?>
+{
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out string? value)
+    {
+        // Implementation
+    }
+}
+````
+
+## Configuration
+
+This rule is disabled by default as it's a suggestion for improved nullable annotations. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0221.severity = suggestion
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MissingMaybeNullWhenAttributeOnTryGetValueFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MissingMaybeNullWhenAttributeOnTryGetValueFixer.cs
@@ -1,0 +1,31 @@
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class MissingMaybeNullWhenAttributeOnTryGetValueFixer : CodeFixProvider
+{
+    private const string AttributeMetadataName = "System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute";
+    private const string MethodName = "TryGetValue";
+    private const string Title = "Add [MaybeNullWhen(false)]";
+
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.MissingMaybeNullWhenAttributeOnTryGetValue);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (!NullableAnalysisAttributeFixerHelper.TryGetParameterToFix(root, semanticModel, context.Span, AttributeMetadataName, MethodName, context.CancellationToken, out var parameter, out var parameterSymbol))
+            return;
+
+        if (parameterSymbol.RefKind != RefKind.Out)
+            return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                Title,
+                ct => NullableAnalysisAttributeFixerHelper.AddOrUpdateAttributeAsync(context.Document, parameter, AttributeMetadataName, expectedValue: false, ct),
+                equivalenceKey: Title),
+            context.Diagnostics);
+    }
+}

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MissingNotNullWhenAttributeOnEqualsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MissingNotNullWhenAttributeOnEqualsFixer.cs
@@ -1,10 +1,11 @@
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public sealed class MissingNotNullWhenAttributeOnEqualsFixer : CodeFixProvider
 {
+    private const string AttributeMetadataName = "System.Diagnostics.CodeAnalysis.NotNullWhenAttribute";
+    private const string Title = "Add [NotNullWhen(true)]";
+
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.MissingNotNullWhenAttributeOnEquals);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
@@ -12,71 +13,15 @@ public sealed class MissingNotNullWhenAttributeOnEqualsFixer : CodeFixProvider
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        var parameter = nodeToFix?.FirstAncestorOrSelf<ParameterSyntax>();
-        if (parameter is null)
-            return;
-
         var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-        if (semanticModel?.GetDeclaredSymbol(parameter, context.CancellationToken) is not IParameterSymbol parameterSymbol)
-            return;
-
-        if (parameterSymbol.ContainingSymbol is not IMethodSymbol methodSymbol)
-            return;
-
-        var (attributeMetadataName, expectedValue, title) = methodSymbol.Name switch
-        {
-            "TryGetValue" when parameterSymbol.RefKind == RefKind.Out => ("System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute", false, "Add [MaybeNullWhen(false)]"),
-            "Equals" => ("System.Diagnostics.CodeAnalysis.NotNullWhenAttribute", true, "Add [NotNullWhen(true)]"),
-            _ => default,
-        };
-
-        if (attributeMetadataName is null)
+        if (!NullableAnalysisAttributeFixerHelper.TryGetParameterToFix(root, semanticModel, context.Span, AttributeMetadataName, nameof(object.Equals), context.CancellationToken, out var parameter, out _))
             return;
 
         context.RegisterCodeFix(
             CodeAction.Create(
-                title,
-                ct => AddOrUpdateAttribute(context.Document, parameter, attributeMetadataName, expectedValue, ct),
-                equivalenceKey: title),
+                Title,
+                ct => NullableAnalysisAttributeFixerHelper.AddOrUpdateAttributeAsync(context.Document, parameter, AttributeMetadataName, expectedValue: true, ct),
+                equivalenceKey: Title),
             context.Diagnostics);
-    }
-
-    private static async Task<Document> AddOrUpdateAttribute(Document document, ParameterSyntax parameter, string attributeMetadataName, bool expectedValue, CancellationToken cancellationToken)
-    {
-        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var semanticModel = editor.SemanticModel;
-        var generator = editor.Generator;
-
-        var attributeSymbol = semanticModel.Compilation.GetBestTypeByMetadataName(attributeMetadataName);
-        if (attributeSymbol is null)
-            return document;
-
-        var boolExpression = expectedValue ? LiteralExpression(SyntaxKind.TrueLiteralExpression) : LiteralExpression(SyntaxKind.FalseLiteralExpression);
-        var argumentList = AttributeArgumentList(SingletonSeparatedList(AttributeArgument(boolExpression)));
-
-        var existingAttribute = parameter.AttributeLists
-            .SelectMany(static attributeList => attributeList.Attributes)
-            .FirstOrDefault(attribute =>
-            {
-                var symbol = semanticModel.GetSymbolInfo(attribute, cancellationToken).Symbol?.ContainingType;
-                return symbol.IsEqualTo(attributeSymbol);
-            });
-
-        if (existingAttribute is not null)
-        {
-            editor.ReplaceNode(existingAttribute, existingAttribute.WithArgumentList(argumentList));
-            return editor.GetChangedDocument();
-        }
-
-        var newAttribute = generator.Attribute(
-            generator.TypeExpression(attributeSymbol, addImport: true),
-            [
-                generator.AttributeArgument(generator.LiteralExpression(expectedValue)),
-            ]);
-
-        var newNode = generator.AddAttributes(parameter, newAttribute);
-        editor.ReplaceNode(parameter, newNode);
-        return editor.GetChangedDocument();
     }
 }

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/NullableAnalysisAttributeFixerHelper.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/NullableAnalysisAttributeFixerHelper.cs
@@ -1,0 +1,69 @@
+using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Meziantou.Analyzer.Rules;
+
+internal static class NullableAnalysisAttributeFixerHelper
+{
+    public static async Task<Document> AddOrUpdateAttributeAsync(Document document, ParameterSyntax parameter, string attributeMetadataName, bool expectedValue, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var semanticModel = editor.SemanticModel;
+        var generator = editor.Generator;
+
+        var attributeSymbol = semanticModel.Compilation.GetBestTypeByMetadataName(attributeMetadataName);
+        if (attributeSymbol is null)
+            return document;
+
+        var existingAttribute = parameter.AttributeLists
+            .SelectMany(static attributeList => attributeList.Attributes)
+            .FirstOrDefault(attribute =>
+            {
+                var symbol = semanticModel.GetSymbolInfo(attribute, cancellationToken).Symbol?.ContainingType;
+                return symbol.IsEqualTo(attributeSymbol);
+            });
+
+        if (existingAttribute is not null)
+        {
+            var boolExpression = expectedValue ? LiteralExpression(SyntaxKind.TrueLiteralExpression) : LiteralExpression(SyntaxKind.FalseLiteralExpression);
+            var argumentList = AttributeArgumentList(SingletonSeparatedList(AttributeArgument(boolExpression)));
+            editor.ReplaceNode(existingAttribute, existingAttribute.WithArgumentList(argumentList));
+            return editor.GetChangedDocument();
+        }
+
+        var newAttribute = generator.Attribute(
+            generator.TypeExpression(attributeSymbol, addImport: true),
+            [
+                generator.AttributeArgument(generator.LiteralExpression(expectedValue)),
+            ]);
+
+        var newNode = generator.AddAttributes(parameter, newAttribute);
+        editor.ReplaceNode(parameter, newNode);
+        return editor.GetChangedDocument();
+    }
+
+    public static bool TryGetParameterToFix(SyntaxNode? root, SemanticModel? semanticModel, TextSpan span, string attributeMetadataName, string methodName, CancellationToken cancellationToken, [NotNullWhen(true)] out ParameterSyntax? parameter, [NotNullWhen(true)] out IParameterSymbol? parameterSymbol)
+    {
+        parameter = null;
+        parameterSymbol = null;
+
+        if (root?.FindNode(span, getInnermostNodeForTie: true)?.FirstAncestorOrSelf<ParameterSyntax>() is not { } parameterSyntax)
+            return false;
+
+        if (semanticModel is null)
+            return false;
+
+        if (semanticModel.GetDeclaredSymbol(parameterSyntax, cancellationToken) is not IParameterSymbol symbol)
+            return false;
+
+        if (symbol.ContainingSymbol is not IMethodSymbol methodSymbol || !string.Equals(methodSymbol.Name, methodName, StringComparison.Ordinal))
+            return false;
+
+        if (semanticModel.Compilation.GetBestTypeByMetadataName(attributeMetadataName) is null)
+            return false;
+
+        parameter = parameterSyntax;
+        parameterSymbol = symbol;
+        return true;
+    }
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -655,3 +655,6 @@ dotnet_diagnostic.MA0219.severity = error
 
 # MA0220: The configured regular expression is not valid
 dotnet_diagnostic.MA0220.severity = error
+
+# MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
+dotnet_diagnostic.MA0221.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -655,3 +655,6 @@ dotnet_diagnostic.MA0219.severity = suggestion
 
 # MA0220: The configured regular expression is not valid
 dotnet_diagnostic.MA0220.severity = suggestion
+
+# MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
+dotnet_diagnostic.MA0221.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -655,3 +655,6 @@ dotnet_diagnostic.MA0219.severity = warning
 
 # MA0220: The configured regular expression is not valid
 dotnet_diagnostic.MA0220.severity = warning
+
+# MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
+dotnet_diagnostic.MA0221.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -655,3 +655,6 @@ dotnet_diagnostic.MA0219.severity = silent
 
 # MA0220: The configured regular expression is not valid
 dotnet_diagnostic.MA0220.severity = warning
+
+# MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
+dotnet_diagnostic.MA0221.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -655,3 +655,6 @@ dotnet_diagnostic.MA0219.severity = none
 
 # MA0220: The configured regular expression is not valid
 dotnet_diagnostic.MA0220.severity = none
+
+# MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
+dotnet_diagnostic.MA0221.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -220,6 +220,7 @@ internal static class RuleIdentifiers
     public const string EmptyLanguageAttributeInXmlComment = "MA0218";
     public const string MissingLanguageAttributeInXmlComment = "MA0219";
     public const string InvalidRegexConfiguration = "MA0220";
+    public const string MissingMaybeNullWhenAttributeOnTryGetValue = "MA0221";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/MissingMaybeNullWhenAttributeOnTryGetValueAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MissingMaybeNullWhenAttributeOnTryGetValueAnalyzer.cs
@@ -1,0 +1,89 @@
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MissingMaybeNullWhenAttributeOnTryGetValueAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.MissingMaybeNullWhenAttributeOnTryGetValue,
+        title: "TryGetValue method should use [MaybeNullWhen(false)] on the value parameter",
+        messageFormat: "TryGetValue method should use [MaybeNullWhen(false)] on parameter '{0}'",
+        RuleCategories.Design,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.MissingMaybeNullWhenAttributeOnTryGetValue));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(ctx =>
+        {
+            var maybeNullWhenAttributeSymbol = ctx.Compilation.GetBestTypeByMetadataName("System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute");
+            if (maybeNullWhenAttributeSymbol is null)
+                return;
+
+            var idictionaryOfTSymbol = ctx.Compilation.GetBestTypeByMetadataName("System.Collections.Generic.IDictionary`2");
+            if (idictionaryOfTSymbol is null)
+                return;
+
+            if (idictionaryOfTSymbol.GetMembers("TryGetValue").Length != 1)
+                return;
+
+            ctx.RegisterSymbolAction(context =>
+            {
+                var namedType = (INamedTypeSymbol)context.Symbol;
+                foreach (var interfaceType in namedType.AllInterfaces)
+                {
+                    if (!interfaceType.ConstructedFrom.IsEqualTo(idictionaryOfTSymbol))
+                        continue;
+
+                    var dictionaryTryGetValueSymbols = interfaceType.GetMembers("TryGetValue");
+                    if (dictionaryTryGetValueSymbols.Length != 1)
+                        continue;
+
+                    if (namedType.FindImplementationForInterfaceMember(dictionaryTryGetValueSymbols[0]) is not IMethodSymbol implementation)
+                        continue;
+
+                    if (implementation.Parameters.Length != 2)
+                        continue;
+
+                    var valueParameter = implementation.Parameters[1];
+
+                    // Check if the parameter is an out parameter
+                    if (valueParameter.RefKind != RefKind.Out)
+                        continue;
+
+                    // Check if the parameter is nullable
+                    if (valueParameter.NullableAnnotation != NullableAnnotation.Annotated)
+                        continue;
+
+                    // Check if the parameter already has [MaybeNullWhen(false)] attribute
+                    if (HasMaybeNullWhenAttribute(valueParameter, maybeNullWhenAttributeSymbol, expectedValue: false))
+                        continue;
+
+                    context.ReportDiagnostic(Rule, valueParameter, valueParameter.Name);
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+
+    private static bool HasMaybeNullWhenAttribute(IParameterSymbol parameter, INamedTypeSymbol maybeNullWhenAttributeSymbol, bool expectedValue)
+    {
+        foreach (var attribute in parameter.GetAttributes())
+        {
+            if (attribute.AttributeClass.IsEqualTo(maybeNullWhenAttributeSymbol))
+            {
+                if (attribute.ConstructorArguments.Length == 1 && attribute.ConstructorArguments[0].Value is bool value && value == expectedValue)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/MissingNotNullWhenAttributeOnEqualsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MissingNotNullWhenAttributeOnEqualsAnalyzer.cs
@@ -1,11 +1,9 @@
-using System.Runtime.CompilerServices;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor EqualsRule = new(
+    private static readonly DiagnosticDescriptor Rule = new(
         RuleIdentifiers.MissingNotNullWhenAttributeOnEquals,
         title: "Equals method should use [NotNullWhen(true)] on the parameter",
         messageFormat: "Equals method should use [NotNullWhen(true)] on parameter '{0}'",
@@ -15,17 +13,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzer : DiagnosticAnal
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.MissingNotNullWhenAttributeOnEquals));
 
-    private static readonly DiagnosticDescriptor TryGetValueRule = new(
-        RuleIdentifiers.MissingNotNullWhenAttributeOnEquals,
-        title: "TryGetValue method should use [MaybeNullWhen(false)] on the value parameter",
-        messageFormat: "TryGetValue method should use [MaybeNullWhen(false)] on parameter '{0}'",
-        RuleCategories.Design,
-        DiagnosticSeverity.Info,
-        isEnabledByDefault: false,
-        description: "",
-        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.MissingNotNullWhenAttributeOnEquals));
-
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(EqualsRule, TryGetValueRule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -35,126 +23,74 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzer : DiagnosticAnal
         context.RegisterCompilationStartAction(ctx =>
         {
             var notNullWhenAttributeSymbol = ctx.Compilation.GetBestTypeByMetadataName("System.Diagnostics.CodeAnalysis.NotNullWhenAttribute");
-            var maybeNullWhenAttributeSymbol = ctx.Compilation.GetBestTypeByMetadataName("System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute");
+            if (notNullWhenAttributeSymbol is null)
+                return;
+
             var iequatableOfTSymbol = ctx.Compilation.GetBestTypeByMetadataName("System.IEquatable`1");
-            var idictionaryOfTSymbol = ctx.Compilation.GetBestTypeByMetadataName("System.Collections.Generic.IDictionary`2");
 
-            if (idictionaryOfTSymbol != null && maybeNullWhenAttributeSymbol is not null)
+            ctx.RegisterSymbolAction(context =>
             {
-                var tryGetValueSymbols = idictionaryOfTSymbol.GetMembers("TryGetValue");
-                if (tryGetValueSymbols.Length == 1)
+                var method = (IMethodSymbol)context.Symbol;
+                if (method.Name is not nameof(object.Equals))
+                    return;
+
+                if (!method.ReturnType.IsBoolean())
+                    return;
+
+                if (method.Parameters.Length != 1)
+                    return;
+
+                if (method.IsStatic)
+                    return;
+
+                var parameter = method.Parameters[0];
+
+                // Check if the parameter is nullable, this also ensures nullable annotations are enabled for the parameter
+                if (parameter.NullableAnnotation != NullableAnnotation.Annotated)
+                    return;
+
+                // Check if it's Equals(object?) override using helper
+                var isObjectEqualsOverride = false;
+                if (method.IsOverride && parameter.Type.IsObject())
                 {
-                    var tryGetValueSymbol = tryGetValueSymbols[0];
-                    ctx.RegisterSymbolAction(context =>
+                    // Verify it's overriding object.Equals by checking the base member
+                    var currentMethod = method.OverriddenMethod;
+                    while (currentMethod is not null)
                     {
-                        var namedType = (INamedTypeSymbol)context.Symbol;
-                        foreach (var interfaceType in namedType.AllInterfaces)
+                        if (currentMethod.ContainingType.IsObject())
                         {
-                            if (!interfaceType.ConstructedFrom.IsEqualTo(idictionaryOfTSymbol))
-                                continue;
-
-                            var dictionaryTryGetValueSymbols = interfaceType.GetMembers("TryGetValue");
-                            if (dictionaryTryGetValueSymbols.Length != 1)
-                                continue;
-
-                            var implementation = namedType.FindImplementationForInterfaceMember(dictionaryTryGetValueSymbols[0]) as IMethodSymbol;
-                            if (implementation is null)
-                                continue;
-
-                            if (implementation.Parameters.Length != 2)
-                                continue;
-
-                            var valueParameter = implementation.Parameters[1];
-
-                            // Check if the parameter is an out parameter
-                            if (valueParameter.RefKind != RefKind.Out)
-                                continue;
-
-                            // Check if the parameter is nullable
-                            if (valueParameter.NullableAnnotation != NullableAnnotation.Annotated)
-                                continue;
-
-                            // Check if the parameter already has [MaybeNullWhen(false)] attribute
-                            if (HasMaybeNullWhenAttribute(valueParameter, maybeNullWhenAttributeSymbol, expectedValue: false))
-                                continue;
-
-                            // Report diagnostic
-                            context.ReportDiagnostic(TryGetValueRule, valueParameter, valueParameter.Name);
+                            isObjectEqualsOverride = true;
+                            break;
                         }
-                    }, SymbolKind.NamedType);
+                        currentMethod = currentMethod.OverriddenMethod;
+                    }
                 }
 
-
-            }
-
-            if (notNullWhenAttributeSymbol is not null)
-            {
-                context.RegisterSymbolAction(context =>
+                // Check if it's IEquatable<T>.Equals(T?) implementation using helper
+                var isIEquatableEquals = false;
+                if (iequatableOfTSymbol is not null && method.ContainingType is not null && !method.ContainingType.IsValueType)
                 {
-                    var method = (IMethodSymbol)context.Symbol;
-                    if (method.Name is nameof(object.Equals))
+                    if (method.IsInterfaceImplementation())
                     {
-                        if (!method.ReturnType.IsBoolean())
-                            return;
-
-                        if (method.Parameters.Length != 1)
-                            return;
-
-                        if (method.IsStatic)
-                            return;
-
-                        var parameter = method.Parameters[0];
-
-                        // Check if the parameter is nullable, this also ensures nullable annotations are enabled for the parameter
-                        if (parameter.NullableAnnotation != NullableAnnotation.Annotated)
-                            return;
-
-
-                        // Check if it's Equals(object?) override using helper
-                        var isObjectEqualsOverride = false;
-                        if (method.IsOverride && parameter.Type.IsObject())
+                        var interfaceMethod = method.GetImplementedInterfaceMember();
+                        if (interfaceMethod is not null &&
+                            interfaceMethod.ContainingType is INamedTypeSymbol interfaceType &&
+                            interfaceType.ConstructedFrom.IsEqualTo(iequatableOfTSymbol))
                         {
-                            // Verify it's overriding object.Equals by checking the base member
-                            var currentMethod = method.OverriddenMethod;
-                            while (currentMethod is not null)
-                            {
-                                if (currentMethod.ContainingType.IsObject())
-                                {
-                                    isObjectEqualsOverride = true;
-                                    break;
-                                }
-                                currentMethod = currentMethod.OverriddenMethod;
-                            }
+                            isIEquatableEquals = true;
                         }
-
-                        // Check if it's IEquatable<T>.Equals(T?) implementation using helper
-                        var isIEquatableEquals = false;
-                        if (iequatableOfTSymbol is not null && method.ContainingType is not null && !method.ContainingType.IsValueType)
-                        {
-                            if (method.IsInterfaceImplementation())
-                            {
-                                var interfaceMethod = method.GetImplementedInterfaceMember();
-                                if (interfaceMethod is not null &&
-                                    interfaceMethod.ContainingType is INamedTypeSymbol interfaceType &&
-                                    interfaceType.ConstructedFrom.IsEqualTo(iequatableOfTSymbol))
-                                {
-                                    isIEquatableEquals = true;
-                                }
-                            }
-                        }
-
-                        if (!isObjectEqualsOverride && !isIEquatableEquals)
-                            return;
-
-                        // Check if the parameter already has [NotNullWhen(true)] attribute
-                        if (HasNotNullWhenAttribute(parameter, notNullWhenAttributeSymbol, expectedValue: true))
-                            return;
-
-                        // Report diagnostic
-                        context.ReportDiagnostic(EqualsRule, parameter, parameter.Name);
                     }
-                }, SymbolKind.Method);
-            }
+                }
+
+                if (!isObjectEqualsOverride && !isIEquatableEquals)
+                    return;
+
+                // Check if the parameter already has [NotNullWhen(true)] attribute
+                if (HasNotNullWhenAttribute(parameter, notNullWhenAttributeSymbol, expectedValue: true))
+                    return;
+
+                context.ReportDiagnostic(Rule, parameter, parameter.Name);
+            }, SymbolKind.Method);
         });
     }
 
@@ -170,21 +106,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzer : DiagnosticAnal
                 }
             }
         }
-        return false;
-    }
 
-    private static bool HasMaybeNullWhenAttribute(IParameterSymbol parameter, INamedTypeSymbol maybeNullWhenAttributeSymbol, bool expectedValue)
-    {
-        foreach (var attribute in parameter.GetAttributes())
-        {
-            if (attribute.AttributeClass.IsEqualTo(maybeNullWhenAttributeSymbol))
-            {
-                if (attribute.ConstructorArguments.Length == 1 && attribute.ConstructorArguments[0].Value is bool value && value == expectedValue)
-                {
-                    return true;
-                }
-            }
-        }
         return false;
     }
 }

--- a/tests/Meziantou.Analyzer.Test/RuleHelpUri.cs
+++ b/tests/Meziantou.Analyzer.Test/RuleHelpUri.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Analyzer.Test;
@@ -5,6 +6,26 @@ public sealed class RuleHelpUri
 {
     [Fact]
     public void HelpUriIsSet()
+    {
+        foreach (var diag in GetSupportedDiagnostics())
+        {
+            Assert.Equal($"https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/{diag.Id}.md", diag.HelpLinkUri);
+        }
+    }
+
+    [Fact]
+    public void EachRuleIdHasASingleDescriptor()
+    {
+        var duplicatedIds = GetSupportedDiagnostics()
+            .GroupBy(diag => diag.Id, StringComparer.Ordinal)
+            .Where(group => group.DistinctBy(diag => diag.Title.ToString(CultureInfo.InvariantCulture), StringComparer.Ordinal).Count() > 1)
+            .Select(group => group.Key)
+            .ToArray();
+
+        Assert.Empty(duplicatedIds);
+    }
+
+    private static IEnumerable<DiagnosticDescriptor> GetSupportedDiagnostics()
     {
         foreach (var type in typeof(AbstractTypesShouldNotHaveConstructorsAnalyzer).Assembly.GetExportedTypes())
         {
@@ -17,7 +38,7 @@ public sealed class RuleHelpUri
             var instance = (DiagnosticAnalyzer)Activator.CreateInstance(type)!;
             foreach (var diag in instance.SupportedDiagnostics)
             {
-                Assert.Equal($"https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/{diag.Id}.md", diag.HelpLinkUri);
+                yield return diag;
             }
         }
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/MissingMaybeNullWhenAttributeOnTryGetValueAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MissingMaybeNullWhenAttributeOnTryGetValueAnalyzerTests.cs
@@ -1,0 +1,447 @@
+using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
+    Meziantou.Analyzer.Rules.MissingMaybeNullWhenAttributeOnTryGetValueAnalyzer,
+    Meziantou.Analyzer.Rules.MissingMaybeNullWhenAttributeOnTryGetValueFixer>;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class MissingMaybeNullWhenAttributeOnTryGetValueAnalyzerTests
+{
+    [Fact]
+    public Task TryGetValue_IDictionary_ExplicitWithoutAttribute_ShouldReportDiagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+
+            class MyDictionary : IDictionary<string, string?>
+            {
+                bool IDictionary<string, string?>.TryGetValue(string key, out string? {|MA0221:value|})
+                {
+                    value = null;
+                    return false;
+                }
+
+                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public ICollection<string> Keys => throw new System.NotImplementedException();
+                public ICollection<string?> Values => throw new System.NotImplementedException();
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string? value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryGetValue_IDictionary_ExplicitWithAttribute_ShouldNotReportDiagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Diagnostics.CodeAnalysis;
+
+            class MyDictionary : IDictionary<string, string?>
+            {
+                bool IDictionary<string, string?>.TryGetValue(string key, [MaybeNullWhen(false)] out string? value)
+                {
+                    value = null;
+                    return false;
+                }
+
+                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public ICollection<string> Keys => throw new System.NotImplementedException();
+                public ICollection<string?> Values => throw new System.NotImplementedException();
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string? value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryGetValue_IDictionary_WithoutAttribute_ShouldReportDiagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+
+            class MyDictionary : IDictionary<string, string?>
+            {
+                public bool TryGetValue(string key, out string? {|MA0221:value|})
+                {
+                    value = null;
+                    return false;
+                }
+
+                // Other IDictionary members...
+                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public ICollection<string> Keys => throw new System.NotImplementedException();
+                public ICollection<string?> Values => throw new System.NotImplementedException();
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string? value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryGetValue_IDictionary_WithoutAttribute_ShouldFix()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Diagnostics.CodeAnalysis;
+
+            class MyDictionary : IDictionary<string, string?>
+            {
+                public bool TryGetValue(string key, out string? {|MA0221:value|})
+                {
+                    value = null;
+                    return false;
+                }
+
+                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public ICollection<string> Keys => throw new System.NotImplementedException();
+                public ICollection<string?> Values => throw new System.NotImplementedException();
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string? value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+        test.FixedCode = """
+            using System.Collections.Generic;
+            using System.Diagnostics.CodeAnalysis;
+
+            class MyDictionary : IDictionary<string, string?>
+            {
+                public bool TryGetValue(string key, [MaybeNullWhen(false)] out string? value)
+                {
+                    value = null;
+                    return false;
+                }
+
+                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public ICollection<string> Keys => throw new System.NotImplementedException();
+                public ICollection<string?> Values => throw new System.NotImplementedException();
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string? value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryGetValue_IDictionary_WithAttribute_ShouldNotReportDiagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Diagnostics.CodeAnalysis;
+
+            class MyDictionary : IDictionary<string, string?>
+            {
+                public bool TryGetValue(string key, [MaybeNullWhen(false)] out string? value)
+                {
+                    value = null;
+                    return false;
+                }
+
+                // Other IDictionary members...
+                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public ICollection<string> Keys => throw new System.NotImplementedException();
+                public ICollection<string?> Values => throw new System.NotImplementedException();
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string? value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryGetValue_IDictionary_Twice_BothInvalid_ShouldReportDiagnostics()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            class MyDictionary : IDictionary<string, string?>, IDictionary<int, string?>
+            {
+                public bool TryGetValue(string key, out string? {|MA0221:stringValue|})
+                {
+                    stringValue = null;
+                    return false;
+                }
+
+                public bool TryGetValue(int key, out string? {|MA0221:intValue|})
+                {
+                    intValue = null;
+                    return false;
+                }
+
+                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public string? this[int key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+                ICollection<string> IDictionary<string, string?>.Keys => throw new System.NotImplementedException();
+                ICollection<int> IDictionary<int, string?>.Keys => throw new System.NotImplementedException();
+                ICollection<string?> IDictionary<string, string?>.Values => throw new System.NotImplementedException();
+                ICollection<string?> IDictionary<int, string?>.Values => throw new System.NotImplementedException();
+
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string? value) => throw new System.NotImplementedException();
+                public void Add(int key, string? value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public bool ContainsKey(int key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<int, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(int key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
+                IEnumerator<KeyValuePair<string, string?>> IEnumerable<KeyValuePair<string, string?>>.GetEnumerator() => throw new System.NotImplementedException();
+                IEnumerator<KeyValuePair<int, string?>> IEnumerable<KeyValuePair<int, string?>>.GetEnumerator() => throw new System.NotImplementedException();
+                IEnumerator IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryGetValue_IDictionary_Twice_OneInvalid_ShouldReportDiagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+            using System.Diagnostics.CodeAnalysis;
+
+            class MyDictionary : IDictionary<string, string?>, IDictionary<int, string?>
+            {
+                public bool TryGetValue(string key, out string? {|MA0221:stringValue|})
+                {
+                    stringValue = null;
+                    return false;
+                }
+
+                public bool TryGetValue(int key, [MaybeNullWhen(false)] out string? intValue)
+                {
+                    intValue = null;
+                    return false;
+                }
+
+                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public string? this[int key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+                ICollection<string> IDictionary<string, string?>.Keys => throw new System.NotImplementedException();
+                ICollection<int> IDictionary<int, string?>.Keys => throw new System.NotImplementedException();
+                ICollection<string?> IDictionary<string, string?>.Values => throw new System.NotImplementedException();
+                ICollection<string?> IDictionary<int, string?>.Values => throw new System.NotImplementedException();
+
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string? value) => throw new System.NotImplementedException();
+                public void Add(int key, string? value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public bool ContainsKey(int key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<int, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(int key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
+                IEnumerator<KeyValuePair<string, string?>> IEnumerable<KeyValuePair<string, string?>>.GetEnumerator() => throw new System.NotImplementedException();
+                IEnumerator<KeyValuePair<int, string?>> IEnumerable<KeyValuePair<int, string?>>.GetEnumerator() => throw new System.NotImplementedException();
+                IEnumerator IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryGetValue_IDictionary_Twice_NoneInvalid_ShouldNotReportDiagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+            using System.Diagnostics.CodeAnalysis;
+
+            class MyDictionary : IDictionary<string, string?>, IDictionary<int, string?>
+            {
+                public bool TryGetValue(string key, [MaybeNullWhen(false)] out string? stringValue)
+                {
+                    stringValue = null;
+                    return false;
+                }
+
+                public bool TryGetValue(int key, [MaybeNullWhen(false)] out string? intValue)
+                {
+                    intValue = null;
+                    return false;
+                }
+
+                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public string? this[int key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+                ICollection<string> IDictionary<string, string?>.Keys => throw new System.NotImplementedException();
+                ICollection<int> IDictionary<int, string?>.Keys => throw new System.NotImplementedException();
+                ICollection<string?> IDictionary<string, string?>.Values => throw new System.NotImplementedException();
+                ICollection<string?> IDictionary<int, string?>.Values => throw new System.NotImplementedException();
+
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string? value) => throw new System.NotImplementedException();
+                public void Add(int key, string? value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public bool ContainsKey(int key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<int, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(int key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
+                IEnumerator<KeyValuePair<string, string?>> IEnumerable<KeyValuePair<string, string?>>.GetEnumerator() => throw new System.NotImplementedException();
+                IEnumerator<KeyValuePair<int, string?>> IEnumerable<KeyValuePair<int, string?>>.GetEnumerator() => throw new System.NotImplementedException();
+                IEnumerator IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryGetValue_NotIDictionary_ShouldNotReportDiagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            class MyClass
+            {
+                public bool TryGetValue(string key, out string? value)
+                {
+                    value = null;
+                    return false;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryGetValue_NonNullableValue_ShouldNotReportDiagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+
+            class MyDictionary : IDictionary<string, string>
+            {
+                public bool TryGetValue(string key, out string value)
+                {
+                    value = "";
+                    return false;
+                }
+
+                // Other IDictionary members...
+                public string this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+                public ICollection<string> Keys => throw new System.NotImplementedException();
+                public ICollection<string> Values => throw new System.NotImplementedException();
+                public int Count => throw new System.NotImplementedException();
+                public bool IsReadOnly => throw new System.NotImplementedException();
+                public void Add(string key, string value) => throw new System.NotImplementedException();
+                public void Add(KeyValuePair<string, string> item) => throw new System.NotImplementedException();
+                public void Clear() => throw new System.NotImplementedException();
+                public bool Contains(KeyValuePair<string, string> item) => throw new System.NotImplementedException();
+                public bool ContainsKey(string key) => throw new System.NotImplementedException();
+                public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex) => throw new System.NotImplementedException();
+                public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => throw new System.NotImplementedException();
+                public bool Remove(string key) => throw new System.NotImplementedException();
+                public bool Remove(KeyValuePair<string, string> item) => throw new System.NotImplementedException();
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/MissingNotNullWhenAttributeOnEqualsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MissingNotNullWhenAttributeOnEqualsAnalyzerTests.cs
@@ -1,6 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.MissingNotNullWhenAttributeOnEqualsAnalyzer,
     Meziantou.Analyzer.Rules.MissingNotNullWhenAttributeOnEqualsFixer>;
@@ -9,18 +6,10 @@ namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
 {
-    // The analyzer declares two descriptors with the same MA0186 id, so the markup cannot tell them apart
-    private static CodeFixTest CreateTest()
-    {
-        var test = new CodeFixTest();
-        test.MarkupOptions = MarkupOptions.UseFirstDescriptor;
-        return test;
-    }
-
     [Fact]
     public Task Equals_Object_WithoutAttribute_ShouldReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             class Sample
             {
@@ -39,7 +28,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_Object_WithoutAttribute_ShouldFix()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             using System.Diagnostics.CodeAnalysis;
 
@@ -73,7 +62,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_Object_WithWrongAttributeValue_ShouldFix()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             using System.Diagnostics.CodeAnalysis;
 
@@ -105,82 +94,9 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     }
 
     [Fact]
-    public Task TryGetValue_IDictionary_ExplicitWithoutAttribute_ShouldReportDiagnostic()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections.Generic;
-
-            class MyDictionary : IDictionary<string, string?>
-            {
-                bool IDictionary<string, string?>.TryGetValue(string key, out string? {|MA0186:value|})
-                {
-                    value = null;
-                    return false;
-                }
-
-                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public ICollection<string> Keys => throw new System.NotImplementedException();
-                public ICollection<string?> Values => throw new System.NotImplementedException();
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string? value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task TryGetValue_IDictionary_ExplicitWithAttribute_ShouldNotReportDiagnostic()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections.Generic;
-            using System.Diagnostics.CodeAnalysis;
-
-            class MyDictionary : IDictionary<string, string?>
-            {
-                bool IDictionary<string, string?>.TryGetValue(string key, [MaybeNullWhen(false)] out string? value)
-                {
-                    value = null;
-                    return false;
-                }
-
-                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public ICollection<string> Keys => throw new System.NotImplementedException();
-                public ICollection<string?> Values => throw new System.NotImplementedException();
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string? value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
     public Task Equals_Object_WithAttribute_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             using System.Diagnostics.CodeAnalysis;
 
@@ -201,7 +117,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_IEquatable_WithoutAttribute_ShouldReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             using System;
 
@@ -227,7 +143,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_IEquatable_WithAttribute_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             using System;
             using System.Diagnostics.CodeAnalysis;
@@ -254,7 +170,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_NonNullableParameter_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             class Sample
             {
@@ -273,7 +189,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task NotEqualsMethod_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             class Sample
             {
@@ -290,7 +206,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task PrivateEquals_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             class Sample
             {
@@ -307,7 +223,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task StaticEquals_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             class Sample
             {
@@ -324,7 +240,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_WrongSignature_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             class Sample
             {
@@ -341,7 +257,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_IEquatable_BothMethodsWithoutAttribute_ShouldReportBothDiagnostics()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             using System;
 
@@ -367,7 +283,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_IEquatable_ValueType_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             using System;
 
@@ -393,7 +309,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_NullableDisabled_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             #nullable disable
             class Sample
@@ -413,7 +329,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_NullableEnabled_ShouldReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             #nullable enable
             class Sample
@@ -433,7 +349,7 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
     [Fact]
     public Task Equals_NullableEnabledThenDisabled_ShouldNotReportDiagnostic()
     {
-        var test = CreateTest();
+        var test = new CodeFixTest();
         test.TestCode = """
             #nullable enable
             class Sample1
@@ -455,372 +371,6 @@ public sealed class MissingNotNullWhenAttributeOnEqualsAnalyzerTests
                 }
 
                 public override int GetHashCode() => 0;
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task TryGetValue_IDictionary_WithoutAttribute_ShouldReportDiagnostic()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections.Generic;
-
-            class MyDictionary : IDictionary<string, string?>
-            {
-                public bool TryGetValue(string key, out string? {|MA0186:value|})
-                {
-                    value = null;
-                    return false;
-                }
-
-                // Other IDictionary members...
-                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public ICollection<string> Keys => throw new System.NotImplementedException();
-                public ICollection<string?> Values => throw new System.NotImplementedException();
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string? value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task TryGetValue_IDictionary_WithoutAttribute_ShouldFix()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections.Generic;
-            using System.Diagnostics.CodeAnalysis;
-
-            class MyDictionary : IDictionary<string, string?>
-            {
-                public bool TryGetValue(string key, out string? {|MA0186:value|})
-                {
-                    value = null;
-                    return false;
-                }
-
-                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public ICollection<string> Keys => throw new System.NotImplementedException();
-                public ICollection<string?> Values => throw new System.NotImplementedException();
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string? value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
-            }
-            """;
-        test.FixedCode = """
-            using System.Collections.Generic;
-            using System.Diagnostics.CodeAnalysis;
-
-            class MyDictionary : IDictionary<string, string?>
-            {
-                public bool TryGetValue(string key, [MaybeNullWhen(false)] out string? value)
-                {
-                    value = null;
-                    return false;
-                }
-
-                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public ICollection<string> Keys => throw new System.NotImplementedException();
-                public ICollection<string?> Values => throw new System.NotImplementedException();
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string? value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task TryGetValue_IDictionary_WithAttribute_ShouldNotReportDiagnostic()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections.Generic;
-            using System.Diagnostics.CodeAnalysis;
-
-            class MyDictionary : IDictionary<string, string?>
-            {
-                public bool TryGetValue(string key, [MaybeNullWhen(false)] out string? value)
-                {
-                    value = null;
-                    return false;
-                }
-
-                // Other IDictionary members...
-                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public ICollection<string> Keys => throw new System.NotImplementedException();
-                public ICollection<string?> Values => throw new System.NotImplementedException();
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string? value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task TryGetValue_IDictionary_Twice_BothInvalid_ShouldReportDiagnostics()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections;
-            using System.Collections.Generic;
-
-            class MyDictionary : IDictionary<string, string?>, IDictionary<int, string?>
-            {
-                public bool TryGetValue(string key, out string? {|MA0186:stringValue|})
-                {
-                    stringValue = null;
-                    return false;
-                }
-
-                public bool TryGetValue(int key, out string? {|MA0186:intValue|})
-                {
-                    intValue = null;
-                    return false;
-                }
-
-                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public string? this[int key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-
-                ICollection<string> IDictionary<string, string?>.Keys => throw new System.NotImplementedException();
-                ICollection<int> IDictionary<int, string?>.Keys => throw new System.NotImplementedException();
-                ICollection<string?> IDictionary<string, string?>.Values => throw new System.NotImplementedException();
-                ICollection<string?> IDictionary<int, string?>.Values => throw new System.NotImplementedException();
-
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string? value) => throw new System.NotImplementedException();
-                public void Add(int key, string? value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public bool ContainsKey(int key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<int, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(int key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
-                IEnumerator<KeyValuePair<string, string?>> IEnumerable<KeyValuePair<string, string?>>.GetEnumerator() => throw new System.NotImplementedException();
-                IEnumerator<KeyValuePair<int, string?>> IEnumerable<KeyValuePair<int, string?>>.GetEnumerator() => throw new System.NotImplementedException();
-                IEnumerator IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task TryGetValue_IDictionary_Twice_OneInvalid_ShouldReportDiagnostic()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections;
-            using System.Collections.Generic;
-            using System.Diagnostics.CodeAnalysis;
-
-            class MyDictionary : IDictionary<string, string?>, IDictionary<int, string?>
-            {
-                public bool TryGetValue(string key, out string? {|MA0186:stringValue|})
-                {
-                    stringValue = null;
-                    return false;
-                }
-
-                public bool TryGetValue(int key, [MaybeNullWhen(false)] out string? intValue)
-                {
-                    intValue = null;
-                    return false;
-                }
-
-                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public string? this[int key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-
-                ICollection<string> IDictionary<string, string?>.Keys => throw new System.NotImplementedException();
-                ICollection<int> IDictionary<int, string?>.Keys => throw new System.NotImplementedException();
-                ICollection<string?> IDictionary<string, string?>.Values => throw new System.NotImplementedException();
-                ICollection<string?> IDictionary<int, string?>.Values => throw new System.NotImplementedException();
-
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string? value) => throw new System.NotImplementedException();
-                public void Add(int key, string? value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public bool ContainsKey(int key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<int, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(int key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
-                IEnumerator<KeyValuePair<string, string?>> IEnumerable<KeyValuePair<string, string?>>.GetEnumerator() => throw new System.NotImplementedException();
-                IEnumerator<KeyValuePair<int, string?>> IEnumerable<KeyValuePair<int, string?>>.GetEnumerator() => throw new System.NotImplementedException();
-                IEnumerator IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task TryGetValue_IDictionary_Twice_NoneInvalid_ShouldNotReportDiagnostic()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections;
-            using System.Collections.Generic;
-            using System.Diagnostics.CodeAnalysis;
-
-            class MyDictionary : IDictionary<string, string?>, IDictionary<int, string?>
-            {
-                public bool TryGetValue(string key, [MaybeNullWhen(false)] out string? stringValue)
-                {
-                    stringValue = null;
-                    return false;
-                }
-
-                public bool TryGetValue(int key, [MaybeNullWhen(false)] out string? intValue)
-                {
-                    intValue = null;
-                    return false;
-                }
-
-                public string? this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public string? this[int key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-
-                ICollection<string> IDictionary<string, string?>.Keys => throw new System.NotImplementedException();
-                ICollection<int> IDictionary<int, string?>.Keys => throw new System.NotImplementedException();
-                ICollection<string?> IDictionary<string, string?>.Values => throw new System.NotImplementedException();
-                ICollection<string?> IDictionary<int, string?>.Values => throw new System.NotImplementedException();
-
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string? value) => throw new System.NotImplementedException();
-                public void Add(int key, string? value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public bool ContainsKey(int key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<int, string?>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(int key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string?> item) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<int, string?> item) => throw new System.NotImplementedException();
-                IEnumerator<KeyValuePair<string, string?>> IEnumerable<KeyValuePair<string, string?>>.GetEnumerator() => throw new System.NotImplementedException();
-                IEnumerator<KeyValuePair<int, string?>> IEnumerable<KeyValuePair<int, string?>>.GetEnumerator() => throw new System.NotImplementedException();
-                IEnumerator IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task TryGetValue_NotIDictionary_ShouldNotReportDiagnostic()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            class MyClass
-            {
-                public bool TryGetValue(string key, out string? value)
-                {
-                    value = null;
-                    return false;
-                }
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task TryGetValue_NonNullableValue_ShouldNotReportDiagnostic()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections.Generic;
-
-            class MyDictionary : IDictionary<string, string>
-            {
-                public bool TryGetValue(string key, out string value)
-                {
-                    value = "";
-                    return false;
-                }
-
-                // Other IDictionary members...
-                public string this[string key] { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-                public ICollection<string> Keys => throw new System.NotImplementedException();
-                public ICollection<string> Values => throw new System.NotImplementedException();
-                public int Count => throw new System.NotImplementedException();
-                public bool IsReadOnly => throw new System.NotImplementedException();
-                public void Add(string key, string value) => throw new System.NotImplementedException();
-                public void Add(KeyValuePair<string, string> item) => throw new System.NotImplementedException();
-                public void Clear() => throw new System.NotImplementedException();
-                public bool Contains(KeyValuePair<string, string> item) => throw new System.NotImplementedException();
-                public bool ContainsKey(string key) => throw new System.NotImplementedException();
-                public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex) => throw new System.NotImplementedException();
-                public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => throw new System.NotImplementedException();
-                public bool Remove(string key) => throw new System.NotImplementedException();
-                public bool Remove(KeyValuePair<string, string> item) => throw new System.NotImplementedException();
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
             }
             """;
 


### PR DESCRIPTION
## Problem

`MissingNotNullWhenAttributeOnEqualsAnalyzer` declared **two descriptors under the same `MA0186` id**:

- `Equals method should use [NotNullWhen(true)] on the parameter`
- `TryGetValue method should use [MaybeNullWhen(false)] on the value parameter`

It was the only id in the repository with two descriptors.

The documentation generator de-duplicates descriptors by id (`DistinctBy(diag => diag.Id)`), so `README.md`, `docs/README.md` and all five shipped editorconfigs described MA0186 solely as the `Equals` rule. The `TryGetValue` behavior was documented nowhere but the body of `docs/Rules/MA0186.md`, whose H1 the generator overwrote with the `Equals` title.

Consequences:

- A consumer who got the `TryGetValue` diagnostic and searched the rule table by title found nothing.
- Neither half could be configured independently of the other.
- The second descriptor's title, severity and `isEnabledByDefault` were dead metadata that no generated artifact reflected, so drift there was undetectable.

## What changed

The `TryGetValue` rule becomes **MA0221** with its own analyzer, code fixer, documentation page and tests:

- `MissingMaybeNullWhenAttributeOnTryGetValueAnalyzer` / `MissingMaybeNullWhenAttributeOnTryGetValueFixer` (MA0221)
- `MissingNotNullWhenAttributeOnEqualsAnalyzer` / `MissingNotNullWhenAttributeOnEqualsFixer` keep MA0186, `Equals` only

Both analyzers now bail out early in `RegisterCompilationStartAction` when their attribute type is absent from the compilation, rather than nesting the whole body in an `if`.

The old fixer picked the attribute to add by switching on the method name inside `RegisterCodeFixesAsync`; each fixer now has its attribute fixed by its rule id. They share the attribute-rewriting logic through `NullableAnalysisAttributeFixerHelper`, and the "does this attribute type exist" check moved ahead of `RegisterCodeFix` — previously it ran inside the fix action and could return the document unchanged, which the code-fixer guidance in `AGENTS.md` calls out.

`RuleHelpUri` gains `EachRuleIdHasASingleDescriptor`, so a future duplicate id fails a test instead of silently disappearing from the generated lists.

Documentation was regenerated with `dotnet run --project src/DocumentationGenerator`; a second run reported no further changes. `docs/Rules/MA0186.md` is trimmed to the `Equals` case, the new `docs/Rules/MA0221.md` covers `TryGetValue`, and the two cross-link.

## Note for reviewers

**MA0221 is a new id, so anyone who had explicitly enabled MA0186 loses the `TryGetValue` diagnostics until they also enable MA0221.** Both rules ship disabled by default, so this only affects users who opted in.

The alternative would have been collapsing to a single descriptor with a title covering both cases, keeping the specifics in `messageFormat` — that avoids the migration but leaves the two behaviors permanently coupled behind one severity setting.

## Verification

- `dotnet build` — succeeded, 0 warnings.
- Split tests on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9): 28 passed each (16 Equals + 10 TryGetValue + 2 rule-metadata).
- Full suite on the default version (roslyn5.9): 3910 passed, 0 failed.