### PR TITLE
Cover the untested analyzer and fixer paths and remove the dead ones

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseZeroToInitializeAnEnumValueFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseZeroToInitializeAnEnumValueFixer.cs
@@ -72,41 +72,7 @@ public sealed class DoNotUseZeroToInitializeAnEnumValueFixer : CodeFixProvider
 
     private static INamedTypeSymbol? GetTargetEnumType(SemanticModel semanticModel, ExpressionSyntax expression, CancellationToken cancellationToken)
     {
-        if (semanticModel.GetTypeInfo(expression, cancellationToken).ConvertedType is INamedTypeSymbol { EnumUnderlyingType: not null } convertedEnumType)
-            return convertedEnumType;
-
-        if (expression.Parent is EqualsValueClauseSyntax equalsValueClause)
-        {
-            if (equalsValueClause.Parent is ParameterSyntax parameterSyntax)
-            {
-                if (semanticModel.GetDeclaredSymbol(parameterSyntax, cancellationToken) is IParameterSymbol parameterSymbol &&
-                    parameterSymbol.Type is INamedTypeSymbol { EnumUnderlyingType: not null } parameterEnumType)
-                {
-                    return parameterEnumType;
-                }
-            }
-            else if (equalsValueClause.Parent is VariableDeclaratorSyntax variableDeclaratorSyntax &&
-                     semanticModel.GetDeclaredSymbol(variableDeclaratorSyntax, cancellationToken) is ILocalSymbol localSymbol &&
-                     localSymbol.Type is INamedTypeSymbol { EnumUnderlyingType: not null } localEnumType)
-            {
-                return localEnumType;
-            }
-        }
-
-        if (expression.Parent is AssignmentExpressionSyntax assignmentExpression &&
-            assignmentExpression.Right == expression &&
-            semanticModel.GetTypeInfo(assignmentExpression.Left, cancellationToken).Type is INamedTypeSymbol { EnumUnderlyingType: not null } assignmentEnumType)
-        {
-            return assignmentEnumType;
-        }
-
-        if (expression.Parent is ArgumentSyntax argumentSyntax &&
-            semanticModel.GetOperation(argumentSyntax, cancellationToken) is IArgumentOperation { Parameter.Type: INamedTypeSymbol { EnumUnderlyingType: not null } parameterEnumType2 })
-        {
-            return parameterEnumType2;
-        }
-
-        return null;
+        return semanticModel.GetTypeInfo(expression, cancellationToken).ConvertedType is INamedTypeSymbol { EnumUnderlyingType: not null } enumType ? enumType : null;
     }
 
     private static async Task<Document> UseEnumField(Document document, ExpressionSyntax expressionToFix, IFieldSymbol fieldSymbol, CancellationToken cancellationToken)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/JSInvokableMethodsMustBePublicFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/JSInvokableMethodsMustBePublicFixer.cs
@@ -10,11 +10,11 @@ public sealed class JSInvokableMethodsMustBePublicFixer : CodeFixProvider
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
         const string Title = "Make method public";
         foreach (var diagnostic in context.Diagnostics)
         {
-            var methodDeclaration = GetMethodDeclaration(root, semanticModel, diagnostic, context.CancellationToken);
+            // An explicit interface implementation cannot have an accessibility modifier
+            var methodDeclaration = root?.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<MethodDeclarationSyntax>();
             if (methodDeclaration is null || methodDeclaration.ExplicitInterfaceSpecifier is not null)
                 continue;
 
@@ -64,23 +64,5 @@ public sealed class JSInvokableMethodsMustBePublicFixer : CodeFixProvider
                modifier.IsKind(SyntaxKind.InternalKeyword) ||
                modifier.IsKind(SyntaxKind.ProtectedKeyword) ||
                modifier.IsKind(SyntaxKind.PublicKeyword);
-    }
-
-    private static MethodDeclarationSyntax? GetMethodDeclaration(SyntaxNode? root, SemanticModel? semanticModel, Diagnostic diagnostic, CancellationToken cancellationToken)
-    {
-        if (semanticModel?.GetEnclosingSymbol(diagnostic.Location.SourceSpan.Start, cancellationToken) is IMethodSymbol methodSymbol)
-        {
-            return methodSymbol.DeclaringSyntaxReferences
-                .Select(reference => reference.GetSyntax(cancellationToken))
-                .OfType<MethodDeclarationSyntax>()
-                .FirstOrDefault();
-        }
-
-        var nodeToFix = root?.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
-        return nodeToFix?.FirstAncestorOrSelf<MethodDeclarationSyntax>()
-            ?? root?.FindToken(diagnostic.Location.SourceSpan.Start).Parent?.FirstAncestorOrSelf<MethodDeclarationSyntax>()
-            ?? root?.DescendantNodes()
-                .OfType<MethodDeclarationSyntax>()
-                .FirstOrDefault(method => method.Identifier.Span.IntersectsWith(diagnostic.Location.SourceSpan) || method.Span.IntersectsWith(diagnostic.Location.SourceSpan));
     }
 }

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/MergeIsPatternChecksFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/MergeIsPatternChecksFixer.cs
@@ -261,72 +261,16 @@ public sealed class MergeIsPatternChecksFixer : CodeFixProvider
             return true;
         }
 
-        switch (patternOperation)
+        // A qualified enum member in a pattern is parsed as a type, so the constant pattern the compiler
+        // binds it to has the syntax of the expression instead of the syntax of a pattern
+        if (patternOperation is IConstantPatternOperation { Value.Syntax: ExpressionSyntax expressionSyntax })
         {
-            case IConstantPatternOperation constantPatternOperation:
-                if (constantPatternOperation.Syntax is PatternSyntax syntaxPattern)
-                {
-                    patternSyntax = syntaxPattern;
-                    return true;
-                }
-
-                if (constantPatternOperation.Value?.Syntax is ExpressionSyntax expressionSyntax)
-                {
-                    patternSyntax = ConstantPattern(expressionSyntax);
-                    return true;
-                }
-
-                break;
-
-            case INegatedPatternOperation negatedPatternOperation:
-                if (TryCreatePatternSyntax(negatedPatternOperation.Pattern, out var negatedPatternSyntax))
-                {
-                    patternSyntax = UnaryPattern(
-                        negatedPatternSyntax is BinaryPatternSyntax
-                            ? ParenthesizedPattern(negatedPatternSyntax)
-                            : negatedPatternSyntax);
-                    return true;
-                }
-
-                break;
-
-            case IBinaryPatternOperation binaryPatternOperation:
-                if (TryCreatePatternSyntax(binaryPatternOperation.LeftPattern, out var leftPatternSyntax) &&
-                    TryCreatePatternSyntax(binaryPatternOperation.RightPattern, out var rightPatternSyntax) &&
-                    TryGetPatternOperator(binaryPatternOperation.OperatorKind, out var binaryPatternKind, out var operatorTokenKind))
-                {
-                    patternSyntax = BinaryPattern(
-                        binaryPatternKind,
-                        ParenthesizePatternIfNeeded(leftPatternSyntax, binaryPatternKind),
-                        Token(operatorTokenKind),
-                        ParenthesizePatternIfNeeded(rightPatternSyntax, binaryPatternKind));
-                    return true;
-                }
-
-                break;
+            patternSyntax = ConstantPattern(expressionSyntax);
+            return true;
         }
 
         patternSyntax = null!;
         return false;
-    }
-
-    private static bool TryGetPatternOperator(BinaryOperatorKind operatorKind, out SyntaxKind binaryPatternKind, out SyntaxKind operatorTokenKind)
-    {
-        switch (operatorKind)
-        {
-            case BinaryOperatorKind.And:
-                binaryPatternKind = SyntaxKind.AndPattern;
-                operatorTokenKind = SyntaxKind.AndKeyword;
-                return true;
-            case BinaryOperatorKind.Or:
-                binaryPatternKind = SyntaxKind.OrPattern;
-                operatorTokenKind = SyntaxKind.OrKeyword;
-                return true;
-            default:
-                binaryPatternKind = default;
-                operatorTokenKind = default;
-                return false;
-        }
     }
 
     private static bool CanMergeCandidates(SyntaxKind logicalExpressionKind, List<MergeCandidate> mergeCandidates)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
@@ -64,10 +64,6 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
                 context.RegisterCodeFix(CodeAction.Create(title, ct => RemoveToString(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
-            case OptimizeStringBuilderUsageData.ReplaceToStringWithAppendFormat:
-                context.RegisterCodeFix(CodeAction.Create(title, ct => ReplaceWithAppendFormat(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
-                break;
-
             case OptimizeStringBuilderUsageData.ReplaceStringFormatWithAppendFormat:
                 context.RegisterCodeFix(CodeAction.Create(title, ct => ReplaceStringFormatWithAppendFormat(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
                 break;
@@ -256,46 +252,6 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
 
         editor.ReplaceNode(nodeToFix, newExpression);
         return editor.GetChangedDocument();
-    }
-
-    private static async Task<Document> ReplaceWithAppendFormat(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
-    {
-        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var generator = editor.Generator;
-        var operation = (IInvocationOperation?)editor.SemanticModel.GetOperation(nodeToFix, cancellationToken);
-        if (operation is null)
-            return document;
-
-        var methodName = operation.TargetMethod.Name; // Append or AppendLine
-        var isAppendLine = string.Equals(methodName, nameof(StringBuilder.AppendLine), StringComparison.Ordinal);
-
-        var toStringOperation = (IInvocationOperation)operation.Arguments[0].Value;
-
-        var newExpression = generator.InvocationExpression(generator.MemberAccessExpression(operation.GetChildOperations().First().Syntax, "AppendFormat"),
-            toStringOperation.Arguments[1].Syntax,
-            GetFormatExpression(toStringOperation.Arguments[0].Value),
-            toStringOperation.GetChildOperations().First().Syntax);
-
-        if (isAppendLine)
-        {
-            newExpression = generator.InvocationExpression(generator.MemberAccessExpression(newExpression, "AppendLine"));
-        }
-
-        editor.ReplaceNode(nodeToFix, newExpression);
-        return editor.GetChangedDocument();
-
-        SyntaxNode GetFormatExpression(IOperation formatOperation)
-        {
-            if (formatOperation.ConstantValue.HasValue)
-            {
-                return generator.LiteralExpression("{0:" + (string?)formatOperation.ConstantValue.Value + "}");
-            }
-
-            return generator.AddExpression(generator.AddExpression(
-                generator.LiteralExpression("{0:"),
-                formatOperation.Syntax),
-                generator.LiteralExpression("}"));
-        }
     }
 
     private static async Task<Document> ReplaceStringFormatWithAppendFormat(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexExplicitCaptureOptionsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexExplicitCaptureOptionsFixer.cs
@@ -63,10 +63,14 @@ public sealed class UseRegexExplicitCaptureOptionsFixer : CodeFixProvider
                 {
                     foreach (var argument in attribute.ArgumentList.Arguments)
                     {
-                        IParameterSymbol? parameter = null;
+                        // A property or field initializer is not a constructor parameter
                         if (argument.NameEquals is not null)
+                            continue;
+
+                        IParameterSymbol? parameter = null;
+                        if (argument.NameColon is not null)
                         {
-                            parameter = constructor.Parameters.FirstOrDefault(p => p.Name == argument.NameEquals.Name.Identifier.ValueText);
+                            parameter = constructor.Parameters.FirstOrDefault(p => p.Name == argument.NameColon.Name.Identifier.ValueText);
                         }
                         else
                         {

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateUnsafeAccessorAttributeUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ValidateUnsafeAccessorAttributeUsageFixer.cs
@@ -14,23 +14,21 @@ public sealed class ValidateUnsafeAccessorAttributeUsageFixer : CodeFixProvider
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        if (nodeToFix is null)
+
+        // The rule only reports the local functions, as their name is mangled by the compiler
+        if (nodeToFix?.FirstAncestorOrSelf<LocalFunctionStatementSyntax>() is not { } localFunction)
             return;
 
         const string Title = "Set UnsafeAccessor Name";
         context.RegisterCodeFix(
-            CodeAction.Create(Title, ct => SetNameProperty(context.Document, nodeToFix, ct), equivalenceKey: Title),
+            CodeAction.Create(Title, ct => SetNameProperty(context.Document, localFunction, ct), equivalenceKey: Title),
             context.Diagnostics);
     }
 
-    private static async Task<Document> SetNameProperty(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static async Task<Document> SetNameProperty(Document document, LocalFunctionStatementSyntax localFunction, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var declaration = (SyntaxNode?)nodeToFix.FirstAncestorOrSelf<LocalFunctionStatementSyntax>() ?? nodeToFix.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-        if (declaration is null)
-            declaration = editor.OriginalRoot;
-
-        foreach (var (attributeList, methodName) in EnumerateCandidateAttributes(declaration))
+        foreach (var attributeList in localFunction.AttributeLists)
         {
             foreach (var attribute in attributeList.Attributes)
             {
@@ -40,13 +38,10 @@ public sealed class ValidateUnsafeAccessorAttributeUsageFixer : CodeFixProvider
                 if (HasNameProperty(attribute))
                     return document;
 
-                if (methodName.Length == 0)
-                    return document;
-
                 var argument = AttributeArgument(
                     NameEquals(IdentifierName("Name")),
                     nameColon: null,
-                    expression: LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(methodName)));
+                    expression: LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(localFunction.Identifier.ValueText)));
 
                 var newArgumentList = attribute.ArgumentList is null
                     ? AttributeArgumentList(SeparatedList(new[] { argument }))
@@ -59,44 +54,6 @@ public sealed class ValidateUnsafeAccessorAttributeUsageFixer : CodeFixProvider
         }
 
         return document;
-    }
-
-    private static IEnumerable<(AttributeListSyntax AttributeList, string MethodName)> EnumerateCandidateAttributes(SyntaxNode declaration)
-    {
-        switch (declaration)
-        {
-            case LocalFunctionStatementSyntax localFunction:
-                foreach (var attributeList in localFunction.AttributeLists)
-                {
-                    yield return (attributeList, localFunction.Identifier.ValueText);
-                }
-
-                yield break;
-
-            case MethodDeclarationSyntax method:
-                foreach (var attributeList in method.AttributeLists)
-                {
-                    yield return (attributeList, method.Identifier.ValueText);
-                }
-
-                foreach (var localFunctionDeclaration in method.DescendantNodes().OfType<LocalFunctionStatementSyntax>())
-                {
-                    foreach (var attributeList in localFunctionDeclaration.AttributeLists)
-                    {
-                        yield return (attributeList, localFunctionDeclaration.Identifier.ValueText);
-                    }
-                }
-
-                yield break;
-        }
-
-        foreach (var localFunctionDeclaration in declaration.DescendantNodes().OfType<LocalFunctionStatementSyntax>())
-        {
-            foreach (var attributeList in localFunctionDeclaration.AttributeLists)
-            {
-                yield return (attributeList, localFunctionDeclaration.Identifier.ValueText);
-            }
-        }
     }
 
     private static bool HasNameProperty(AttributeSyntax attribute)

--- a/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzer.cs
@@ -171,17 +171,6 @@ public sealed partial class EqualityShouldBeCorrectlyImplementedAnalyzer : Diagn
             return false;
         }
 
-        private static bool HasMethodInHierarchy(INamedTypeSymbol type, Func<IMethodSymbol, bool> predicate)
-        {
-            foreach (var member in type.GetAllMembers(includeInterfaceMembers: true).OfType<IMethodSymbol>())
-            {
-                if (predicate(member))
-                    return true;
-            }
-
-            return false;
-        }
-
         private static bool HasComparisonOperator(INamedTypeSymbol parentType)
         {
             var operatorNames = new List<string>(6)
@@ -205,16 +194,6 @@ public sealed partial class EqualityShouldBeCorrectlyImplementedAnalyzer : Diagn
             return operatorNames.Count == 0;
         }
 
-        private static bool IsEqualsMethod(IMethodSymbol symbol)
-        {
-            return symbol.Name == nameof(object.Equals) &&
-            symbol.ReturnType.IsBoolean() &&
-            symbol.Parameters.Length == 1 &&
-            symbol.Parameters[0].Type.IsObject() &&
-            symbol.DeclaredAccessibility == Accessibility.Public &&
-            !symbol.IsStatic;
-        }
-
         private bool IsEqualsMethodOverride(IMethodSymbol symbol)
         {
             // Check if it's an Equals(object) method AND it's overridden (not the base System.Object method)
@@ -226,16 +205,6 @@ public sealed partial class EqualityShouldBeCorrectlyImplementedAnalyzer : Diagn
                    !symbol.IsStatic &&
                    !symbol.IsEqualTo(ObjectEqualsSymbol) &&
                    !symbol.IsEqualTo(ValueTypeEqualsSymbol);
-        }
-
-        private static bool IsCompareToMethod(IMethodSymbol symbol)
-        {
-            return symbol.Name == nameof(IComparable.CompareTo) &&
-            symbol.ReturnType.IsInt32() &&
-            symbol.Parameters.Length == 1 &&
-            symbol.Parameters[0].Type.IsObject() &&
-            symbol.DeclaredAccessibility == Accessibility.Public &&
-            !symbol.IsStatic;
         }
 
         private static bool IsCompareToOfTMethod(IMethodSymbol symbol)

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageData.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageData.cs
@@ -9,7 +9,6 @@ internal enum OptimizeStringBuilderUsageData
     SplitStringInterpolation,
     SplitAddOperator,
     RemoveToString,
-    ReplaceToStringWithAppendFormat,
     ReplaceStringFormatWithAppendFormat,
     ReplaceSubstring,
     ReplaceStringJoinWithAppendJoin,

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
@@ -1,8 +1,6 @@
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using Meziantou.Analyzer.Configurations;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Meziantou.Analyzer.Rules;
 
@@ -349,8 +347,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
             if (availableSymbols.Count == 0 && XunitTestContextSymbol is null)
                 return [];
 
-            var isInStaticContext = operation.IsInStaticContext(cancellationToken);
-
             // For each symbol, get their members
             var paths = new List<string>();
             foreach (var availableSymbol in availableSymbols)
@@ -364,9 +360,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
                     foreach (var member in members)
                     {
                         if (!AreAllSymbolsAccessibleFromOperation(member, operation))
-                            continue;
-
-                        if (availableSymbol.Name is null && isInStaticContext && member.Length > 0 && !member[0].IsStatic)
                             continue;
 
                         var fullPath = ComputeFullPath(availableSymbol.Name, member);
@@ -396,11 +389,8 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
                 return true;
             }
 
-            static string ComputeFullPath(string? prefix, IEnumerable<ISymbol> symbols)
+            static string ComputeFullPath(string prefix, IEnumerable<ISymbol> symbols)
             {
-                if (prefix is null)
-                    return string.Join('.', symbols.Select(symbol => symbol.Name));
-
                 var suffix = string.Join('.', symbols.Select(symbol => symbol.Name));
                 if (string.IsNullOrEmpty(suffix))
                     return prefix;
@@ -412,15 +402,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
             {
                 return operation.SemanticModel!.IsAccessible(operation.Syntax.Span.Start, symbol);
             }
-        }
-
-        private static ITypeSymbol? GetContainingType(IOperation operation, CancellationToken cancellationToken)
-        {
-            var ancestor = operation.Syntax.Ancestors().FirstOrDefault(node => node is TypeDeclarationSyntax);
-            if (ancestor is null)
-                return null;
-
-            return operation.SemanticModel!.GetDeclaredSymbol(ancestor, cancellationToken) as ITypeSymbol;
         }
 
         private static IEnumerable<T> Prepend<T>(T value, IEnumerable<T> items)
@@ -436,13 +417,13 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
     [StructLayout(LayoutKind.Auto)]
     private readonly struct NameAndType
     {
-        public NameAndType(string? name, ITypeSymbol? typeSymbol)
+        public NameAndType(string name, ITypeSymbol? typeSymbol)
         {
             Name = name;
             TypeSymbol = typeSymbol;
         }
 
-        public string? Name { get; }
+        public string Name { get; }
         public ITypeSymbol? TypeSymbol { get; }
     }
 }

--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
@@ -210,8 +210,6 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
                 availableSymbols.Add(new(symbol.Name, symbolType));
             }
 
-            var isInStaticContext = operation.IsInStaticContext(cancellationToken);
-
             // For each symbol, get their members
             var paths = new List<string>();
             foreach (var availableSymbol in availableSymbols)
@@ -225,9 +223,6 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
                     foreach (var member in members)
                     {
                         if (!AreAllSymbolsAccessibleFromOperation(member, operation))
-                            continue;
-
-                        if (availableSymbol.Name is null && isInStaticContext && member.Length > 0 && !member[0].IsStatic)
                             continue;
 
                         var fullPath = ComputeFullPath(availableSymbol.Name, member);
@@ -252,11 +247,8 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
                 return true;
             }
 
-            static string ComputeFullPath(string? prefix, IEnumerable<ISymbol> symbols)
+            static string ComputeFullPath(string prefix, IEnumerable<ISymbol> symbols)
             {
-                if (prefix is null)
-                    return string.Join('.', symbols.Select(symbol => symbol.Name));
-
                 var suffix = string.Join('.', symbols.Select(symbol => symbol.Name));
                 if (string.IsNullOrEmpty(suffix))
                     return prefix;
@@ -283,13 +275,13 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
     [StructLayout(LayoutKind.Auto)]
     private readonly struct NameAndType
     {
-        public NameAndType(string? name, ITypeSymbol? typeSymbol)
+        public NameAndType(string name, ITypeSymbol? typeSymbol)
         {
             Name = name;
             TypeSymbol = typeSymbol;
         }
 
-        public string? Name { get; }
+        public string Name { get; }
         public ITypeSymbol? TypeSymbol { get; }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidUnusedInternalTypesAnalyzerTests.cs
@@ -2408,6 +2408,42 @@ public sealed class AvoidUnusedInternalTypesAnalyzerTests
     }
 
     [Fact]
+    public Task InternalClassUsedAsArrayElementType_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            internal class UsedClass
+            {
+            }
+
+            public class Sample
+            {
+                public object Create() => new UsedClass[0];
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InternalClassUsedAsJaggedArrayElementType_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            internal class UsedClass
+            {
+            }
+
+            public class Sample
+            {
+                public object Create() => new UsedClass[0][];
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task CodeFix_RemoveType_WithAssemblyAttribute()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests.cs
@@ -209,6 +209,152 @@ public sealed class ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAna
     }
 
     [Fact]
+    public Task AddOrUpdate_Closure_CodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var value = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, k => k, {|MA0106:(k, v) => value|});
+            """;
+        test.FixedCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var value = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, (k, arg) => k, (k, v, arg) => arg, value);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task GetOrAdd_FactoryArg_UsingTheKeyAndTheFactoryArg_CodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var factoryArg = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.GetOrAdd(key, {|MA0105:(k, arg) => factoryArg|}, factoryArg);
+            """;
+        test.FixedCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var factoryArg = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.GetOrAdd(key, (k, arg) => arg, factoryArg);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AddOrUpdate_AddValueFactoryUsingTheKey_CodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, {|MA0105:k => key|}, (k, v) => k + v);
+            """;
+        test.FixedCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, k => k, (k, v) => k + v);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AddOrUpdate_UpdateValueFactoryUsingTheKey_CodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, k => k, {|MA0105:(k, v) => key + v|});
+            """;
+        test.FixedCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, k => k, (k, v) => k + v);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AddOrUpdate_FactoryArg_AddValueFactoryUsingTheKeyAndTheFactoryArg_CodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var factoryArg = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, {|MA0105:(k, arg) => factoryArg|}, (k, v, arg) => k + v + arg, factoryArg);
+            """;
+        test.FixedCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var factoryArg = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, (k, arg) => arg, (k, v, arg) => k + v + arg, factoryArg);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AddOrUpdate_FactoryArg_UpdateValueFactoryUsingTheKeyAndTheFactoryArg_CodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var factoryArg = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, (k, arg) => k + arg, {|MA0105:(k, v, arg) => v + factoryArg|}, factoryArg);
+            """;
+        test.FixedCode = """
+            using System.Collections.Concurrent;
+
+            var key = 1;
+            var factoryArg = 1;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(key, (k, arg) => k + arg, (k, v, arg) => v + arg, factoryArg);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task AddOrUpdate_Variable_netstandard2()
     {
         var test = new CodeFixTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseZeroToInitializeAnEnumValueTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseZeroToInitializeAnEnumValueTests.cs
@@ -539,6 +539,137 @@ public sealed class DoNotUseZeroToInitializeAnEnumValueTests
         return test.RunAsync();
     }
 
+    [Theory]
+    [InlineData("sbyte")]
+    [InlineData("byte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("int")]
+    [InlineData("uint")]
+    [InlineData("long")]
+    [InlineData("ulong")]
+    public Task Assignation_CodeFix_EnumBaseType(string baseType)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            enum MyEnum : {{baseType}} { A = 0, B = 1 }
+
+            class Test
+            {
+                void A()
+                {
+                    MyEnum a = {|MA0099:0|};
+                }
+            }
+            """;
+        test.FixedCode = $$"""
+            enum MyEnum : {{baseType}} { A = 0, B = 1 }
+
+            class Test
+            {
+                void A()
+                {
+                    MyEnum a = MyEnum.A;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Reassignation_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            enum MyEnum { A = 0, B = 1 }
+
+            class Test
+            {
+                void A()
+                {
+                    MyEnum a = default;
+                    a = {|MA0099:0|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            enum MyEnum { A = 0, B = 1 }
+
+            class Test
+            {
+                void A()
+                {
+                    MyEnum a = default;
+                    a = MyEnum.A;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionalParameter_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            enum MyEnum { A = 0, B = 1 }
+            class Test
+            {
+                void A(MyEnum a = {|MA0099:0|})
+                {
+                }
+            }
+            """;
+        test.FixedCode = """
+            enum MyEnum { A = 0, B = 1 }
+            class Test
+            {
+                void A(MyEnum a = MyEnum.A)
+                {
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReportOnArgument_ZeroInArgument_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("MA0099.report_on", "argument");
+        test.TestCode = """
+            enum MyEnum { A = 0, B = 1 }
+
+            class Test
+            {
+                void M(MyEnum x) { }
+
+                void A()
+                {
+                    M({|MA0099:0|});
+                }
+            }
+            """;
+        test.FixedCode = """
+            enum MyEnum { A = 0, B = 1 }
+
+            class Test
+            {
+                void M(MyEnum x) { }
+
+                void A()
+                {
+                    M(MyEnum.A);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Fact]
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Analyzer/issues/1210")]
     public Task ReportOnArgument_ZeroInAssignment_NoDiagnostic()

--- a/tests/Meziantou.Analyzer.Test/Rules/JSInvokableMethodsMustBePublicAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/JSInvokableMethodsMustBePublicAnalyzerTests.cs
@@ -40,6 +40,33 @@ public sealed class JSInvokableMethodsMustBePublicAnalyzerTests
     }
 
     [Fact]
+    public Task ExplicitInterfaceImplementation_NoCodeFix()
+    {
+        const string Source = """
+            using Microsoft.JSInterop;
+
+            interface ITest
+            {
+                void A();
+            }
+
+            class Test : ITest
+            {
+                [JSInvokable]
+                void ITest.{|MA0118:A|}() => throw null;
+            }
+            """;
+
+        var test = CreateTest();
+        test.TestCode = Source;
+
+        // An explicit interface implementation cannot have an accessibility modifier, so no code fix is offered
+        test.FixedCode = Source;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Test_CodeFix_InternalMethod()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/MethodShouldNotBeTooLongAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MethodShouldNotBeTooLongAnalyzerTests.cs
@@ -218,4 +218,104 @@ public sealed class MethodShouldNotBeTooLongAnalyzerTests
         var root = tree.GetRoot().DescendantNodes().OfType<BlockSyntax>().First();
         return MethodShouldNotBeTooLongAnalyzer.CountStatements(default, root);
     }
+
+    [Fact]
+    public Task TooLongPropertyAccessors_Statements()
+    {
+        var test = CreateTest(("MA0051.maximum_statements_per_method", "2"));
+        test.TestCode = """
+            public class Test
+            {
+                int Property
+                {
+                    {|MA0051:get|}
+                    {
+                        var a = 0;var b = 0;
+                        return a + b;
+                    }
+                    {|MA0051:set|}
+                    {
+                        var a = 0;var b = 0;
+                        _ = a + b;
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ValidPropertyAccessors_Statements()
+    {
+        var test = CreateTest(("MA0051.maximum_statements_per_method", "2"));
+        test.TestCode = """
+            public class Test
+            {
+                int Property
+                {
+                    get
+                    {
+                        var a = 0;
+                        return a;
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongPropertyAccessor_ExpressionBody_Lines()
+    {
+        var test = CreateTest(("MA0051.maximum_lines_per_method", "1"));
+        test.TestCode = """
+            public class Test
+            {
+                int Property
+                {
+                    {|MA0051:get|} => 0 +
+                        1 +
+                        2;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongConstructor_Statements()
+    {
+        var test = CreateTest(("MA0051.maximum_statements_per_method", "2"));
+        test.TestCode = """
+            public class Test
+            {
+                {|MA0051:Test|}()
+                {
+                    var a = 0;var b = 0;var c = 0;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongDestructor_Statements()
+    {
+        var test = CreateTest(("MA0051.maximum_statements_per_method", "2"));
+        test.TestCode = """
+            public class Test
+            {
+                ~{|MA0051:Test|}()
+                {
+                    var a = 0;var b = 0;var c = 0;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzerTests.cs
@@ -174,4 +174,106 @@ public sealed class NonFlagsEnumsShouldNotBeMarkedWithFlagsAttributeAnalyzerTest
 
         return test.RunAsync();
     }
+
+    [Theory]
+    [InlineData("sbyte")]
+    [InlineData("byte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("int")]
+    [InlineData("uint")]
+    [InlineData("long")]
+    [InlineData("ulong")]
+    public Task NonPowerOfTwo_UnderlyingType(string underlyingType)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            [System.Flags]
+            enum {|MA0062:Test|} : {{underlyingType}}
+            {
+                A = 1,
+                B = 2,
+                C = 5, // Non valid
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("sbyte")]
+    [InlineData("byte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("int")]
+    [InlineData("uint")]
+    [InlineData("long")]
+    [InlineData("ulong")]
+    public Task PowerOfTwoOrCombination_UnderlyingType(string underlyingType)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            [System.Flags]
+            enum Test : {{underlyingType}}
+            {
+                A = 1,
+                B = 2,
+                C = 3,
+                D = 4,
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("sbyte", "-1")]
+    [InlineData("byte", "0xFF")]
+    [InlineData("short", "-1")]
+    [InlineData("ushort", "0xFFFF")]
+    [InlineData("int", "-1")]
+    [InlineData("uint", "0xFFFFFFFF")]
+    [InlineData("long", "-1")]
+    [InlineData("ulong", "0xFFFFFFFFFFFFFFFF")]
+    public Task AllBitSet_UnderlyingType_WithoutConfiguration(string underlyingType, string allBitsSetValue)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            [System.Flags]
+            enum {|MA0062:Test|} : {{underlyingType}}
+            {
+                None     = 0,
+                Option1  = 1,
+                All      = {{allBitsSetValue}},
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("sbyte", "-1")]
+    [InlineData("byte", "0xFF")]
+    [InlineData("short", "-1")]
+    [InlineData("ushort", "0xFFFF")]
+    [InlineData("int", "-1")]
+    [InlineData("uint", "0xFFFFFFFF")]
+    [InlineData("long", "-1")]
+    [InlineData("ulong", "0xFFFFFFFFFFFFFFFF")]
+    public Task AllBitSet_UnderlyingType_WithConfiguration(string underlyingType, string allBitsSetValue)
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("MA0062.allow_all_bits_set_value", "true");
+        test.TestCode = $$"""
+            [System.Flags]
+            enum Test : {{underlyingType}}
+            {
+                None     = 0,
+                Option1  = 1,
+                All      = {{allBitsSetValue}},
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
@@ -461,6 +461,41 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     }
 
     [Fact]
+    public Task LongCount_ArrayAsync()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var list = new int[10];
+                    _ = list.{|#0:LongCount|}();
+                    list.LongCount(x => x == 0);
+                }
+            }
+
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(RuleIdentifiers.UseListOfTMethodsInsteadOfEnumerableExtensionMethods, DiagnosticSeverity.Info).WithLocation(0).WithMessage("Use 'LongLength' instead of 'LongCount()'"));
+        test.FixedCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var list = new int[10];
+                    _ = list.LongLength;
+                    list.LongCount(x => x == 0);
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Count_VariableTypedAsEnumerableAssignedToList()
     {
         var test = new CodeFixTest();
@@ -641,6 +676,41 @@ public sealed class OptimizeLinqUsageAnalyzerTests
                 {
                     var enumerable = System.Linq.Enumerable.Empty<int>();
                     _ = enumerable.Any();
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("Count(x => x > 0) == 0", "Replace 'Count() == 0' with 'Any() == false'", "!enumerable.Any(x => x > 0)")]
+    [InlineData("Count(x => x > 0) > 0", "Replace 'Count() > 0' with 'Any()'", "enumerable.Any(x => x > 0)")]
+    public Task Count_WithPredicate_Any(string text, string expectedMessage, string fixedExpression)
+    {
+        var test = new CodeFixTest();
+        test.TestCode = $$"""
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var enumerable = System.Linq.Enumerable.Empty<int>();
+                    _ = {|#0:enumerable.{{text}}|};
+                }
+            }
+
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0031", DiagnosticSeverity.Info).WithLocation(0).WithMessage(expectedMessage));
+        test.FixedCode = $$"""
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    var enumerable = System.Linq.Enumerable.Empty<int>();
+                    _ = {{fixedExpression}};
                 }
             }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/ProcessStartAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ProcessStartAnalyzerTests.cs
@@ -102,6 +102,40 @@ public sealed class ProcessStartAnalyzerTests
     }
 
     [Fact]
+    public Task Process_start_should_fix_when_use_shell_execute_is_not_set_by_setting_it_to_true()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = {|MA0161:new ProcessStartInfo()|};
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+        test.CodeActionIndex = 1;
+        test.CodeActionEquivalenceKey = "Set UseShellExecute to true";
+        test.FixedCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = new ProcessStartInfo() { UseShellExecute = true };
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Process_start_should_report_when_use_shell_execute_is_set_to_true_and_output_redirected()
     {
         var test = new CodeFixTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyNegatedBooleanExpressionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyNegatedBooleanExpressionAnalyzerTests.cs
@@ -114,6 +114,40 @@ public sealed class SimplifyNegatedBooleanExpressionAnalyzerTests
         return test.RunAsync();
     }
 
+    [Theory]
+    [InlineData("<", ">=")]
+    [InlineData("<=", ">")]
+    [InlineData(">", "<=")]
+    [InlineData(">=", "<")]
+    public Task RelationalComparison_FlipOperator(string operatorText, string negatedOperatorText)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            class TestClass
+            {
+                void Test(int value, int max, object target)
+                {
+                    _ = {|MA0213:!(value {{operatorText}} max && !IsEditable(target))|};
+                }
+
+                bool IsEditable(object target) => true;
+            }
+            """;
+        test.FixedCode = $$"""
+            class TestClass
+            {
+                void Test(int value, int max, object target)
+                {
+                    _ = value {{negatedOperatorText}} max || IsEditable(target);
+                }
+
+                bool IsEditable(object target) => true;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Fact]
     public Task ReturnExpression()
     {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -197,6 +197,37 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
     }
 
     [Fact]
+    public Task CallingMethodWithClassThatContainsANestedPropertyOfTypeCancellationToken_ShouldReportDiagnosticWithFullPath()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                public static void A(HttpContext context)
+                {
+                    {|#0:MethodWithCancellationToken()|};
+                }
+
+                public static void MethodWithCancellationToken() => throw null;
+                public static void MethodWithCancellationToken(System.Threading.CancellationToken cancellationToken) => throw null;
+            }
+
+            class HttpContext
+            {
+                public HttpRequest Request { get; }
+            }
+
+            class HttpRequest
+            {
+                public System.Threading.CancellationToken RequestAborted { get; }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0040", DiagnosticSeverity.Info).WithLocation(0).WithMessage("Use an overload with a CancellationToken, available tokens: context.Request.RequestAborted"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task CallingMethodWithRecordPropsThatContainsAPropertyOfTypeCancellationToken_ShouldReportDiagnosticWithParameterName()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
@@ -128,6 +128,38 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzerTests
     }
 
     [Fact]
+    public Task WhenAvailable_NestedPropOfNestedProp()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                void A(Sample foo)
+                {
+                    {|MA0166:System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero)|};
+                }
+
+                class Sample { public Nested B {get;} }
+                class Nested { public System.TimeProvider A {get;} }
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                void A(Sample foo)
+                {
+                    System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero, foo.B.A);
+                }
+
+                class Sample { public Nested B {get;} }
+                class Nested { public System.TimeProvider A {get;} }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task OptionalParameter_WhenAvailable()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
@@ -659,6 +659,40 @@ public sealed class UseAttributeIsDefinedAnalyzerTests
         return test.RunAsync();
     }
 
+    [Theory]
+    [InlineData("member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length < 1", "!")]
+    [InlineData("member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length <= 0", "!")]
+    public Task GetCustomAttributes_Length_Comparison(string expression, string negation)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {|MA0179:{{expression}}|};
+                }
+            }
+            """;
+        test.FixedCode = $$"""
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {{negation}}Attribute.IsDefined(member, typeof(ObsoleteAttribute), false);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Fact]
     public Task Attribute_GetCustomAttributes_Length_GreaterThanZero()
     {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
@@ -558,6 +558,78 @@ public sealed class UseAwaitInsteadOfReturningTaskAnalyzerTests
     }
 
     [Fact]
+    public Task NestedSimpleLambdaReturn_DoesNotAffectParent()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task<int> Inner() => throw null;
+                Task<int> Parent()
+                {
+                    Func<int, Task<int>> f = value => null;
+                    _ = f(0);
+                    return {|MA0214:Inner()|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task<int> Inner() => throw null;
+                async Task<int> Parent()
+                {
+                    Func<int, Task<int>> f = value => null;
+                    _ = f(0);
+                    return await Inner();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task NestedAnonymousMethodReturn_DoesNotAffectParent()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task<int> Inner() => throw null;
+                Task<int> Parent()
+                {
+                    Func<Task<int>> f = delegate { return null; };
+                    _ = f();
+                    return {|MA0214:Inner()|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task<int> Inner() => throw null;
+                async Task<int> Parent()
+                {
+                    Func<Task<int>> f = delegate { return null; };
+                    _ = f();
+                    return await Inner();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task AlreadyAsync_NoDiagnostic()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
@@ -45,6 +45,36 @@ public sealed class UseConfigureAwaitAnalyzerTests
     }
 
     [Fact]
+    public Task MissingConfigureAwait_ShouldReportError_FixWithConfigureAwaitTrue()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    {|MA0004:await Task.Delay(1)|};
+                }
+            }
+            """;
+        test.CodeActionIndex = 1;
+        test.CodeActionEquivalenceKey = "Use ConfigureAwait(true)";
+        test.FixedCode = """
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    await Task.Delay(1).ConfigureAwait(true);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task MissingConfigureAwait_AwaitForeach_ShouldReportError()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
@@ -928,4 +928,82 @@ public sealed class UseHasFlagMethodAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task EqualityCheck_BitwiseAndOnTheRight_ReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+            }
+
+            class Sample
+            {
+                bool M(MyEnum value) => {|MA0192:MyEnum.Flag1 == (value & MyEnum.Flag1)|};
+            }
+            """;
+        test.FixedCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+            }
+
+            class Sample
+            {
+                bool M(MyEnum value) => value.HasFlag(MyEnum.Flag1);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("sbyte")]
+    [InlineData("byte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("int")]
+    [InlineData("uint")]
+    [InlineData("long")]
+    [InlineData("ulong")]
+    public Task EqualityCheck_UnderlyingType_ReportDiagnostic(string underlyingType)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            [System.Flags]
+            enum MyEnum : {{underlyingType}}
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                bool M(MyEnum value) => {|MA0192:(value & MyEnum.Flag1) == MyEnum.Flag1|};
+            }
+            """;
+        test.FixedCode = $$"""
+            [System.Flags]
+            enum MyEnum : {{underlyingType}}
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                bool M(MyEnum value) => value.HasFlag(MyEnum.Flag1);
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseReadOnlyStructForRefReadOnlyParametersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseReadOnlyStructForRefReadOnlyParametersAnalyzerTests.cs
@@ -13,6 +13,11 @@ public class UseReadOnlyStructForRefReadOnlyParametersAnalyzerTests
         return test;
     }
 
+    /// <summary>
+    /// The code of the tests using the members of a type is not a top-level program, so it has no entry point.
+    /// </summary>
+    private static AnalyzerTest CreateLibraryTest() => new();
+
     [Fact]
     public Task ParameterNotRefReadOnly()
     {
@@ -92,6 +97,115 @@ public class UseReadOnlyStructForRefReadOnlyParametersAnalyzerTests
 
             void A<T>(in T foo) where T: struct { }
             readonly struct Foo { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Method_StructNotReadOnly_in()
+    {
+        var test = CreateLibraryTest();
+        test.TestCode = """
+            class Test
+            {
+                void A(in Foo {|MA0168:foo|}) { }
+            }
+
+            struct Foo { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Method_StructNotReadOnly_ref_readonly()
+    {
+        var test = CreateLibraryTest();
+        test.TestCode = """
+            class Test
+            {
+                void A(ref readonly Foo {|MA0168:foo|}) { }
+            }
+
+            struct Foo { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Method_StructReadOnly()
+    {
+        var test = CreateLibraryTest();
+        test.TestCode = """
+            class Test
+            {
+                void A(in Foo foo) { }
+            }
+
+            readonly struct Foo { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Constructor_StructNotReadOnly_in()
+    {
+        var test = CreateLibraryTest();
+        test.TestCode = """
+            class Test
+            {
+                Test(in Foo {|MA0168:foo|}) { }
+            }
+
+            struct Foo { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Indexer_StructNotReadOnly_in()
+    {
+        var test = CreateLibraryTest();
+        test.TestCode = """
+            class Test
+            {
+                int this[in Foo {|MA0168:foo|}] => 0;
+            }
+
+            struct Foo { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Delegate_StructNotReadOnly_in()
+    {
+        var test = CreateLibraryTest();
+        test.TestCode = """
+            delegate void A(in Foo {|MA0168:foo|});
+
+            struct Foo { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Method_ParameterNotRefReadOnly()
+    {
+        var test = CreateLibraryTest();
+        test.TestCode = """
+            class Test
+            {
+                void A(Foo foo) { }
+            }
+
+            struct Foo { }
             """;
 
         return test.RunAsync();

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexOptionsAnalyzerTests.cs
@@ -166,6 +166,32 @@ public sealed class UseRegexOptionsAnalyzerTests
         return test.RunAsync();
     }
 
+    [Fact]
+    public Task GeneratedRegex_RegexOptions_NamedArguments_CodeFix()
+    {
+        var test = new GeneratedRegexCodeFixTest();
+        test.UseFrameworkSourceGenerators = true;
+        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.TestCode = """
+            using System.Text.RegularExpressions;
+            partial class TestClass
+            {
+                [{|MA0023:GeneratedRegex(options: RegexOptions.CultureInvariant, pattern: "([a-z]+)", matchTimeoutMilliseconds: -1)|}]
+                private static partial Regex Test();
+            }
+            """;
+        test.FixedCode = """
+            using System.Text.RegularExpressions;
+            partial class TestClass
+            {
+                [GeneratedRegex(options: RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, pattern: "([a-z]+)", matchTimeoutMilliseconds: -1)]
+                private static partial Regex Test();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
 #if CSHARP13_OR_GREATER
     [Fact]
     public Task GeneratedRegexProperty_RegexOptions_Valid()

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStructLayoutAttributeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStructLayoutAttributeAnalyzerTests.cs
@@ -53,6 +53,33 @@ public sealed class UseStructLayoutAttributeAnalyzerTests
     }
 
     [Fact]
+    public Task MissingAttribute_FixWithSequentialLayout()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            struct {|MA0008:TypeName|}
+            {
+                int a;
+                int b;
+            }
+            """;
+        test.CodeActionIndex = 1;
+        test.CodeActionEquivalenceKey = "Add Sequential StructLayout attribute";
+        test.FixedCode = """
+            using System.Runtime.InteropServices;
+
+            [StructLayout(LayoutKind.Sequential)]
+            struct TypeName
+            {
+                int a;
+                int b;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task AddAttributeShouldUseShortname()
     {
         var test = CreateTest();


### PR DESCRIPTION
Running the test suite with code coverage surfaced 16 rule files containing methods that no test ever executed. Each one turned out to be either a shipping behavior with no regression protection, or code that cannot be reached at all. This PR covers the former and deletes the latter.

## Tests added

| Rule | Path that had no test |
|---|---|
| MA0168 | The `RegisterSymbolAction(SymbolKind.Parameter)` handler. Every existing test declared a top-level local function, so `in` / `ref readonly` parameters on methods, constructors, indexers and delegates were never analyzed. |
| MA0182 | An internal type used only as an array element type (`AnalyzeArrayCreation` never ran). |
| MA0062, MA0192, MA0099 | All eight enum underlying types. Only `int` was covered, leaving the `sbyte`/`short`/`ushort`/`uint`/`long`/`ulong` arms of the bit-set and zero checks cold. |
| MA0040, MA0166 | The nested member path (`context.Request.RequestAborted`). |
| MA0106 | The `AddOrUpdate` code fix, which was registered but never applied by any test. |
| MA0105 | All four `AddOrUpdate` and `GetOrAdd` parameter mappings. |
| MA0020, MA0031 | `LongCount()` → `LongLength`, and `Count(predicate)` → `Any(predicate)`. |
| MA0004, MA0008, MA0161 | The second offered code action (`ConfigureAwait(true)`, `LayoutKind.Sequential`, `UseShellExecute = true`). |
| MA0214 | A lambda and an anonymous method inside the rewritten body, which the rewriter must not descend into. |
| MA0213 | Flipping the relational operators (`<` → `>=`, …). Only `==` / `!=` were covered. |
| MA0179 | The `length < 1` and `length <= 0` comparisons. |
| MA0051 | Property accessors, constructors and destructors — registered but never exercised. |
| MA0118 | An explicit interface implementation, which correctly offers no code fix. |

## Bug fixed

`UseRegexExplicitCaptureOptionsFixer` matched `NameEquals` (a property or field initializer) against the constructor parameters, so an attribute written with named arguments had `RegexOptions.ExplicitCapture` appended to the wrong argument:

```c#
// before
[GeneratedRegex(options: RegexOptions.CultureInvariant, pattern: "([a-z]+)", matchTimeoutMilliseconds: -1)]
// fixed to (does not compile)
[GeneratedRegex(options: RegexOptions.CultureInvariant, pattern: "([a-z]+)" | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: -1)]
```

It now matches `NameColon`, with a regression test.

## Unreachable code removed

- `EqualityShouldBeCorrectlyImplementedAnalyzer`: `HasMethodInHierarchy`, `IsEqualsMethod` and `IsCompareToMethod` had no caller.
- `UseAnOverloadThatHasCancellationTokenAnalyzer`: `GetContainingType` had no caller.
- Both overload analyzers: the null-name handling of `NameAndType`, as the name always comes from `ISymbol.Name`. This also removed a per-diagnostic `IsInStaticContext` call that existed only to feed that dead check, and two usings that became unused.
- `OptimizeStringBuilderUsage`: `ReplaceToStringWithAppendFormat` and its fix method — the analyzer has never reported that value.
- `MergeIsPatternChecksFixer`: the negated and binary pattern cases plus `TryGetPatternOperator`. A `not` / `and` / `or` pattern always has a `PatternSyntax`, so the early return wins (confirmed by coverage on both Roslyn 4.8 and 5.9).
- `ValidateUnsafeAccessorAttributeUsageFixer`: the method and fallback enumeration, as MA0146 is only reported for `MethodKind.LocalFunction`. The local function lookup also moved into `RegisterCodeFixesAsync`, per the validate-before-registering guidance in `AGENTS.md`.
- `JSInvokableMethodsMustBePublicFixer`: the `GetEnclosingSymbol` lookup and the last fallback, along with the semantic model they needed.
- `DoNotUseZeroToInitializeAnEnumValueFixer`: the four fallbacks of `GetTargetEnumType`, as the converted type resolves every reported position (the new tests cover each of those syntactic positions).

## For the reviewer

Two things were deliberately left alone:

1. `RemoveUnnecessaryBracesInTypeDeclarationFixer.ContainsCommentOrDirectiveInBraces` is the single remaining never-executed lambda. It duplicates the analyzer's own guard, which is what the fixer guidance asks for, so it is unreachable by design and was kept.
2. **`UseAttributeIsDefined` reversed comparisons look like an unfinished feature rather than dead code.** `IsValidLengthComparisonPattern` has a fully written `lengthIsOnLeft: false` branch (`0 == length`, `1 > length`, `0 >= length`, …) in both the analyzer and the fixer, but the analyzer only ever passes `lengthIsOnLeft: true` and only inspects the left operand, so `0 == x.Length` reports nothing today. Tests for those six shapes were written, observed to fail, and then removed rather than deleting the branches: whether to wire the feature up or drop it is a product decision.

## Verification

- `dotnet build` on the whole solution: succeeds with no warnings.
- `dotnet test --max-parallel-test-modules 2`: **20,554 tests pass** across Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9 (the default project goes from 4,079 to 4,169 tests).
- `dotnet run --project src/DocumentationGenerator`: exits 0, no markdown changes.
- Coverage of `Rules/`: **90.6% → 91.8% lines**, **78.1% → 79.7% branches**; rule files with a never-executed method drop from 16 to 1.
