### PR TITLE
Remove the GetAllMembers extension methods superseded by Meziantou.Framework.Roslyn

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Directory.Build.props
+++ b/src/Meziantou.Analyzer.CodeFixers/Directory.Build.props
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.13" PrivateAssets="all" />
+    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.1.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/EqualityShouldBeCorrectlyImplementedFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/EqualityShouldBeCorrectlyImplementedFixer.cs
@@ -243,7 +243,7 @@ public sealed class EqualityShouldBeCorrectlyImplementedFixer : CodeFixProvider
             return document;
 
         var missingOperators = new HashSet<string>(ComparisonOperatorNames, StringComparer.Ordinal);
-        foreach (var method in declaredTypeSymbol.GetAllMembers().OfType<IMethodSymbol>())
+        foreach (var method in declaredTypeSymbol.GetAllMembers(includeInterfaceMembers: true).OfType<IMethodSymbol>())
         {
             if (method.MethodKind is MethodKind.UserDefinedOperator)
             {

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexSourceGeneratorFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexSourceGeneratorFixer.cs
@@ -96,7 +96,7 @@ public sealed class UseRegexSourceGeneratorFixer : CodeFixProvider
 
         if (typeSymbol is not null)
         {
-            var members = typeSymbol.GetAllMembers().ToArray();
+            var members = typeSymbol.GetAllMembers(includeInterfaceMembers: true).ToArray();
             // If we're going to remove a field/variable, exclude it from the uniqueness check
             if (shouldRemoveFieldOrVariable)
             {

--- a/src/Meziantou.Analyzer/Directory.Build.props
+++ b/src/Meziantou.Analyzer/Directory.Build.props
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.13" PrivateAssets="all" />
+    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.1.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Meziantou.Analyzer/Internals/SymbolExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/SymbolExtensions.cs
@@ -23,51 +23,6 @@ internal static class SymbolExtensions
         return symbol is IFieldSymbol field && field.IsConst;
     }
 
-    public static IEnumerable<ISymbol> GetAllMembers(this INamespaceOrTypeSymbol? symbol)
-    {
-        while (symbol is not null)
-        {
-            foreach (var member in symbol.GetMembers())
-                yield return member;
-
-            if (symbol is ITypeSymbol typeSymbol)
-            {
-                symbol = typeSymbol.BaseType;
-            }
-            else
-            {
-                yield break;
-            }
-        }
-    }
-
-    public static IEnumerable<ISymbol> GetAllMembers(this INamespaceOrTypeSymbol? symbol, string name)
-    {
-        while (symbol is not null)
-        {
-            foreach (var member in symbol.GetMembers(name))
-                yield return member;
-
-            if (symbol is INamedTypeSymbol { TypeKind: TypeKind.Interface } interfaceSymbol)
-            {
-                foreach (var iface in interfaceSymbol.AllInterfaces)
-                {
-                    foreach (var member in iface.GetMembers(name))
-                        yield return member;
-                }
-            }
-
-            if (symbol is ITypeSymbol typeSymbol)
-            {
-                symbol = typeSymbol.BaseType;
-            }
-            else
-            {
-                yield break;
-            }
-        }
-    }
-
     public static bool IsTopLevelStatement(this ISymbol symbol, CancellationToken cancellationToken)
     {
         if (symbol.DeclaringSyntaxReferences.Length == 0)

--- a/src/Meziantou.Analyzer/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzer.cs
@@ -233,10 +233,11 @@ public sealed class DebuggerDisplayAttributeShouldContainValidExpressionsAnalyze
         {
             if (parent is INamespaceOrTypeSymbol namespaceOrTypeSymbol)
             {
-                // Explicitly implemented interface members are not accessible on an expression typed with the implementing type,
-                // so the members of the implemented interfaces are only relevant for interfaces
+                // The members of the base interfaces of an interface are always enumerated, and the explicitly implemented
+                // interface members are not accessible on an expression typed with the implementing type, so the members
+                // of the implemented interfaces must not be enumerated
                 IEnumerable<ISymbol> members = namespaceOrTypeSymbol is ITypeSymbol typeSymbol
-                    ? typeSymbol.GetAllMembers(name, includeInterfaceMembers: typeSymbol.TypeKind is TypeKind.Interface)
+                    ? typeSymbol.GetAllMembers(name, includeInterfaceMembers: false)
                     : namespaceOrTypeSymbol.GetMembers(name);
 
                 if (members.FirstOrDefault() is { } member)

--- a/src/Meziantou.Analyzer/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzer.cs
@@ -231,9 +231,15 @@ public sealed class DebuggerDisplayAttributeShouldContainValidExpressionsAnalyze
 
         static ISymbol? FindSymbol(Compilation compilation, ISymbol parent, string name)
         {
-            if (parent is INamespaceOrTypeSymbol typeSymbol)
+            if (parent is INamespaceOrTypeSymbol namespaceOrTypeSymbol)
             {
-                if (typeSymbol.GetAllMembers(name).FirstOrDefault() is { } member)
+                // Explicitly implemented interface members are not accessible on an expression typed with the implementing type,
+                // so the members of the implemented interfaces are only relevant for interfaces
+                IEnumerable<ISymbol> members = namespaceOrTypeSymbol is ITypeSymbol typeSymbol
+                    ? typeSymbol.GetAllMembers(name, includeInterfaceMembers: typeSymbol.TypeKind is TypeKind.Interface)
+                    : namespaceOrTypeSymbol.GetMembers(name);
+
+                if (members.FirstOrDefault() is { } member)
                 {
                     if (member is INamespaceOrTypeSymbol)
                         return member;
@@ -242,7 +248,7 @@ public sealed class DebuggerDisplayAttributeShouldContainValidExpressionsAnalyze
                 }
 
                 // Interfaces don't derive from System.Object, but its members are still accessible on interface-typed expressions
-                if (typeSymbol is ITypeSymbol { TypeKind: TypeKind.Interface })
+                if (namespaceOrTypeSymbol is ITypeSymbol { TypeKind: TypeKind.Interface })
                 {
                     if (compilation.GetSpecialType(SpecialType.System_Object).GetMembers(name).FirstOrDefault() is { } objectMember)
                         return objectMember.GetSymbolType();

--- a/src/Meziantou.Analyzer/Rules/DoNotLogClassifiedDataAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotLogClassifiedDataAnalyzer.cs
@@ -159,7 +159,7 @@ public sealed class DoNotLogClassifiedDataAnalyzer : DiagnosticAnalyzer
                 return false;
 
             // Check all members (properties and fields) including inherited members
-            foreach (var member in type.GetAllMembers())
+            foreach (var member in type.GetAllMembers(includeInterfaceMembers: true))
             {
                 if (member is IPropertySymbol property)
                 {

--- a/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseBlockingCallInAsyncContextAnalyzer.cs
@@ -593,7 +593,7 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzer : DiagnosticAnaly
 
         private bool HasDisposeAsyncMethod(INamedTypeSymbol symbol)
         {
-            var members = symbol.GetAllMembers("DisposeAsync");
+            var members = symbol.GetAllMembers("DisposeAsync", includeInterfaceMembers: true);
             foreach (var member in members.OfType<IMethodSymbol>())
             {
                 if (member.Parameters.Length != 0)

--- a/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzer.cs
@@ -173,7 +173,7 @@ public sealed partial class EqualityShouldBeCorrectlyImplementedAnalyzer : Diagn
 
         private static bool HasMethodInHierarchy(INamedTypeSymbol type, Func<IMethodSymbol, bool> predicate)
         {
-            foreach (var member in type.GetAllMembers().OfType<IMethodSymbol>())
+            foreach (var member in type.GetAllMembers(includeInterfaceMembers: true).OfType<IMethodSymbol>())
             {
                 if (predicate(member))
                     return true;
@@ -194,7 +194,7 @@ public sealed partial class EqualityShouldBeCorrectlyImplementedAnalyzer : Diagn
             "op_Inequality",
         };
 
-            foreach (var member in parentType.GetAllMembers().OfType<IMethodSymbol>())
+            foreach (var member in parentType.GetAllMembers(includeInterfaceMembers: true).OfType<IMethodSymbol>())
             {
                 if (member.MethodKind is MethodKind.UserDefinedOperator)
                 {

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
@@ -288,7 +288,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
                     return [[]];
 
                 var result = new List<ISymbol[]>();
-                var members = symbol.GetAllMembers();
+                var members = symbol.GetAllMembers(includeInterfaceMembers: true);
                 foreach (var member in members)
                 {
                     if (member.IsImplicitlyDeclared)

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
@@ -152,7 +152,7 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
                     return [[]];
 
                 var result = new List<ISymbol[]>();
-                var members = symbol.GetAllMembers();
+                var members = symbol.GetAllMembers(includeInterfaceMembers: true);
                 foreach (var member in members)
                 {
                     if (member.IsImplicitlyDeclared)

--- a/tests/Meziantou.Analyzer.Test/Directory.Build.props
+++ b/tests/Meziantou.Analyzer.Test/Directory.Build.props
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.0.13" PrivateAssets="all" />
+    <PackageReference Include="Meziantou.Framework.Roslyn" Version="1.1.0" PrivateAssets="all" />
     <!-- Loaded at runtime by the IDE analyzers the suppressor tests run, so it must be in the output folder -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />

--- a/tests/Meziantou.Analyzer.Test/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzerTests.cs
@@ -486,6 +486,73 @@ public sealed class DebuggerDisplayAttributeShouldContainValidExpressionsAnalyze
     }
 
     [Fact]
+    public Task BaseInterfaceMemberOnInterfaceTypedMember()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics;
+            [DebuggerDisplay("{Foo.Value}")]
+            public class Dummy
+            {
+                public IFoo Foo { get; }
+            }
+
+            public interface IFoo : IBar
+            {
+            }
+
+            public interface IBar
+            {
+                string Value { get; }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ImplicitlyImplementedInterfaceMember()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics;
+            [DebuggerDisplay("{Value}")]
+            public class Dummy : IFoo
+            {
+                public string Value => throw null;
+            }
+
+            public interface IFoo
+            {
+                string Value { get; }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExplicitlyImplementedInterfaceMemberIsNotAccessible()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics;
+            [{|MA0151:DebuggerDisplay("{Value}")|}]
+            public class Dummy : IFoo
+            {
+                string IFoo.Value => throw null;
+            }
+
+            public interface IFoo
+            {
+                string Value { get; }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task UnknownMemberOnInterfaceTypedMember()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseBlockingCallInAsyncContextAnalyzerTests.cs
@@ -899,6 +899,84 @@ public sealed class DoNotUseBlockingCallInAsyncContextAnalyzerTests
     }
 
     [Fact]
+    public Task Using_InterfaceInheritingIAsyncDisposable_Diagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+
+            interface ISample : IDisposable, IAsyncDisposable
+            {
+            }
+
+            class Test
+            {
+                public async Task A()
+                {
+                    {|MA0042:using var value = Create();|}
+                }
+
+                private ISample Create() => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Using_InterfaceNotInheritingIAsyncDisposable_NoDiagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+
+            interface ISample : IDisposable
+            {
+            }
+
+            class Test
+            {
+                public async Task A()
+                {
+                    using var value = Create();
+                }
+
+                private ISample Create() => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Using_ExplicitlyImplementedIAsyncDisposable_Diagnostic()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+
+            class Sample : IDisposable, IAsyncDisposable
+            {
+                void IDisposable.Dispose() => throw null;
+                ValueTask IAsyncDisposable.DisposeAsync() => throw null;
+            }
+
+            class Test
+            {
+                public async Task A()
+                {
+                    {|MA0042:using var value = new Sample();|}
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task ExtensionMethod()
     {
         var test = new CodeFixTest();


### PR DESCRIPTION
## What

`Meziantou.Analyzer.Internals` and `Meziantou.Framework.Roslyn` are both global usings, and both declared a `GetAllMembers` extension method. This removes the two overloads declared in this repository so that every call site uses the ones of the package.

## Why

The package declares its overloads on `ITypeSymbol`, this repository declared them on `INamespaceOrTypeSymbol`. `ITypeSymbol` is the more derived receiver type, so overload resolution silently picked:

- the **package** version for the 9 call sites whose receiver is typed `ITypeSymbol` or `INamedTypeSymbol`,
- the **repository** version for the single call site whose receiver is typed `INamespaceOrTypeSymbol`.

Nothing at a call site said which implementation it ran, and the two did not enumerate the same members. Renaming the overloads of this repository and building produces exactly one compilation error, which is how the split above was established. The same mechanism would apply to any helper added to the package later under a name this repository already uses: existing call sites would rebind to it with no compilation error.

Note that the divergence is no longer observable in the diagnostics. The package used to walk only the base types, and now walks the interfaces too (`includeInterfaceMembers`, `true` by default), so the behaviors converged. This change removes the ambiguity itself, not a reported bug.

## Changes

- `SymbolExtensions`: remove `GetAllMembers(this INamespaceOrTypeSymbol?)` and `GetAllMembers(this INamespaceOrTypeSymbol?, string)`. The parameterless one had no caller at all, as every call site bound to the package.
- `DebuggerDisplayAttributeShouldContainValidExpressionsAnalyzer`: the `FindSymbol` local function was the only caller of the removed overloads. Its receiver is an `INamespaceOrTypeSymbol`, which the extension method of the package cannot accept, so it now handles the namespaces and the types separately. A namespace has no base type, so the walk of the removed overload was a no-op for it and `GetMembers(name)` is equivalent.

## For the reviewer

The interesting part is the `includeInterfaceMembers` argument of that call site:

```csharp
IEnumerable<ISymbol> members = namespaceOrTypeSymbol is ITypeSymbol typeSymbol
    ? typeSymbol.GetAllMembers(name, includeInterfaceMembers: typeSymbol.TypeKind is TypeKind.Interface)
    : namespaceOrTypeSymbol.GetMembers(name);
```

It is not the default of the package (`true`), and that is deliberate: the removed overload walked `AllInterfaces` only when the symbol was itself an interface, and MA0080 needs that distinction. With `true`, a class receiver would match its explicitly implemented interface members, which are not accessible on an expression typed with that class, so `{ExplicitlyImplementedMember}` in a `DebuggerDisplay` string would stop being reported. The comment in the diff records this.

## Validation

- The solution builds for the 5 Roslyn versions, with no new warning.
- `dotnet test`: 19798 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator` exits 0, no markdown file changed.
