### PR TITLE
Add MA0224 and MA0225 to require the Respect* options on JsonSerializerOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0221](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0221.md)|Design|TryGetValue method should use \[MaybeNullWhen(false)\] on the value parameter|ℹ️|❌|✔️|❌|
 |[MA0222](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0222.md)|Design|JsonSourceGenerationOptions should set RespectNullableAnnotations|⚠️|❌|✔️|❌|
 |[MA0223](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0223.md)|Design|JsonSourceGenerationOptions should set RespectRequiredConstructorParameters|⚠️|❌|✔️|❌|
+|[MA0224](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0224.md)|Design|JsonSerializerOptions should set RespectNullableAnnotations|⚠️|❌|✔️|❌|
+|[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|⚠️|❌|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -222,6 +222,8 @@
 |[MA0221](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0221.md)|Design|TryGetValue method should use \[MaybeNullWhen(false)\] on the value parameter|<span title='Info'>ℹ️</span>|❌|✔️|❌|
 |[MA0222](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0222.md)|Design|JsonSourceGenerationOptions should set RespectNullableAnnotations|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0223](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0223.md)|Design|JsonSourceGenerationOptions should set RespectRequiredConstructorParameters|<span title='Warning'>⚠️</span>|❌|✔️|❌|
+|[MA0224](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0224.md)|Design|JsonSerializerOptions should set RespectNullableAnnotations|<span title='Warning'>⚠️</span>|❌|✔️|❌|
+|[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0224.md
+++ b/docs/Rules/MA0224.md
@@ -1,0 +1,50 @@
+# MA0224 - JsonSerializerOptions should set RespectNullableAnnotations
+<!-- sources -->
+Sources: [JsonSerializerOptionsAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/JsonSerializerOptionsAnalyzer.cs), [JsonSerializerOptionsFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/JsonSerializerOptionsFixer.cs)
+<!-- sources -->
+
+`System.Text.Json` does not enforce the nullable annotations of the types it serializes and deserializes. `RespectNullableAnnotations`, introduced in .NET 9, makes the serializer throw when a `null` value is read into, or written from, a non-nullable property, field or constructor parameter. It defaults to `false` for backward compatibility, so a `JsonSerializerOptions` instance that does not configure it silently produces instances whose non-nullable members are `null`.
+
+This rule reports the creation of a `JsonSerializerOptions` that does not configure the option. It does not require a particular value: setting the option to `false` is a deliberate choice, and satisfies the rule as much as setting it to `true`.
+
+[MA0225](MA0225.md) reports the closely related `RespectRequiredConstructorParameters` option. [MA0222](MA0222.md) reports the same option on the `[JsonSourceGenerationOptions]` attribute of a `JsonSerializerContext`.
+
+````csharp
+using System.Text.Json;
+
+// ❌ The option is not configured, and deserializing {"Name":null} sets Name to null
+var options = new JsonSerializerOptions();
+
+// ✅ Deserializing {"Name":null} throws
+var options = new JsonSerializerOptions { RespectNullableAnnotations = true };
+
+// ✅ The legacy behavior is kept, but the choice is explicit
+var options = new JsonSerializerOptions { RespectNullableAnnotations = false };
+
+// ✅ The option is set on the local the creation is assigned to
+var options = new JsonSerializerOptions();
+options.RespectNullableAnnotations = true;
+
+// ✅ JsonSerializerDefaults.Strict, introduced in .NET 10, sets the option
+var options = new JsonSerializerOptions(JsonSerializerDefaults.Strict);
+````
+
+Note that the option only rejects the `null` values that are present in the payload: a missing property is left to its default value, which is `null` for an uninitialized non-nullable reference type. Use the `required` modifier or `[JsonRequired]` to reject the payloads that do not contain the property.
+
+The rule does not report anything when the target framework does not support the option.
+
+The rule only reports the creation of a `JsonSerializerOptions`, and considers the option configured when it is set in the object initializer, or on the local the creation is assigned to in the same method. It does not report the options that are configured without being created, such as the ones of `ConfigureHttpJsonOptions` or `AddJsonOptions` in an ASP.NET Core application, and it does not report the copy constructor, as the copied instance can be configured somewhere else.
+
+The option can also be enabled for the whole application with the `System.Text.Json.Serialization.RespectNullableAnnotationsDefault` feature switch, which this rule does not detect:
+
+````xml
+<ItemGroup>
+  <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectNullableAnnotationsDefault" Value="true" />
+</ItemGroup>
+````
+
+This rule is disabled by default as it requires every `JsonSerializerOptions` to configure the option. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0224.severity = warning
+````

--- a/docs/Rules/MA0225.md
+++ b/docs/Rules/MA0225.md
@@ -1,0 +1,50 @@
+# MA0225 - JsonSerializerOptions should set RespectRequiredConstructorParameters
+<!-- sources -->
+Sources: [JsonSerializerOptionsAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/JsonSerializerOptionsAnalyzer.cs), [JsonSerializerOptionsFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/JsonSerializerOptionsFixer.cs)
+<!-- sources -->
+
+For historical reasons, `System.Text.Json` treats all the constructor parameters as optional, and fills the ones that are missing from the payload with their default value. `RespectRequiredConstructorParameters`, introduced in .NET 9, makes the serializer throw when a non-optional constructor parameter is missing. It defaults to `false` for backward compatibility, so a `JsonSerializerOptions` instance that does not configure it silently produces instances built from an incomplete payload.
+
+This rule reports the creation of a `JsonSerializerOptions` that does not configure the option. It does not require a particular value: setting the option to `false` is a deliberate choice, and satisfies the rule as much as setting it to `true`.
+
+[MA0224](MA0224.md) reports the closely related `RespectNullableAnnotations` option. [MA0223](MA0223.md) reports the same option on the `[JsonSourceGenerationOptions]` attribute of a `JsonSerializerContext`.
+
+````csharp
+using System.Text.Json;
+
+// ❌ The option is not configured, and deserializing {} creates a Person whose Id is 0
+var options = new JsonSerializerOptions();
+
+// ✅ Deserializing {} throws as Id is missing
+var options = new JsonSerializerOptions { RespectRequiredConstructorParameters = true };
+
+// ✅ The legacy behavior is kept, but the choice is explicit
+var options = new JsonSerializerOptions { RespectRequiredConstructorParameters = false };
+
+// ✅ The option is set on the local the creation is assigned to
+var options = new JsonSerializerOptions();
+options.RespectRequiredConstructorParameters = true;
+
+// ✅ JsonSerializerDefaults.Strict, introduced in .NET 10, sets the option
+var options = new JsonSerializerOptions(JsonSerializerDefaults.Strict);
+
+record Person(int Id);
+````
+
+The rule does not report anything when the target framework does not support the option.
+
+The rule only reports the creation of a `JsonSerializerOptions`, and considers the option configured when it is set in the object initializer, or on the local the creation is assigned to in the same method. It does not report the options that are configured without being created, such as the ones of `ConfigureHttpJsonOptions` or `AddJsonOptions` in an ASP.NET Core application, and it does not report the copy constructor, as the copied instance can be configured somewhere else.
+
+The option can also be enabled for the whole application with the `System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault` feature switch, which this rule does not detect:
+
+````xml
+<ItemGroup>
+  <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault" Value="true" />
+</ItemGroup>
+````
+
+This rule is disabled by default as it requires every `JsonSerializerOptions` to configure the option. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0225.severity = warning
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/JsonSerializerOptionsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/JsonSerializerOptionsFixer.cs
@@ -1,0 +1,55 @@
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class JsonSerializerOptionsFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.SetRespectNullableAnnotationsOnJsonSerializerOptions, RuleIdentifiers.SetRespectRequiredConstructorParametersOnJsonSerializerOptions);
+
+    public override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root?.FindNode(context.Span, getInnermostNodeForTie: true) is not BaseObjectCreationExpressionSyntax creation)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var propertyName = GetPropertyName(diagnostic.Id);
+            if (propertyName is null)
+                continue;
+
+            var title = $"Set {propertyName} to true";
+            context.RegisterCodeFix(
+                CodeAction.Create(title, ct => Refactor(context.Document, creation, propertyName, ct), equivalenceKey: title),
+                diagnostic);
+        }
+    }
+
+    private static string? GetPropertyName(string diagnosticId) => diagnosticId switch
+    {
+        RuleIdentifiers.SetRespectNullableAnnotationsOnJsonSerializerOptions => "RespectNullableAnnotations",
+        RuleIdentifiers.SetRespectRequiredConstructorParametersOnJsonSerializerOptions => "RespectRequiredConstructorParameters",
+        _ => null,
+    };
+
+    private static async Task<Document> Refactor(Document document, BaseObjectCreationExpressionSyntax creation, string propertyName, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        var assignment = SyntaxFactory.AssignmentExpression(
+            SyntaxKind.SimpleAssignmentExpression,
+            SyntaxFactory.IdentifierName(propertyName),
+            SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression));
+
+        var initializer = creation.Initializer ?? SyntaxFactory.InitializerExpression(SyntaxKind.ObjectInitializerExpression);
+        editor.ReplaceNode(creation, creation.WithInitializer(initializer.AddExpressions(assignment)).WithAdditionalAnnotations(Formatter.Annotation));
+
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -664,3 +664,9 @@ dotnet_diagnostic.MA0222.severity = error
 
 # MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0223.severity = error
+
+# MA0224: JsonSerializerOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0224.severity = error
+
+# MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0225.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -664,3 +664,9 @@ dotnet_diagnostic.MA0222.severity = suggestion
 
 # MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0223.severity = suggestion
+
+# MA0224: JsonSerializerOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0224.severity = suggestion
+
+# MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0225.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -664,3 +664,9 @@ dotnet_diagnostic.MA0222.severity = warning
 
 # MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0223.severity = warning
+
+# MA0224: JsonSerializerOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0224.severity = warning
+
+# MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0225.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -664,3 +664,9 @@ dotnet_diagnostic.MA0222.severity = none
 
 # MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0223.severity = none
+
+# MA0224: JsonSerializerOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0224.severity = none
+
+# MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0225.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -664,3 +664,9 @@ dotnet_diagnostic.MA0222.severity = none
 
 # MA0223: JsonSourceGenerationOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0223.severity = none
+
+# MA0224: JsonSerializerOptions should set RespectNullableAnnotations
+dotnet_diagnostic.MA0224.severity = none
+
+# MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
+dotnet_diagnostic.MA0225.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -223,6 +223,8 @@ internal static class RuleIdentifiers
     public const string MissingMaybeNullWhenAttributeOnTryGetValue = "MA0221";
     public const string SetRespectNullableAnnotations = "MA0222";
     public const string SetRespectRequiredConstructorParameters = "MA0223";
+    public const string SetRespectNullableAnnotationsOnJsonSerializerOptions = "MA0224";
+    public const string SetRespectRequiredConstructorParametersOnJsonSerializerOptions = "MA0225";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/JsonSerializerOptionsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/JsonSerializerOptionsAnalyzer.cs
@@ -1,0 +1,184 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class JsonSerializerOptionsAnalyzer : DiagnosticAnalyzer
+{
+    private const string RespectNullableAnnotationsPropertyName = "RespectNullableAnnotations";
+    private const string RespectRequiredConstructorParametersPropertyName = "RespectRequiredConstructorParameters";
+
+    private static readonly DiagnosticDescriptor RespectNullableAnnotationsRule = new(
+        RuleIdentifiers.SetRespectNullableAnnotationsOnJsonSerializerOptions,
+        title: "JsonSerializerOptions should set RespectNullableAnnotations",
+        messageFormat: "Set RespectNullableAnnotations on the JsonSerializerOptions instance",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.SetRespectNullableAnnotationsOnJsonSerializerOptions));
+
+    private static readonly DiagnosticDescriptor RespectRequiredConstructorParametersRule = new(
+        RuleIdentifiers.SetRespectRequiredConstructorParametersOnJsonSerializerOptions,
+        title: "JsonSerializerOptions should set RespectRequiredConstructorParameters",
+        messageFormat: "Set RespectRequiredConstructorParameters on the JsonSerializerOptions instance",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.SetRespectRequiredConstructorParametersOnJsonSerializerOptions));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RespectNullableAnnotationsRule, RespectRequiredConstructorParametersRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var analyzerContext = new AnalyzerContext(compilationContext.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            compilationContext.RegisterOperationAction(analyzerContext.AnalyzeObjectCreation, OperationKind.ObjectCreation);
+        });
+    }
+
+    private sealed class AnalyzerContext(Compilation compilation)
+    {
+        private readonly INamedTypeSymbol? _optionsSymbol = compilation.GetBestTypeByMetadataName("System.Text.Json.JsonSerializerOptions");
+
+        // JsonSerializerDefaults.Strict, introduced in .NET 10, sets both properties
+        private readonly IFieldSymbol? _strictDefaults = compilation.GetBestTypeByMetadataName("System.Text.Json.JsonSerializerDefaults")?
+            .GetMembers("Strict")
+            .OfType<IFieldSymbol>()
+            .FirstOrDefault(field => field.HasConstantValue);
+
+        // Both properties were introduced in .NET 9
+        private bool SupportsRespectNullableAnnotations => HasBooleanProperty(_optionsSymbol, RespectNullableAnnotationsPropertyName);
+
+        private bool SupportsRespectRequiredConstructorParameters => HasBooleanProperty(_optionsSymbol, RespectRequiredConstructorParametersPropertyName);
+
+        public bool IsValid => _optionsSymbol is not null
+            && (SupportsRespectNullableAnnotations || SupportsRespectRequiredConstructorParameters);
+
+        public void AnalyzeObjectCreation(OperationAnalysisContext context)
+        {
+            var operation = (IObjectCreationOperation)context.Operation;
+            if (!operation.Type.IsEqualTo(_optionsSymbol))
+                return;
+
+            // The copy constructor copies the options of an instance that can be configured somewhere else
+            if (operation.Arguments is [{ Parameter.Type: { } parameterType }] && parameterType.IsEqualTo(_optionsSymbol))
+                return;
+
+            var setByDefaults = UsesStrictDefaults(operation);
+
+            if (SupportsRespectNullableAnnotations && !IsSet(operation, RespectNullableAnnotationsPropertyName, setByDefaults))
+            {
+                context.ReportDiagnostic(RespectNullableAnnotationsRule, GetLocation(operation));
+            }
+
+            if (SupportsRespectRequiredConstructorParameters && !IsSet(operation, RespectRequiredConstructorParametersPropertyName, setByDefaults))
+            {
+                context.ReportDiagnostic(RespectRequiredConstructorParametersRule, GetLocation(operation));
+            }
+        }
+
+        private bool UsesStrictDefaults(IObjectCreationOperation operation)
+        {
+            if (_strictDefaults is null || operation.Arguments is not [var argument])
+                return false;
+
+            return argument.Parameter?.Type.IsEqualTo(_strictDefaults.ContainingType) is true
+                && argument.Value.ConstantValue is { HasValue: true, Value: var value }
+                && Equals(value, _strictDefaults.ConstantValue);
+        }
+
+        private static bool HasBooleanProperty(INamedTypeSymbol? symbol, string propertyName)
+        {
+            if (symbol is null)
+                return false;
+
+            foreach (var member in symbol.GetMembers(propertyName))
+            {
+                if (member is IPropertySymbol { Type.SpecialType: SpecialType.System_Boolean })
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Indicates whether the option is explicitly configured, whatever the value it is set to.
+        /// </summary>
+        private static bool IsSet(IObjectCreationOperation operation, string propertyName, bool setByDefaults)
+        {
+            if (setByDefaults)
+                return true;
+
+            if (operation.Initializer is { } initializer)
+            {
+                foreach (var initializerOperation in initializer.Initializers)
+                {
+                    if (initializerOperation is ISimpleAssignmentOperation { Target: IPropertyReferenceOperation property } && IsProperty(property, propertyName))
+                        return true;
+                }
+            }
+
+            return IsSetOnLocal(operation, propertyName);
+        }
+
+        /// <summary>
+        /// Indicates whether the created instance is stored in a local that a following statement configures,
+        /// such as <c>var options = new JsonSerializerOptions(); options.RespectNullableAnnotations = true;</c>.
+        /// </summary>
+        private static bool IsSetOnLocal(IObjectCreationOperation operation, string propertyName)
+        {
+            if (GetAssignedLocal(operation) is not { } local)
+                return false;
+
+            IOperation root = operation;
+            while (root.Parent is not null)
+            {
+                root = root.Parent;
+            }
+
+            foreach (var descendant in root.Descendants())
+            {
+                if (descendant is ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Instance: ILocalReferenceOperation localReference } property }
+                    && IsProperty(property, propertyName)
+                    && local.IsEqualTo(localReference.Local))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsProperty(IPropertyReferenceOperation operation, string propertyName)
+            => string.Equals(operation.Property.Name, propertyName, StringComparison.Ordinal);
+
+        private static ILocalSymbol? GetAssignedLocal(IObjectCreationOperation operation) => operation.Parent switch
+        {
+            IVariableInitializerOperation { Parent: IVariableDeclaratorOperation declarator } => declarator.Symbol,
+            ISimpleAssignmentOperation { Target: ILocalReferenceOperation localReference } => localReference.Local,
+            _ => null,
+        };
+
+        /// <summary>
+        /// Gets the location of the creation without its object initializer, which can span many lines.
+        /// </summary>
+        private static Location GetLocation(IObjectCreationOperation operation)
+        {
+            if (operation.Syntax is not BaseObjectCreationExpressionSyntax { Initializer: not null } creation)
+                return operation.Syntax.GetLocation();
+
+            var end = creation.ArgumentList?.Span.End ?? (creation as ObjectCreationExpressionSyntax)?.Type.Span.End ?? creation.NewKeyword.Span.End;
+            return Location.Create(creation.SyntaxTree, TextSpan.FromBounds(creation.SpanStart, end));
+        }
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/JsonSerializerOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/JsonSerializerOptionsAnalyzerTests.cs
@@ -1,0 +1,348 @@
+using Microsoft.CodeAnalysis.Testing;
+using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
+    Meziantou.Analyzer.Rules.JsonSerializerOptionsAnalyzer>;
+using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
+    Meziantou.Analyzer.Rules.JsonSerializerOptionsAnalyzer,
+    Meziantou.Analyzer.Rules.JsonSerializerOptionsFixer>;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class JsonSerializerOptionsAnalyzerTests
+{
+    [Theory]
+    [InlineData("RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true")]
+    [InlineData("RespectNullableAnnotations = false, RespectRequiredConstructorParameters = false")]
+    [InlineData("RespectNullableAnnotations = true, RespectRequiredConstructorParameters = false")]
+    public Task BothOptionsSet(string options)
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = $$"""
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = new() { {{options}} };
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("RespectRequiredConstructorParameters = true")]
+    [InlineData("RespectRequiredConstructorParameters = false")]
+    public Task MissingRespectNullableAnnotations(string options)
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = $$"""
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = {|MA0224:new()|} { {{options}} };
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("RespectNullableAnnotations = true")]
+    [InlineData("RespectNullableAnnotations = false")]
+    public Task MissingRespectRequiredConstructorParameters(string options)
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = $$"""
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = {|MA0225:new()|} { {{options}} };
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task CreationWithoutTheOptions()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = {|MA0224:{|MA0225:new JsonSerializerOptions()|}|};
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task CreationWithoutTheOptions_ReportsTheCreationWithoutItsInitializer()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = {|MA0224:{|MA0225:new JsonSerializerOptions|}|}
+                {
+                    WriteIndented = true,
+                };
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionsSetOnTheLocal()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                void A()
+                {
+                    var options = new JsonSerializerOptions();
+                    options.RespectNullableAnnotations = true;
+                    options.RespectRequiredConstructorParameters = false;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionsSetOnTheLocalAssignedAfterItsDeclaration()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                void A()
+                {
+                    JsonSerializerOptions options;
+                    options = new JsonSerializerOptions();
+                    options.RespectNullableAnnotations = true;
+                    options.RespectRequiredConstructorParameters = true;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionsSetOnAnotherLocal()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                void A(JsonSerializerOptions other)
+                {
+                    var options = {|MA0224:{|MA0225:new JsonSerializerOptions()|}|};
+                    var configured = new JsonSerializerOptions { RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true };
+                    other.RespectNullableAnnotations = true;
+                    other.RespectRequiredConstructorParameters = true;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionsSetOnTheLocalInAnotherMethod()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                JsonSerializerOptions A() => {|MA0224:{|MA0225:new JsonSerializerOptions()|}|};
+
+                void B()
+                {
+                    var options = A();
+                    options.RespectNullableAnnotations = true;
+                    options.RespectRequiredConstructorParameters = true;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task CopyConstructor()
+    {
+        // The copied instance can be configured somewhere else
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                JsonSerializerOptions A(JsonSerializerOptions other) => new JsonSerializerOptions(other);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StrictDefaults()
+    {
+        // JsonSerializerDefaults.Strict, introduced in .NET 10, sets both options
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Strict) { RespectNullableAnnotations = false };
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("JsonSerializerDefaults.Web")]
+    [InlineData("JsonSerializerDefaults.General")]
+    public Task DefaultsNotSettingTheOptions(string arguments)
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = $$"""
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = {|MA0224:{|MA0225:new JsonSerializerOptions({{arguments}})|}|};
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OtherType()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            class Sample
+            {
+                static readonly Sample Instance = new();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task UnsupportedTargetFramework()
+    {
+        // The options were introduced in .NET 9
+        var test = new AnalyzerTest();
+        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = new();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Fix_AddsRespectNullableAnnotations()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = {|MA0224:new()|} { RespectRequiredConstructorParameters = true };
+            }
+            """;
+        test.FixedCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = new() { RespectRequiredConstructorParameters = true, RespectNullableAnnotations = true };
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Fix_AddsRespectRequiredConstructorParameters()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = {|MA0225:new()|} { RespectNullableAnnotations = false };
+            }
+            """;
+        test.FixedCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = new() { RespectNullableAnnotations = false, RespectRequiredConstructorParameters = true };
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Fix_AddsTheInitializer()
+    {
+        var test = new CodeFixTest();
+
+        // Both fixes change the same creation, so they cannot be batched in a single iteration
+        test.NumberOfFixAllIterations = 2;
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = {|MA0224:{|MA0225:new JsonSerializerOptions()|}|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                static readonly JsonSerializerOptions Options = new JsonSerializerOptions() { RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true };
+            }
+            """;
+
+        return test.RunAsync();
+    }
+}


### PR DESCRIPTION
## What

Two new rules, disabled by default, that extend [MA0222](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0222.md)/[MA0223](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0223.md) to the options built at runtime:

- **MA0224** — `JsonSerializerOptions` should set `RespectNullableAnnotations`
- **MA0225** — `JsonSerializerOptions` should set `RespectRequiredConstructorParameters`

## Why

MA0222 and MA0223 only look at the `[JsonSourceGenerationOptions]` attribute of a `JsonSerializerContext`. An application that serializes with `new JsonSerializerOptions()` gets the same silent legacy behavior — `null` read into a non-nullable member, and missing constructor parameters filled with their default value — with nothing reporting it. Like MA0222 and MA0223, the rules do not require a particular value: setting the option to `false` is a deliberate choice and satisfies them.

## How

`JsonSerializerOptionsAnalyzer` registers an operation action on `OperationKind.ObjectCreation` and considers the option configured when:

- it is set in the object initializer, or
- it is set on the local the creation is assigned to (`var o = new JsonSerializerOptions(); o.RespectNullableAnnotations = true;`), including a local assigned after its declaration, and

Not reported:

- `new JsonSerializerOptions(other)` — the copy constructor starts from an instance configured elsewhere
- `new JsonSerializerOptions(JsonSerializerDefaults.Strict)` — sets both options (.NET 10)
- anything, when the target framework predates the properties (.NET 9), same gate as MA0222/MA0223

`new JsonSerializerOptions(JsonSerializerDefaults.Web)` and `General` are reported.

`JsonSerializerOptionsFixer` adds `<Option> = true` to the object initializer, creating the initializer when the creation has none.

## Notes for the reviewer

- The diagnostic is reported on the creation **without** its object initializer, so a long `{ ... }` block is not squiggled: `new JsonSerializerOptions`, `new()`, `new JsonSerializerOptions(...)`.
- Documented limitations: options configured without a `new` (`ConfigureHttpJsonOptions`, `AddJsonOptions` in ASP.NET Core), and a local configured from another method, are not detected. A rule for the configure-lambda case could be a follow-up.

## Validation

- New tests: 22, passing on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9)
- Full `Meziantou.Analyzer.Test.roslyn5.9` suite: 4070/4070 passing
- `dotnet run --project src/DocumentationGenerator` run until it reported no change