### PR TITLE
Do not report MA0028 on StringBuilder.Insert with a Substring argument

### DIFF
--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
@@ -283,7 +283,7 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
                         return true;
                     }
                 }
-                else if (string.Equals(targetMethod.Name, nameof(string.Substring), System.StringComparison.Ordinal) && targetMethod.ContainingType.IsString())
+                else if (methodName != "Insert" && string.Equals(targetMethod.Name, nameof(string.Substring), System.StringComparison.Ordinal) && targetMethod.ContainingType.IsString())
                 {
                     var properties = CreateProperties(OptimizeStringBuilderUsageData.ReplaceSubstring);
                     context.ReportDiagnostic(Rule, properties, operation, $"Use {methodName}(string, int, int) or {methodName}(ReadOnlySpan<char>) instead of Substring");

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -259,6 +259,9 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     // StringBuilder.Insert has no counterpart for some of the Append overloads, so the ToString call is kept
     [InlineData(@"10.ToString()")]
     [InlineData(@"new StringBuilder().ToString()")]
+    // StringBuilder.Insert(int, string, int) repeats the value instead of slicing it, so the Substring call is kept
+    [InlineData(@"""abc"".Substring(2)")]
+    [InlineData(@"""abc"".Substring(0, 1)")]
     public Task Insert_NoDiagnostic(string text)
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

`OptimizeStringBuilderUsageAnalyzer` reported MA0028 on `StringBuilder.Insert` when the inserted string came from `Substring`:

```csharp
new StringBuilder().Insert(0, s.Substring(1));
```

> Use `Insert(string, int, int)` or `Insert(ReadOnlySpan<char>)` instead of Substring

`StringBuilder.Insert(string, int, int)` does not exist. The closest real overload is `Insert(int index, string value, int count)`, which **repeats** the value rather than slicing it — so there is no `Insert` counterpart to suggest here at all.

## Why

The `Substring` branch of `IsOptimizable` was the only one of the four `IInvocationOperation` branches missing the `methodName != "Insert"` guard. The three siblings — `ToString`, `string.Format` and `string.Join` — all begin with it, and the comment above them explains exactly why `Insert` has to be excluded: those overloads are `Append`'s, and `Insert` has no counterpart for some of them.

## Change

One line, matching the neighbouring branches:

```csharp
else if (methodName != "Insert" && string.Equals(targetMethod.Name, nameof(string.Substring), ...))
```

Plus two `Insert_NoDiagnostic` theory cases (`"abc".Substring(2)` and `"abc".Substring(0, 1)`) with a comment recording why `Insert` is excluded.

## Notes for the reviewer

The code fixer was **not** throwing on these. Its pattern `Arguments: [{ Value: IInvocationOperation ... }, ..]` fails to match, because argument 0 of `Insert` is the `int` index, so it returned before calling `RegisterCodeFix` and no lightbulb was ever offered. The user-visible defect was the diagnostic message naming a non-existent API, so the fixer needed no change and is untouched.

`docs/Rules/MA0028.md` never described the `Substring`/`Insert` behaviour, so there was nothing to update there.

## Verification

- Analyzer builds clean, 0 warnings.
- Reverted the analyzer fix while keeping the new tests: both failed with exactly the reported message, confirming the tests are a real regression guard rather than vacuous. Restored the fix and they pass.
- MA0028 tests pass on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9) — 107/107 each, up from 105 with the two added cases.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.