### PR TITLE
Do not report MA0046 on events of type EventHandler<TSender, TEventArgs>

### DIFF
--- a/docs/Rules/MA0046.md
+++ b/docs/Rules/MA0046.md
@@ -5,9 +5,12 @@ Source: [UseEventHandlerOfTAnalyzer.cs](https://github.com/meziantou/Meziantou.A
 
 You should use `EventHandler<T>` to declare events, where `T` inherits from `System.EventArgs`.
 
+`EventHandler<TSender, TEventArgs>` (.NET 10 and later) is also allowed. This delegate does not constrain `TSender` to `object` nor `TEventArgs` to `System.EventArgs`, so any construction of it is valid.
+
 Microsoft documentation about events: [Handling and raising events](https://learn.microsoft.com/en-us/dotnet/standard/events/?WT.mc_id=DT-MVP-5003978)
 
 ````csharp
 event Action<object, EventArgs> Foo; // non compliant
 event EventHandler<EventArgs> Foo; // compliant
+event EventHandler<Sample, SampleEventArgs> Foo; // compliant
 ````

--- a/src/Meziantou.Analyzer/Rules/UseEventHandlerOfTAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseEventHandlerOfTAnalyzer.cs
@@ -31,6 +31,12 @@ public sealed class UseEventHandlerOfTAnalyzer : DiagnosticAnalyzer
     {
         public INamedTypeSymbol? EventArgsSymbol { get; } = compilation.GetBestTypeByMetadataName("System.EventArgs");
 
+        /// <summary>
+        /// <c>System.EventHandler&lt;TSender, TEventArgs&gt;</c>, which does not constrain <c>TSender</c> to <c>object</c>
+        /// nor <c>TEventArgs</c> to <c>System.EventArgs</c>, so any construction of it is a valid event type.
+        /// </summary>
+        public INamedTypeSymbol? EventHandlerOfTSenderTEventArgsSymbol { get; } = compilation.GetBestTypeByMetadataName("System.EventHandler`2");
+
         public void AnalyzeSymbol(SymbolAnalysisContext context)
         {
             var symbol = (IEventSymbol)context.Symbol;
@@ -49,6 +55,12 @@ public sealed class UseEventHandlerOfTAnalyzer : DiagnosticAnalyzer
 
         private bool IsValidSignature(IMethodSymbol methodSymbol, [NotNullWhen(false)] out string? message)
         {
+            if (methodSymbol.ContainingType.OriginalDefinition.IsEqualTo(EventHandlerOfTSenderTEventArgsSymbol))
+            {
+                message = null;
+                return true;
+            }
+
             if (!methodSymbol.ReturnsVoid)
             {
                 message = "The delegate must return void";

--- a/tests/Meziantou.Analyzer.Test/Rules/UseEventHandlerOfTAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseEventHandlerOfTAnalyzerTests.cs
@@ -40,6 +40,38 @@ public sealed class UseEventHandlerOfTAnalyzerTests
     }
 
     [Fact]
+    public Task ValidEvent_EventHandlerOfTSenderTEventArgs()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class SampleEventArgs : System.EventArgs
+            {
+            }
+
+            class Test
+            {
+                event System.EventHandler<Test, SampleEventArgs> myevent;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ValidEvent_EventHandlerOfTSenderTEventArgs_EventArgsDoesNotInheritFromEventArgs()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                event System.EventHandler<Test, string> myevent;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task ValidEvent_CustomDelegate()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/UseEventHandlerOfTAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseEventHandlerOfTAnalyzerTests.cs
@@ -40,6 +40,20 @@ public sealed class UseEventHandlerOfTAnalyzerTests
     }
 
     [Fact]
+    public Task ValidEvent_NonGenericEventHandler()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                event System.EventHandler myevent;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task ValidEvent_EventHandlerOfTSenderTEventArgs()
     {
         var test = CreateTest();
@@ -105,8 +119,50 @@ public sealed class UseEventHandlerOfTAnalyzerTests
         return test.RunAsync();
     }
 
+    [Fact]
+    public Task InterfaceImplementation()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            interface ITest
+            {
+                event System.Action<string> {|MA0046:myevent|};
+            }
+
+            class Test : ITest
+            {
+                public event System.Action<string> myevent;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExplicitInterfaceImplementation()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            interface ITest
+            {
+                event System.Action<string> {|MA0046:myevent|};
+            }
+
+            class Test : ITest
+            {
+                event System.Action<string> ITest.myevent { add { } remove { } }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Theory]
+    [InlineData("System.Action")]
     [InlineData("System.Action<string>")]
+    [InlineData("System.Action<object, System.EventArgs, int>")]
+    [InlineData("System.Action<string, System.EventArgs>")]
+    [InlineData("System.Func<object, System.EventArgs, int>")]
     [InlineData("System.EventHandler<string>")]
     public Task InvalidEvent(string signature)
     {


### PR DESCRIPTION
Fixes #1434

## What

MA0046 no longer reports events declared with `System.EventHandler<TSender, TEventArgs>`.

```csharp
public event EventHandler<MyEventSource, MyEventArgs>? UpdateEvent; // no longer reported
```

## Why

.NET 10 added [`System.EventHandler<in TSender, in TEventArgs>`](https://learn.microsoft.com/en-us/dotnet/api/system.eventhandler-2), whose only constraints are `allows ref struct`:

```csharp
public delegate void EventHandler<in TSender, in TEventArgs>(TSender sender, TEventArgs e)
    where TSender : allows ref struct
    where TEventArgs : allows ref struct;
```

`TSender` is not constrained to `object` and `TEventArgs` is not constrained to `System.EventArgs`. The rule validated the signature of the delegate invoke method, so `EventHandler<MySender, MyEventArgs>` failed on the very first check with *"The first parameter must be of type object"*.

## How

`IsValidSignature` accepts any construction of `EventHandler\`2` up front. The delegate's `Invoke` method is a member of the delegate type, so `methodSymbol.ContainingType.OriginalDefinition` identifies it without threading the event type through.

The type arguments are deliberately not validated: the framework provides this delegate precisely to declare events whose sender is typed and whose event data need not derive from `EventArgs`.

## Notes for the reviewer

- The check sits in `IsValidSignature` rather than as an early return in `AnalyzeSymbol` so that the `IsInterfaceImplementation` escape hatch still applies uniformly.
- Two tests added: one with an `EventArgs`-derived type argument, one with `string` as `TEventArgs`. Both were confirmed to fail without the change.
- Tests pass on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9).
- `dotnet run --project src/DocumentationGenerator` reports no pending changes.