### PR TITLE
Add MA0222 and MA0223 to require the System.Text.Json Respect* options to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0219](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md)|Design|Set the language attribute in XML comment|👻|✔️|✔️|❌|
 |[MA0220](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0220.md)|Design|The configured regular expression is not valid|⚠️|✔️|❌|❌|
 |[MA0221](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0221.md)|Design|TryGetValue method should use \[MaybeNullWhen(false)\] on the value parameter|ℹ️|❌|✔️|❌|
+|[MA0222](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0222.md)|Design|JsonSourceGenerationOptions should set RespectNullableAnnotations|⚠️|❌|✔️|❌|
+|[MA0223](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0223.md)|Design|JsonSourceGenerationOptions should set RespectRequiredConstructorParameters|⚠️|❌|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -220,6 +220,8 @@
 |[MA0219](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md)|Design|Set the language attribute in XML comment|<span title='Hidden'>👻</span>|✔️|✔️|❌|
 |[MA0220](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0220.md)|Design|The configured regular expression is not valid|<span title='Warning'>⚠️</span>|✔️|❌|❌|
 |[MA0221](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0221.md)|Design|TryGetValue method should use \[MaybeNullWhen(false)\] on the value parameter|<span title='Info'>ℹ️</span>|❌|✔️|❌|
+|[MA0222](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0222.md)|Design|JsonSourceGenerationOptions should set RespectNullableAnnotations|<span title='Warning'>⚠️</span>|❌|✔️|❌|
+|[MA0223](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0223.md)|Design|JsonSourceGenerationOptions should set RespectRequiredConstructorParameters|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0222.md
+++ b/docs/Rules/MA0222.md
@@ -1,0 +1,57 @@
+# MA0222 - JsonSourceGenerationOptions should set RespectNullableAnnotations
+<!-- sources -->
+Sources: [JsonSourceGenerationOptionsAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/JsonSourceGenerationOptionsAnalyzer.cs), [JsonSourceGenerationOptionsFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/JsonSourceGenerationOptionsFixer.cs)
+<!-- sources -->
+
+`System.Text.Json` does not enforce the nullable annotations of the types it serializes and deserializes. `RespectNullableAnnotations`, introduced in .NET 9, makes the serializer throw when a `null` value is read into, or written from, a non-nullable property, field or constructor parameter. It defaults to `false` for backward compatibility, so a `JsonSerializerContext` that does not configure it silently produces instances whose non-nullable members are `null`.
+
+This rule reports the `JsonSerializerContext` whose `[JsonSourceGenerationOptions]` attribute does not set the option, including the ones that have no `[JsonSourceGenerationOptions]` attribute at all. It does not require a particular value: setting the option to `false` is a deliberate choice, and satisfies the rule as much as setting it to `true`.
+
+[MA0223](MA0223.md) reports the closely related `RespectRequiredConstructorParameters` option.
+
+````csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+// ❌ The option is not configured, and deserializing {"Name":null} sets Name to null
+[JsonSerializable(typeof(Person))]
+partial class PersonContext : JsonSerializerContext;
+
+// ✅ Deserializing {"Name":null} throws
+[JsonSourceGenerationOptions(RespectNullableAnnotations = true)]
+[JsonSerializable(typeof(Person))]
+partial class PersonContext : JsonSerializerContext;
+
+// ✅ The legacy behavior is kept, but the choice is explicit
+[JsonSourceGenerationOptions(RespectNullableAnnotations = false)]
+[JsonSerializable(typeof(Person))]
+partial class PersonContext : JsonSerializerContext;
+
+// ✅ JsonSerializerDefaults.Strict, introduced in .NET 10, sets the option
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Strict)]
+[JsonSerializable(typeof(Person))]
+partial class PersonContext : JsonSerializerContext;
+
+class Person
+{
+    public string Name { get; set; } = "";
+}
+````
+
+Note that the option only rejects the `null` values that are present in the payload: a missing property is left to its default value, which is `null` for an uninitialized non-nullable reference type. Use the `required` modifier or `[JsonRequired]` to reject the payloads that do not contain the property.
+
+The rule does not report anything when the target framework does not support the option.
+
+The option can also be enabled for the whole application with the `System.Text.Json.Serialization.RespectNullableAnnotationsDefault` feature switch, which this rule does not detect:
+
+````xml
+<ItemGroup>
+  <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectNullableAnnotationsDefault" Value="true" />
+</ItemGroup>
+````
+
+This rule is disabled by default as it requires every context to configure the option. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0222.severity = warning
+````

--- a/docs/Rules/MA0223.md
+++ b/docs/Rules/MA0223.md
@@ -1,0 +1,52 @@
+# MA0223 - JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
+<!-- sources -->
+Sources: [JsonSourceGenerationOptionsAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/JsonSourceGenerationOptionsAnalyzer.cs), [JsonSourceGenerationOptionsFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/JsonSourceGenerationOptionsFixer.cs)
+<!-- sources -->
+
+For historical reasons, `System.Text.Json` treats all the constructor parameters as optional, and fills the ones that are missing from the payload with their default value. `RespectRequiredConstructorParameters`, introduced in .NET 9, makes the serializer throw when a non-optional constructor parameter is missing. It defaults to `false` for backward compatibility, so a `JsonSerializerContext` that does not configure it silently produces instances built from an incomplete payload.
+
+This rule reports the `JsonSerializerContext` whose `[JsonSourceGenerationOptions]` attribute does not set the option, including the ones that have no `[JsonSourceGenerationOptions]` attribute at all. It does not require a particular value: setting the option to `false` is a deliberate choice, and satisfies the rule as much as setting it to `true`.
+
+[MA0222](MA0222.md) reports the closely related `RespectNullableAnnotations` option.
+
+````csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+// ❌ The option is not configured, and deserializing {} creates a Person whose Id is 0
+[JsonSerializable(typeof(Person))]
+partial class PersonContext : JsonSerializerContext;
+
+// ✅ Deserializing {} throws as Id is missing
+[JsonSourceGenerationOptions(RespectRequiredConstructorParameters = true)]
+[JsonSerializable(typeof(Person))]
+partial class PersonContext : JsonSerializerContext;
+
+// ✅ The legacy behavior is kept, but the choice is explicit
+[JsonSourceGenerationOptions(RespectRequiredConstructorParameters = false)]
+[JsonSerializable(typeof(Person))]
+partial class PersonContext : JsonSerializerContext;
+
+// ✅ JsonSerializerDefaults.Strict, introduced in .NET 10, sets the option
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Strict)]
+[JsonSerializable(typeof(Person))]
+partial class PersonContext : JsonSerializerContext;
+
+record Person(int Id);
+````
+
+The rule does not report anything when the target framework does not support the option.
+
+The option can also be enabled for the whole application with the `System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault` feature switch, which this rule does not detect:
+
+````xml
+<ItemGroup>
+  <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault" Value="true" />
+</ItemGroup>
+````
+
+This rule is disabled by default as it requires every context to configure the option. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0223.severity = warning
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/JsonSourceGenerationOptionsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/JsonSourceGenerationOptionsFixer.cs
@@ -1,0 +1,73 @@
+using Microsoft.CodeAnalysis.Simplification;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class JsonSourceGenerationOptionsFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.SetRespectNullableAnnotations, RuleIdentifiers.SetRespectRequiredConstructorParameters);
+
+    public override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
+        if (nodeToFix is not (AttributeSyntax or TypeDeclarationSyntax))
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var attributeSymbol = semanticModel.Compilation.GetBestTypeByMetadataName("System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute");
+        if (attributeSymbol is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var propertyName = GetPropertyName(diagnostic.Id);
+            if (propertyName is null)
+                continue;
+
+            var title = $"Set {propertyName} to true";
+            context.RegisterCodeFix(
+                CodeAction.Create(title, ct => Refactor(context.Document, nodeToFix, propertyName, attributeSymbol, ct), equivalenceKey: title),
+                diagnostic);
+        }
+    }
+
+    private static string? GetPropertyName(string diagnosticId) => diagnosticId switch
+    {
+        RuleIdentifiers.SetRespectNullableAnnotations => "RespectNullableAnnotations",
+        RuleIdentifiers.SetRespectRequiredConstructorParameters => "RespectRequiredConstructorParameters",
+        _ => null,
+    };
+
+    private static async Task<Document> Refactor(Document document, SyntaxNode nodeToFix, string propertyName, INamedTypeSymbol attributeSymbol, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        if (nodeToFix is AttributeSyntax attribute)
+        {
+            var argument = SyntaxFactory.AttributeArgument(SyntaxFactory.NameEquals(propertyName), nameColon: null, SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression));
+            var argumentList = attribute.ArgumentList ?? SyntaxFactory.AttributeArgumentList();
+            editor.ReplaceNode(attribute, attribute.WithArgumentList(argumentList.AddArguments(argument)));
+        }
+        else
+        {
+            // The context has no [JsonSourceGenerationOptions] attribute, so the fix adds it
+            var generator = editor.Generator;
+            var newAttribute = generator.Attribute(
+                generator.TypeExpression(attributeSymbol).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation),
+                [generator.AttributeArgument(propertyName, generator.TrueLiteralExpression())]);
+
+            editor.AddAttribute(nodeToFix, newAttribute);
+        }
+
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -658,3 +658,9 @@ dotnet_diagnostic.MA0220.severity = error
 
 # MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
 dotnet_diagnostic.MA0221.severity = error
+
+# MA0222: JsonSourceGenerationOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0222.severity = error
+
+# MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0223.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -658,3 +658,9 @@ dotnet_diagnostic.MA0220.severity = suggestion
 
 # MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
 dotnet_diagnostic.MA0221.severity = suggestion
+
+# MA0222: JsonSourceGenerationOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0222.severity = suggestion
+
+# MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0223.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -658,3 +658,9 @@ dotnet_diagnostic.MA0220.severity = warning
 
 # MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
 dotnet_diagnostic.MA0221.severity = warning
+
+# MA0222: JsonSourceGenerationOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0222.severity = warning
+
+# MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0223.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -658,3 +658,9 @@ dotnet_diagnostic.MA0220.severity = warning
 
 # MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
 dotnet_diagnostic.MA0221.severity = none
+
+# MA0222: JsonSourceGenerationOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0222.severity = none
+
+# MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0223.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -658,3 +658,9 @@ dotnet_diagnostic.MA0220.severity = none
 
 # MA0221: TryGetValue method should use [MaybeNullWhen(false)] on the value parameter
 dotnet_diagnostic.MA0221.severity = none
+
+# MA0222: JsonSourceGenerationOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0222.severity = none
+
+# MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0223.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -221,6 +221,8 @@ internal static class RuleIdentifiers
     public const string MissingLanguageAttributeInXmlComment = "MA0219";
     public const string InvalidRegexConfiguration = "MA0220";
     public const string MissingMaybeNullWhenAttributeOnTryGetValue = "MA0221";
+    public const string SetRespectNullableAnnotations = "MA0222";
+    public const string SetRespectRequiredConstructorParameters = "MA0223";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/JsonSourceGenerationOptionsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/JsonSourceGenerationOptionsAnalyzer.cs
@@ -1,0 +1,152 @@
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class JsonSourceGenerationOptionsAnalyzer : DiagnosticAnalyzer
+{
+    private const string RespectNullableAnnotationsPropertyName = "RespectNullableAnnotations";
+    private const string RespectRequiredConstructorParametersPropertyName = "RespectRequiredConstructorParameters";
+
+    private static readonly DiagnosticDescriptor RespectNullableAnnotationsRule = new(
+        RuleIdentifiers.SetRespectNullableAnnotations,
+        title: "JsonSourceGenerationOptions should set RespectNullableAnnotations",
+        messageFormat: "Set RespectNullableAnnotations on [JsonSourceGenerationOptions]",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.SetRespectNullableAnnotations));
+
+    private static readonly DiagnosticDescriptor RespectRequiredConstructorParametersRule = new(
+        RuleIdentifiers.SetRespectRequiredConstructorParameters,
+        title: "JsonSourceGenerationOptions should set RespectRequiredConstructorParameters",
+        messageFormat: "Set RespectRequiredConstructorParameters on [JsonSourceGenerationOptions]",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.SetRespectRequiredConstructorParameters));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RespectNullableAnnotationsRule, RespectRequiredConstructorParametersRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var analyzerContext = new AnalyzerContext(compilationContext.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            compilationContext.RegisterSymbolAction(analyzerContext.AnalyzeNamedType, SymbolKind.NamedType);
+        });
+    }
+
+    private sealed class AnalyzerContext(Compilation compilation)
+    {
+        private readonly INamedTypeSymbol? _jsonSerializerContextSymbol = compilation.GetBestTypeByMetadataName("System.Text.Json.Serialization.JsonSerializerContext");
+        private readonly INamedTypeSymbol? _attributeSymbol = compilation.GetBestTypeByMetadataName("System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute");
+
+        // JsonSerializerDefaults.Strict, introduced in .NET 10, sets both properties
+        private readonly IFieldSymbol? _strictDefaults = compilation.GetBestTypeByMetadataName("System.Text.Json.JsonSerializerDefaults")?
+            .GetMembers("Strict")
+            .OfType<IFieldSymbol>()
+            .FirstOrDefault(field => field.HasConstantValue);
+
+        // Both properties were introduced in .NET 9
+        private bool SupportsRespectNullableAnnotations => HasBooleanProperty(_attributeSymbol, RespectNullableAnnotationsPropertyName);
+
+        private bool SupportsRespectRequiredConstructorParameters => HasBooleanProperty(_attributeSymbol, RespectRequiredConstructorParametersPropertyName);
+
+        public bool IsValid => _jsonSerializerContextSymbol is not null && _attributeSymbol is not null
+            && (SupportsRespectNullableAnnotations || SupportsRespectRequiredConstructorParameters);
+
+        public void AnalyzeNamedType(SymbolAnalysisContext context)
+        {
+            var symbol = (INamedTypeSymbol)context.Symbol;
+            if (!symbol.InheritsFrom(_jsonSerializerContextSymbol))
+                return;
+
+            var attribute = symbol.GetFirstAttribute(_attributeSymbol);
+            var setByDefaults = attribute is not null && UsesStrictDefaults(attribute);
+
+            if (SupportsRespectNullableAnnotations && !IsSet(attribute, RespectNullableAnnotationsPropertyName, setByDefaults))
+            {
+                Report(context, symbol, attribute, RespectNullableAnnotationsRule);
+            }
+
+            if (SupportsRespectRequiredConstructorParameters && !IsSet(attribute, RespectRequiredConstructorParametersPropertyName, setByDefaults))
+            {
+                Report(context, symbol, attribute, RespectRequiredConstructorParametersRule);
+            }
+        }
+
+        private bool UsesStrictDefaults(AttributeData attribute)
+        {
+            if (_strictDefaults is null || attribute.ConstructorArguments.Length is 0)
+                return false;
+
+            var argument = attribute.ConstructorArguments[0];
+            return argument.Type.IsEqualTo(_strictDefaults.ContainingType) && Equals(argument.Value, _strictDefaults.ConstantValue);
+        }
+
+        private static bool HasBooleanProperty(INamedTypeSymbol? attributeSymbol, string propertyName)
+        {
+            if (attributeSymbol is null)
+                return false;
+
+            foreach (var member in attributeSymbol.GetMembers(propertyName))
+            {
+                if (member is IPropertySymbol { Type.SpecialType: SpecialType.System_Boolean })
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Indicates whether the option is explicitly configured, whatever the value it is set to.
+        /// </summary>
+        private static bool IsSet(AttributeData? attribute, string propertyName, bool setByDefaults)
+        {
+            if (attribute is null)
+                return false;
+
+            foreach (var namedArgument in attribute.NamedArguments)
+            {
+                if (string.Equals(namedArgument.Key, propertyName, StringComparison.Ordinal))
+                    return true;
+            }
+
+            return setByDefaults;
+        }
+
+        private static void Report(SymbolAnalysisContext context, INamedTypeSymbol symbol, AttributeData? attribute, DiagnosticDescriptor rule)
+        {
+            if (attribute is not null)
+            {
+                context.ReportDiagnostic(rule, attribute);
+            }
+            else if (GetDeclarationLocation(context, symbol) is { } location)
+            {
+                context.ReportDiagnostic(rule, location);
+            }
+        }
+
+        /// <summary>
+        /// Gets the location of the declaration the attribute must be added to. The source generator declares another
+        /// part of the context, so the symbol has a location in generated code, where the attribute cannot be added.
+        /// </summary>
+        private static Location? GetDeclarationLocation(SymbolAnalysisContext context, INamedTypeSymbol symbol)
+        {
+            foreach (var location in symbol.Locations)
+            {
+                if (location.SourceTree is null || !location.SourceTree.IsGeneratedCode(context.Options, context.CancellationToken))
+                    return location;
+            }
+
+            return symbol.Locations.FirstOrDefault();
+        }
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/JsonSourceGenerationOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/JsonSourceGenerationOptionsAnalyzerTests.cs
@@ -1,0 +1,263 @@
+using Microsoft.CodeAnalysis.Testing;
+using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
+    Meziantou.Analyzer.Rules.JsonSourceGenerationOptionsAnalyzer>;
+using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
+    Meziantou.Analyzer.Rules.JsonSourceGenerationOptionsAnalyzer,
+    Meziantou.Analyzer.Rules.JsonSourceGenerationOptionsFixer>;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class JsonSourceGenerationOptionsAnalyzerTests
+{
+    // The options are only available from .NET 9, and the System.Text.Json source generator implements
+    // the members of JsonSerializerContext the tests do not declare
+    private static AnalyzerTest CreateTest(ReferenceAssemblies? referenceAssemblies = null) => new()
+    {
+        UseFrameworkSourceGenerators = true,
+        ReferenceAssemblies = referenceAssemblies ?? ReferenceAssemblies.Net.Net90,
+    };
+
+    private static CodeFixTest CreateCodeFixTest() => new()
+    {
+        UseFrameworkSourceGenerators = true,
+        ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+    };
+
+    [Theory]
+    [InlineData("RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true")]
+    [InlineData("RespectNullableAnnotations = false, RespectRequiredConstructorParameters = false")]
+    [InlineData("RespectNullableAnnotations = true, RespectRequiredConstructorParameters = false")]
+    public Task BothOptionsSet(string options)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            using System.Text.Json.Serialization;
+
+            [JsonSourceGenerationOptions({{options}})]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("RespectRequiredConstructorParameters = true")]
+    [InlineData("RespectRequiredConstructorParameters = false")]
+    public Task MissingRespectNullableAnnotations(string options)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            using System.Text.Json.Serialization;
+
+            [{|MA0222:JsonSourceGenerationOptions({{options}})|}]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("RespectNullableAnnotations = true")]
+    [InlineData("RespectNullableAnnotations = false")]
+    public Task MissingRespectRequiredConstructorParameters(string options)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            using System.Text.Json.Serialization;
+
+            [{|MA0223:JsonSourceGenerationOptions({{options}})|}]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AttributeWithoutTheOptions()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Text.Json.Serialization;
+
+            [{|MA0222:{|MA0223:JsonSourceGenerationOptions(WriteIndented = true)|}|}]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MissingAttribute()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Text.Json.Serialization;
+
+            [JsonSerializable(typeof(int))]
+            partial class {|MA0222:{|MA0223:SampleContext|}|} : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+#if ROSLYN_4_14_OR_GREATER // The .NET 10 source generators cannot be loaded by the older versions of Roslyn
+    [Theory]
+    [InlineData("JsonSerializerDefaults.Strict")]
+    [InlineData("JsonSerializerDefaults.Strict, RespectNullableAnnotations = false")]
+    public Task StrictDefaults(string arguments)
+    {
+        // JsonSerializerDefaults.Strict, introduced in .NET 10, sets both options
+        var test = CreateTest(ReferenceAssemblies.Net.Net100);
+        test.TestCode = $$"""
+            using System.Text.Json;
+            using System.Text.Json.Serialization;
+
+            [JsonSourceGenerationOptions({{arguments}})]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("JsonSerializerDefaults.Web")]
+    [InlineData("JsonSerializerDefaults.General")]
+    public Task DefaultsNotSettingTheOptions(string arguments)
+    {
+        var test = CreateTest(ReferenceAssemblies.Net.Net100);
+        test.TestCode = $$"""
+            using System.Text.Json;
+            using System.Text.Json.Serialization;
+
+            [{|MA0222:{|MA0223:JsonSourceGenerationOptions({{arguments}})|}|}]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+#endif
+
+    [Fact]
+    public Task Fix_AddsRespectNullableAnnotations()
+    {
+        var test = CreateCodeFixTest();
+        test.TestCode = """
+            using System.Text.Json.Serialization;
+
+            [{|MA0222:JsonSourceGenerationOptions(RespectRequiredConstructorParameters = true)|}]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+        test.FixedCode = """
+            using System.Text.Json.Serialization;
+
+            [JsonSourceGenerationOptions(RespectRequiredConstructorParameters = true, RespectNullableAnnotations = true)]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Fix_AddsRespectRequiredConstructorParameters()
+    {
+        var test = CreateCodeFixTest();
+        test.TestCode = """
+            using System.Text.Json.Serialization;
+
+            [{|MA0223:JsonSourceGenerationOptions(RespectNullableAnnotations = false)|}]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+        test.FixedCode = """
+            using System.Text.Json.Serialization;
+
+            [JsonSourceGenerationOptions(RespectNullableAnnotations = false, RespectRequiredConstructorParameters = true)]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Fix_AddsBothOptions()
+    {
+        var test = CreateCodeFixTest();
+
+        // Both fixes change the same attribute, so they cannot be batched in a single iteration
+        test.NumberOfFixAllIterations = 2;
+        test.TestCode = """
+            using System.Text.Json.Serialization;
+
+            [{|MA0222:{|MA0223:JsonSourceGenerationOptions(WriteIndented = true)|}|}]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+        test.FixedCode = """
+            using System.Text.Json.Serialization;
+
+            [JsonSourceGenerationOptions(WriteIndented = true, RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true)]
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Fix_AddsTheAttribute()
+    {
+        var test = CreateCodeFixTest();
+
+        // The first fix adds the attribute, the second one adds the remaining option to it
+        test.NumberOfFixAllIterations = 2;
+        test.TestCode = """
+            using System.Text.Json.Serialization;
+
+            [JsonSerializable(typeof(int))]
+            partial class {|MA0222:{|MA0223:SampleContext|}|} : JsonSerializerContext;
+            """;
+        test.FixedCode = """
+            using System.Text.Json.Serialization;
+
+            [JsonSerializable(typeof(int))]
+            [JsonSourceGenerationOptions(RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true)]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task NotAJsonSerializerContext()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class SampleContext;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TargetFrameworkWithoutTheOptions()
+    {
+        var test = CreateTest(ReferenceAssemblies.Net.Net80);
+        test.TestCode = """
+            using System.Text.Json.Serialization;
+
+            [JsonSerializable(typeof(int))]
+            partial class SampleContext : JsonSerializerContext;
+            """;
+
+        return test.RunAsync();
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/JsonSourceGenerationOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/JsonSourceGenerationOptionsAnalyzerTests.cs
@@ -9,19 +9,42 @@ namespace Meziantou.Analyzer.Test.Rules;
 
 public sealed class JsonSourceGenerationOptionsAnalyzerTests
 {
-    // The options are only available from .NET 9, and the System.Text.Json source generator implements
-    // the members of JsonSerializerContext the tests do not declare
-    private static AnalyzerTest CreateTest(ReferenceAssemblies? referenceAssemblies = null) => new()
-    {
-        UseFrameworkSourceGenerators = true,
-        ReferenceAssemblies = referenceAssemblies ?? ReferenceAssemblies.Net.Net90,
-    };
+    /// <summary>
+    /// The target framework the tests compile against, or <see langword="null"/> to use the latest one the harness
+    /// provides. The source generators shipped with a .NET version cannot be loaded by the older versions of
+    /// Roslyn, so the tests lower the target framework to the latest one the running version of Roslyn can load.
+    /// </summary>
+    private static ReferenceAssemblies? DefaultReferenceAssemblies =>
+#if ROSLYN_5_0_OR_GREATER
+        null;
+#elif ROSLYN_4_14_OR_GREATER
+        ReferenceAssemblies.Net.Net100;
+#else
+        ReferenceAssemblies.Net.Net90;
+#endif
 
-    private static CodeFixTest CreateCodeFixTest() => new()
+    // The System.Text.Json source generator implements the members of JsonSerializerContext the tests do not declare
+    private static AnalyzerTest CreateTest(ReferenceAssemblies? referenceAssemblies = null)
     {
-        UseFrameworkSourceGenerators = true,
-        ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
-    };
+        var test = new AnalyzerTest { UseFrameworkSourceGenerators = true };
+        if ((referenceAssemblies ?? DefaultReferenceAssemblies) is { } assemblies)
+        {
+            test.ReferenceAssemblies = assemblies;
+        }
+
+        return test;
+    }
+
+    private static CodeFixTest CreateCodeFixTest()
+    {
+        var test = new CodeFixTest { UseFrameworkSourceGenerators = true };
+        if (DefaultReferenceAssemblies is { } assemblies)
+        {
+            test.ReferenceAssemblies = assemblies;
+        }
+
+        return test;
+    }
 
     [Theory]
     [InlineData("RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true")]
@@ -111,7 +134,7 @@ public sealed class JsonSourceGenerationOptionsAnalyzerTests
     public Task StrictDefaults(string arguments)
     {
         // JsonSerializerDefaults.Strict, introduced in .NET 10, sets both options
-        var test = CreateTest(ReferenceAssemblies.Net.Net100);
+        var test = CreateTest();
         test.TestCode = $$"""
             using System.Text.Json;
             using System.Text.Json.Serialization;
@@ -129,7 +152,7 @@ public sealed class JsonSourceGenerationOptionsAnalyzerTests
     [InlineData("JsonSerializerDefaults.General")]
     public Task DefaultsNotSettingTheOptions(string arguments)
     {
-        var test = CreateTest(ReferenceAssemblies.Net.Net100);
+        var test = CreateTest();
         test.TestCode = $$"""
             using System.Text.Json;
             using System.Text.Json.Serialization;


### PR DESCRIPTION
## What

Two new rules, one per option, both **disabled by default**:

| Id | Title |
|----|-------|
| MA0222 | JsonSourceGenerationOptions should set `RespectNullableAnnotations` |
| MA0223 | JsonSourceGenerationOptions should set `RespectRequiredConstructorParameters` |

They report a `JsonSerializerContext` whose `[JsonSourceGenerationOptions]` attribute does not set the corresponding option, including the contexts that have no attribute at all. A code fixer sets the option to `true`, adding the attribute when the context has none.

## Why

`System.Text.Json` ignores the nullable annotations of the types it (de)serializes, and treats every constructor parameter as optional. `RespectNullableAnnotations` and `RespectRequiredConstructorParameters` (both .NET 9) enable those validations, but default to `false` for backward compatibility — so a context that never mentions them silently produces instances whose non-nullable members are `null`, or that were built from an incomplete payload.

## Notes for the reviewer

- **The rules require the option to be *set*, not to be set to `true`.** `RespectNullableAnnotations = false` is a deliberate choice and satisfies MA0222 exactly as `= true` does. The rules are about making the decision explicit; the fixer is the one that opts for `true`.
- **`JsonSerializerDefaults.Strict` counts as setting both.** It configures them through the constructor, so `[JsonSourceGenerationOptions(JsonSerializerDefaults.Strict)]` stays clean, and a named argument still wins over it. `Web` and `General` do not touch the options and still report. Verified against the real generator that `Strict` sets both, and that an explicit `RespectNullableAnnotations = false` overrides it.
- **One analyzer reports both rules**, following the `ValidateFixedAddressValueTypeAttributeUsageAnalyzer` (MA0207/MA0208) precedent — the symbol lookups and the `JsonSerializerContext` walk are shared, so two analyzer types would double the per-compilation cost for the same work. Each rule is still gated on its own property existing on the attribute type, so they can diverge across target frameworks.
- **The diagnostic on a context without the attribute skips the partial declaration the source generator emits**, so it never points at (or carries an additional location in) a `.g.cs`.
- Nothing is reported when the target framework predates .NET 9.
- **When both rules fire, fix-all needs two iterations** — the two fixes touch the same node. The tests assert this explicitly rather than papering over it.

## Tests

`JsonSourceGenerationOptionsAnalyzerTests` drives the real System.Text.Json source generator (`UseFrameworkSourceGenerators`), without which the `JsonSerializerContext` snippets would not compile.

Reference assemblies are pinned to `Net90` (the minimum version with the options) rather than the default pack, because the newer generators cannot be loaded by the older Roslyn test hosts. The `JsonSerializerDefaults.Strict` cases need `Net100`, whose generators require Roslyn 4.14+, so they are behind `#if ROSLYN_4_14_OR_GREATER`.

- 21/21 pass on roslyn4.14, 5.0, 5.6 and 5.9; 17/17 on roslyn4.8
- Full roslyn5.9 suite: 4042/4042
- Solution builds with 0 warnings, and `dotnet run --project src/DocumentationGenerator` exits 0 on a re-run
