### PR TITLE
Report MA0153 when the type of a logged property or field is classified

### DIFF
--- a/docs/Rules/MA0153.md
+++ b/docs/Rules/MA0153.md
@@ -3,7 +3,7 @@
 Source: [DoNotLogClassifiedDataAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/DoNotLogClassifiedDataAnalyzer.cs)
 <!-- sources -->
 
-Detects when a log parameter is decorated with an attribute that inherits from `Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute`.
+Detects when a log parameter is decorated with an attribute that inherits from `Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute`. The attribute can be set on the logged symbol itself (parameter, property, field), on the type of the logged value, or on the type declaring the logged property or field.
 
 Optionally (when configured), it can also detect when logging an object whose type contains members (properties or fields) decorated with such attributes. Since there could be multiple log providers, any type that has sensitive attributes should not be logged directly, as some providers could log inner fields/properties and ignore the attributes.
 
@@ -15,6 +15,9 @@ ILogger logger;
 // non-compliant as Prop is decorated with an attribute that inherits from DataClassificationAttribute
 logger.LogInformation("{Prop}", new Dummy().Prop);
 
+// non-compliant as the type of Credentials is decorated with an attribute that inherits from DataClassificationAttribute
+logger.LogInformation("{Credentials}", new Dummy().Credentials);
+
 // non-compliant as PatientInfo contains properties decorated with DataClassificationAttribute (when MA0153.report_types_with_data_classification_attributes is enabled)
 PatientInfo patient = new();
 logger.LogInformation("{Patient}", patient);
@@ -23,6 +26,13 @@ class Dummy
 {
     [PiiAttribute]
     public string Prop { get; set; }
+
+    public Credentials Credentials { get; set; }
+}
+
+[PiiAttribute]
+class Credentials
+{
 }
 
 class PatientInfo

--- a/src/Meziantou.Analyzer/Rules/DoNotLogClassifiedDataAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotLogClassifiedDataAnalyzer.cs
@@ -96,28 +96,15 @@ public sealed class DoNotLogClassifiedDataAnalyzer : DiagnosticAnalyzer
                 operation = operation.UnwrapConversions();
                 if (operation is IParameterReferenceOperation { Parameter: var parameter })
                 {
-                    if (parameter.HasAttribute(dataClassificationAttributeSymbol, inherits: true) || parameter.Type.HasAttribute(dataClassificationAttributeSymbol, inherits: true))
-                    {
-                        diagnosticReporter.ReportDiagnostic(Rule, reportOperation);
-                    }
-                    else if (reportTypesWithDataClassification && TypeContainsMembersWithDataClassification(parameter.Type, dataClassificationAttributeSymbol))
-                    {
-                        diagnosticReporter.ReportDiagnostic(Rule, reportOperation);
-                    }
+                    ValidateSymbol(diagnosticReporter, parameter, parameter.Type, containingType: null, reportOperation, dataClassificationAttributeSymbol, reportTypesWithDataClassification);
                 }
                 else if (operation is IPropertyReferenceOperation { Property: var property })
                 {
-                    if (property.HasAttribute(dataClassificationAttributeSymbol, inherits: true) || property.ContainingType.HasAttribute(dataClassificationAttributeSymbol, inherits: true))
-                    {
-                        diagnosticReporter.ReportDiagnostic(Rule, reportOperation);
-                    }
+                    ValidateSymbol(diagnosticReporter, property, property.Type, property.ContainingType, reportOperation, dataClassificationAttributeSymbol, reportTypesWithDataClassification);
                 }
                 else if (operation is IFieldReferenceOperation { Field: var field })
                 {
-                    if (field.HasAttribute(dataClassificationAttributeSymbol, inherits: true) || field.ContainingType.HasAttribute(dataClassificationAttributeSymbol, inherits: true))
-                    {
-                        diagnosticReporter.ReportDiagnostic(Rule, reportOperation);
-                    }
+                    ValidateSymbol(diagnosticReporter, field, field.Type, field.ContainingType, reportOperation, dataClassificationAttributeSymbol, reportTypesWithDataClassification);
                 }
                 else if (operation is IArrayElementReferenceOperation arrayElementReferenceOperation)
                 {
@@ -144,6 +131,20 @@ public sealed class DoNotLogClassifiedDataAnalyzer : DiagnosticAnalyzer
                             diagnosticReporter.ReportDiagnostic(Rule, reportOperation);
                         }
                     }
+                }
+            }
+
+            static void ValidateSymbol(DiagnosticReporter diagnosticReporter, ISymbol symbol, ITypeSymbol type, INamedTypeSymbol? containingType, IOperation reportOperation, INamedTypeSymbol dataClassificationAttributeSymbol, bool reportTypesWithDataClassification)
+            {
+                if (symbol.HasAttribute(dataClassificationAttributeSymbol, inherits: true) ||
+                    type.HasAttribute(dataClassificationAttributeSymbol, inherits: true) ||
+                    containingType?.HasAttribute(dataClassificationAttributeSymbol, inherits: true) is true)
+                {
+                    diagnosticReporter.ReportDiagnostic(Rule, reportOperation);
+                }
+                else if (reportTypesWithDataClassification && TypeContainsMembersWithDataClassification(type, dataClassificationAttributeSymbol))
+                {
+                    diagnosticReporter.ReportDiagnostic(Rule, reportOperation);
                 }
             }
         }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotLogClassifiedDataAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotLogClassifiedDataAnalyzerTests.cs
@@ -175,6 +175,151 @@ public sealed class DoNotLogClassifiedDataAnalyzerTests
     }
 
     [Fact]
+    public Task Logger_LogInformation_DataClassification_Property_AttributeOnPropertyType()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using Microsoft.Extensions.Logging;
+
+            ILogger logger = null;
+            logger.LogInformation("{Prop}", {|MA0153:new Dummy().Prop|});
+
+            class Dummy
+            {
+                public Credentials Prop { get; set; }
+            }
+
+            [TaxonomyAttribute()]
+            class Credentials
+            {
+            }
+
+            class TaxonomyAttribute : Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute
+            {
+                public TaxonomyAttribute() : base(Microsoft.Extensions.Compliance.Classification.DataClassification.Unknown) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Logger_LogInformation_DataClassification_Field_AttributeOnFieldType()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using Microsoft.Extensions.Logging;
+
+            ILogger logger = null;
+            logger.LogInformation("{Prop}", {|MA0153:new Dummy().Prop|});
+
+            class Dummy
+            {
+                public Credentials Prop;
+            }
+
+            [TaxonomyAttribute()]
+            class Credentials
+            {
+            }
+
+            class TaxonomyAttribute : Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute
+            {
+                public TaxonomyAttribute() : base(Microsoft.Extensions.Compliance.Classification.DataClassification.Unknown) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Logger_LogInformation_DataClassification_Property_AttributeOnDeclaringType()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using Microsoft.Extensions.Logging;
+
+            ILogger logger = null;
+            logger.LogInformation("{Prop}", {|MA0153:new Dummy().Prop|});
+
+            [TaxonomyAttribute()]
+            class Dummy
+            {
+                public string Prop { get; set; }
+            }
+
+            class TaxonomyAttribute : Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute
+            {
+                public TaxonomyAttribute() : base(Microsoft.Extensions.Compliance.Classification.DataClassification.Unknown) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Logger_LogInformation_DataClassification_Property_TypeWithClassifiedMembers_ConfigEnabled()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("MA0153.report_types_with_data_classification_attributes", "true");
+        test.TestCode = """
+            using Microsoft.Extensions.Logging;
+
+            ILogger logger = null;
+            logger.LogInformation("{Patient}", {|MA0153:new Dummy().Patient|});
+
+            class Dummy
+            {
+                public PatientInfo Patient { get; set; }
+            }
+
+            class PatientInfo
+            {
+                [PiiData] public string PatientId { get; set; }
+                public ulong RecordId { get; set; }
+            }
+
+            class PiiData : Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute
+            {
+                public PiiData() : base(Microsoft.Extensions.Compliance.Classification.DataClassification.Unknown) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Logger_LogInformation_DataClassification_Property_TypeWithClassifiedMembers_ConfigDisabled()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("MA0153.report_types_with_data_classification_attributes", "false");
+        test.TestCode = """
+            using Microsoft.Extensions.Logging;
+
+            ILogger logger = null;
+            logger.LogInformation("{Patient}", new Dummy().Patient);
+
+            class Dummy
+            {
+                public PatientInfo Patient { get; set; }
+            }
+
+            class PatientInfo
+            {
+                [PiiData] public string PatientId { get; set; }
+                public ulong RecordId { get; set; }
+            }
+
+            class PiiData : Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute
+            {
+                public PiiData() : base(Microsoft.Extensions.Compliance.Classification.DataClassification.Unknown) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Logger_BeginScope_DataClassification_Property()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

MA0153 checked the **declaring** type for logged properties and fields, but the **value** type for parameters. An attribute inheriting from `DataClassificationAttribute` placed on the type of a logged property or field was therefore never reported:

```csharp
[Taxonomy] class Credentials { }

void A(Credentials p) => logger.LogInformation("{P}", p);   // reported
logger.LogInformation("{Prop}", new Dummy().Prop);          // Dummy.Prop is Credentials -> not reported
```

Since a property or field is the most common way classified data is exposed, the rule gave a false sense of coverage for exactly the data it is meant to protect.

## How

The parameter, property and field branches were three near-duplicates that had drifted apart. They now share one `ValidateSymbol` local function that checks, in order:

1. the attribute on the symbol itself,
2. the attribute on the symbol's **type**,
3. the attribute on the declaring type (members only — `null` for parameters, whose declaring type is the enclosing method's type and says nothing about the value).

Unifying the branches also closed a second hole of the same shape: the `MA0153.report_types_with_data_classification_attributes` opt-in — reporting a value whose type *contains* classified members — was implemented only for parameters, so a property or field of such a type was silently missed even with the option on. It now applies to all three.

## Reviewer notes

- The opt-in option is **off by default**, so the behavior change it unlocks does not affect anyone who has not enabled it.
- The new detection on the value type does report more code by default. That is the intent of the fix: the attribute means the value is classified, wherever the value comes from.
- Existing behavior is unchanged for parameters, and the `ContainingType` check for members is preserved (a new test guards it).

## Tests

5 cases added to `DoNotLogClassifiedDataAnalyzerTests`: attribute on a property's type, on a field's type, on a property's declaring type (regression guard), and the property/type-with-classified-members case with the option both enabled and disabled.

21/21 MA0153 tests pass on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9); the full solution builds with 0 warnings. `dotnet run --project src/DocumentationGenerator` exits 0 with no further changes after the `docs/Rules/MA0153.md` update, which documents the three attribute locations and adds a sample.