### PR TITLE
Report MA0130 on System.Type instances

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Directory.Build.props
+++ b/src/Meziantou.Analyzer.CodeFixers/Directory.Build.props
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.11" PrivateAssets="all" />
+    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.13" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Meziantou.Analyzer/Directory.Build.props
+++ b/src/Meziantou.Analyzer/Directory.Build.props
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.11" PrivateAssets="all" />
+    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.13" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Meziantou.Analyzer/Rules/ObjectGetTypeOnTypeInstanceAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ObjectGetTypeOnTypeInstanceAnalyzer.cs
@@ -26,21 +26,33 @@ public sealed class ObjectGetTypeOnTypeInstanceAnalyzer : DiagnosticAnalyzer
             if (typeSymbol is null)
                 return;
 
+            // System.Type hides Object.GetType() with "public new Type GetType()", so the invocation resolves to
+            // Type.GetType() when the instance is statically typed as System.Type, and to Object.GetType() otherwise
+            var objectGetTypeSymbol = GetParameterlessGetTypeMethod(context.Compilation.ObjectType);
+            var typeGetTypeSymbol = GetParameterlessGetTypeMethod(typeSymbol);
+            if (objectGetTypeSymbol is null && typeGetTypeSymbol is null)
+                return;
+
             context.RegisterOperationAction(context =>
             {
                 var operation = (IInvocationOperation)context.Operation;
-                if (operation.Instance is not null && operation.TargetMethod.Name == "GetType" && operation.TargetMethod.ContainingType.IsObject())
-                {
-                    var instanceType = operation.Instance.GetActualType(context.CancellationToken);
-                    if (instanceType is null)
-                        return;
 
-                    if (instanceType.IsOrInheritsFrom(typeSymbol))
-                    {
-                        context.ReportDiagnostic(Rule, operation);
-                    }
+                // The instance of Type.GetType() is statically typed as System.Type, so there is nothing left to check
+                if (operation.TargetMethod.IsEqualTo(typeGetTypeSymbol))
+                {
+                    context.ReportDiagnostic(Rule, operation);
+                    return;
+                }
+
+                // The instance of Object.GetType() can still hold a System.Type, which only the data flow analysis can tell
+                if (operation.TargetMethod.IsEqualTo(objectGetTypeSymbol) && operation.Instance?.GetActualType(context.CancellationToken)?.IsOrInheritsFrom(typeSymbol) is true)
+                {
+                    context.ReportDiagnostic(Rule, operation);
                 }
             }, OperationKind.Invocation);
         });
+
+        static IMethodSymbol? GetParameterlessGetTypeMethod(ITypeSymbol type)
+            => type.GetMembers("GetType").OfType<IMethodSymbol>().FirstOrDefault(method => method is { IsStatic: false, Parameters.IsEmpty: true });
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Directory.Build.props
+++ b/tests/Meziantou.Analyzer.Test/Directory.Build.props
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.11" PrivateAssets="all" />
+    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.13" PrivateAssets="all" />
     <!-- Loaded at runtime by the IDE analyzers the suppressor tests run, so it must be in the output folder -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />

--- a/tests/Meziantou.Analyzer.Test/Rules/ObjectGetTypeOnTypeInstanceAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ObjectGetTypeOnTypeInstanceAnalyzerTests.cs
@@ -18,6 +18,8 @@ public sealed class ObjectGetTypeOnTypeInstanceAnalyzerTests
     [InlineData("string.Empty.GetType();")]
     [InlineData("12.GetType();")]
     [InlineData("System.Type.GetType(\"\");")]
+    [InlineData("object o = 12; o.GetType();")]
+    [InlineData("System.Reflection.MemberInfo member = null; member.GetType();")]
     public Task Valid(string code)
     {
         var test = CreateTest();
@@ -35,6 +37,8 @@ public sealed class ObjectGetTypeOnTypeInstanceAnalyzerTests
             abstract class Test
             {
                 public Test(int a) { }
+
+                object M() => GetType();
             };
             """;
 
@@ -42,9 +46,13 @@ public sealed class ObjectGetTypeOnTypeInstanceAnalyzerTests
     }
 
     [Theory]
-    [InlineData("new object().GetType().GetType();")]
-    [InlineData("((System.Type)null).GetType();")]
-    [InlineData("default(System.Type).GetType();")]
+    [InlineData("[|new object().GetType().GetType()|];")]
+    [InlineData("[|((System.Type)null).GetType()|];")]
+    [InlineData("[|default(System.Type).GetType()|];")]
+    [InlineData("[|typeof(int).GetType()|];")]
+    [InlineData("System.Type type = typeof(int); [|type.GetType()|];")]
+    [InlineData("System.Reflection.TypeInfo type = null; [|type.GetType()|];")]
+    [InlineData("object type = typeof(int); [|type.GetType()|];")]
     public Task Invalid(string code)
     {
         var test = CreateTest();


### PR DESCRIPTION
MA0130 (`GetType() should not be used on System.Type instances`) never reported anything, on any input.

## What was wrong

`System.Type` hides the base method with `public new Type GetType()`. So whenever the instance is statically typed as `System.Type` — which is exactly what the rule exists to catch — overload resolution binds to `System.Type.GetType()`, whose containing type is `System.Type`, not `System.Object`. The guard `operation.TargetMethod.ContainingType.IsObject()` rejected all of those.

The rule is enabled by default at Warning severity, is listed in the README and has a documentation page, so users believed they had a check that did nothing.

CI never noticed because the `Invalid` theory fed its three snippets with no diagnostic markup and no expected diagnostics — under that name, it asserted that the rule reports nothing. Adding the markup makes all three fail with *"Mismatch between number of diagnostics returned, expected 1 actual 0"* against the old analyzer.

## What changed

The analyzer resolves both parameterless `GetType()` methods once on compilation start and compares the invoked method with them:

- an invocation of `Type.GetType()` is reported as is, since its instance is statically typed as `System.Type`;
- an invocation of `Object.GetType()` still runs the data flow analysis, which is what catches `object type = typeof(int); type.GetType();`.

Comparing symbols is also stricter than the previous name and containing-type checks: a user-defined parameterless `GetType()` on a class deriving from `System.Type` is a different symbol and no longer matches.

## Tests

The `Invalid` theory now carries `[|code|]` markup and covers four more shapes: `typeof(int).GetType()`, a `System.Type` local, a `TypeInfo` local, and an `object` local holding a `Type`. Two valid cases are added: an `object` holding an `int`, and a `MemberInfo` that is not a `Type`.

`AbstractClass_Valid` was a regression test for a symbol action removed from this rule in 142fd38e, but contained no `GetType()` call at all. It keeps guarding that regression and now also contains a `GetType()` call, so it exercises this analyzer.

## Dependency

`Meziantou.Framework.Roslyn` is updated to 1.0.13, whose `GetActualType` falls back to the type of the current operation when the value the data flow analysis finds has no type, such as the null literal of `Type type = null;`. Note that 1.0.13 also makes `GetAllMembers` walk implemented interfaces by default (new optional `includeInterfaceMembers = true` parameter), which affects the other call sites in the repository; the full suites pass on every Roslyn version, so nothing regressed there.

## Verification

Full test suites pass on every Roslyn version — 4.8 (3770), 4.14 (3797), 5.0 (3825), 5.6 (3849), 5.9 (3882), 0 failures. `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.
