### PR TITLE
Detect the ProcessStartInfo properties set outside of the initializer

### DIFF
--- a/docs/Rules/MA0161.md
+++ b/docs/Rules/MA0161.md
@@ -17,11 +17,20 @@ Process.Start(new ProcessStartInfo("cmd")); // Intent is not clear if you want t
 
 Process.Start(new ProcessStartInfo("https://www.meziantou.net/")); // Will fail on .NET Core apps
 
+var psi = new ProcessStartInfo(); // Non compliant as UseShellExecute is never set
+psi.FileName = "cmd";
+Process.Start(psi);
+
 // Compliant
 
 Process.Start(new ProcessStartInfo("https://www.meziantou.net/")
 {
     UseShellExecute = true,
 });
+
+// The property can also be set after the object is created
+var compliantPsi = new ProcessStartInfo("https://www.meziantou.net/");
+compliantPsi.UseShellExecute = true;
+Process.Start(compliantPsi);
 
 ````

--- a/docs/Rules/MA0163.md
+++ b/docs/Rules/MA0163.md
@@ -30,6 +30,11 @@ Process.Start(new ProcessStartInfo("cmd")
     RedirectStandardOutput = true,
 });  // It will throw with error "UseShellExecute must be set to false when redirecting I/O" on .NET Framework apps
 
+// The properties can also be set after the object is created
+var psi = new ProcessStartInfo("cmd"); // Non compliant as UseShellExecute is not set to false
+psi.RedirectStandardOutput = true;
+Process.Start(psi);
+
 // Compliant
 
 Process.Start(new ProcessStartInfo("https://www.meziantou.net/")
@@ -42,5 +47,10 @@ Process.Start(new ProcessStartInfo("cmd")
     RedirectStandardOutput = true,
     UseShellExecute = false,
 });
+
+var compliantPsi = new ProcessStartInfo("cmd");
+compliantPsi.RedirectStandardOutput = true;
+compliantPsi.UseShellExecute = false;
+Process.Start(compliantPsi);
 
 ````

--- a/src/Meziantou.Analyzer/Rules/ProcessStartAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ProcessStartAnalyzer.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Runtime.InteropServices;
 
 namespace Meziantou.Analyzer.Rules;
 
@@ -55,6 +55,49 @@ public sealed class ProcessStartAnalyzer : DiagnosticAnalyzer
 
     }
 
+    private enum PropertyValue
+    {
+        NotSet,
+        False,
+        True,
+        Unknown,
+    }
+
+    // The property names cannot use nameof as System.Diagnostics.ProcessStartInfo is banned in analyzers (RS1035)
+    [StructLayout(LayoutKind.Auto)]
+    private struct ProcessStartInfoProperties
+    {
+        public PropertyValue UseShellExecute { get; private set; }
+        private PropertyValue RedirectStandardError { get; set; }
+        private PropertyValue RedirectStandardInput { get; set; }
+        private PropertyValue RedirectStandardOutput { get; set; }
+
+        public readonly bool IsRedirecting
+            => RedirectStandardError is PropertyValue.True || RedirectStandardInput is PropertyValue.True || RedirectStandardOutput is PropertyValue.True;
+
+        public void Set(string propertyName, PropertyValue value)
+        {
+            switch (propertyName)
+            {
+                case "UseShellExecute":
+                    UseShellExecute = value;
+                    break;
+
+                case "RedirectStandardError":
+                    RedirectStandardError = value;
+                    break;
+
+                case "RedirectStandardInput":
+                    RedirectStandardInput = value;
+                    break;
+
+                case "RedirectStandardOutput":
+                    RedirectStandardOutput = value;
+                    break;
+            }
+        }
+    }
+
     private sealed class AnalyzerContext(Compilation compilation)
     {
         private readonly INamedTypeSymbol? _processStartInfoSymbol = compilation.GetBestTypeByMetadataName("System.Diagnostics.ProcessStartInfo");
@@ -79,51 +122,94 @@ public sealed class ProcessStartAnalyzer : DiagnosticAnalyzer
         public void AnalyzeObjectCreation(OperationAnalysisContext context)
         {
             var operation = (IObjectCreationOperation)context.Operation;
-            if (IsProcessStartInfoCreation(operation))
-            {
-                if (operation is { Initializer: { } initializer })
-                {
-                    var useShellExecuteInitializer = initializer.Initializers.OfType<ISimpleAssignmentOperation>()
-                        .FirstOrDefault(x => x.Target.Syntax is IdentifierNameSyntax { Identifier.Text: "UseShellExecute" });
+            if (!IsProcessStartInfoCreation(operation))
+                return;
 
-                    if (useShellExecuteInitializer is null)
-                    {
-                        if (IsRedirectingInputOrOutput(operation.SemanticModel!, initializer))
-                        {
-                            // Redirecting standard input or output while UseShellExecute is not explicitly set
-                            context.ReportDiagnostic(SetToFalseWhenRedirectingOutput, operation);
-                        }
-                        else
-                        {
-                            // Constructing ProcessStartInfo without setting UseShellExecute in the initializer
-                            context.ReportDiagnostic(UseShellExecuteMustBeExplicitlySet, operation);
-                        }
-                    }
-                    else if (IsInitializedToTrue(operation.SemanticModel!, useShellExecuteInitializer))
-                    {
-                        if (IsRedirectingInputOrOutput(operation.SemanticModel!, initializer))
-                        {
-                            // Redirecting standard input or output while UseShellExecute is set to true
-                            context.ReportDiagnostic(SetToFalseWhenRedirectingOutput, operation);
-                        }
-                    }
-                }
-                else
+            var properties = GetProperties(operation);
+            if (properties.IsRedirecting)
+            {
+                if (properties.UseShellExecute is PropertyValue.NotSet or PropertyValue.True)
                 {
-                    // Constructing ProcessStartInfo with not initializer at all
-                    context.ReportDiagnostic(UseShellExecuteMustBeExplicitlySet, operation);
+                    // Redirecting standard input or output while UseShellExecute is not explicitly set to false
+                    context.ReportDiagnostic(SetToFalseWhenRedirectingOutput, operation);
                 }
+            }
+            else if (properties.UseShellExecute is PropertyValue.NotSet)
+            {
+                // Constructing ProcessStartInfo without setting UseShellExecute
+                context.ReportDiagnostic(UseShellExecuteMustBeExplicitlySet, operation);
             }
         }
 
-        private static bool IsInitializedToTrue(SemanticModel semanticModel, ISimpleAssignmentOperation simpleAssignmentOperation)
-            => semanticModel.GetConstantValue(simpleAssignmentOperation.Value.Syntax) is { HasValue: true, Value: true };
+        private ProcessStartInfoProperties GetProperties(IObjectCreationOperation operation)
+        {
+            var result = default(ProcessStartInfoProperties);
+            if (operation.Initializer is not null)
+            {
+                foreach (var assignment in operation.Initializer.Initializers.OfType<ISimpleAssignmentOperation>())
+                {
+                    if (assignment.Target is IPropertyReferenceOperation propertyReference)
+                    {
+                        result.Set(propertyReference.Property.Name, GetAssignedValue(assignment.Value));
+                    }
+                }
+            }
 
-        private static bool IsRedirectingInputOrOutput(SemanticModel semanticModel,
-            IObjectOrCollectionInitializerOperation initializer) =>
-            initializer.Initializers.OfType<ISimpleAssignmentOperation>()
-                .Any(x => x.Target.Syntax is IdentifierNameSyntax { Identifier.Text: "RedirectStandardError" or "RedirectStandardInput" or "RedirectStandardOutput" }
-                                             && IsInitializedToTrue(semanticModel, x));
+            // The properties can also be set after the object is created:
+            //   var psi = new ProcessStartInfo();
+            //   psi.UseShellExecute = false;
+            var target = GetAssignmentTargetSymbol(operation);
+            if (target is not null)
+            {
+                foreach (var descendant in GetRootOperation(operation).Descendants())
+                {
+                    // Only the assignments that follow the creation apply to the created instance
+                    if (descendant is ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Instance: { } instance } propertyReference } assignment
+                        && descendant.Syntax.SpanStart > operation.Syntax.SpanStart
+                        && propertyReference.Property.ContainingType.IsEqualTo(_processStartInfoSymbol)
+                        && target.IsEqualTo(GetReferencedSymbol(instance)))
+                    {
+                        result.Set(propertyReference.Property.Name, GetAssignedValue(assignment.Value));
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static PropertyValue GetAssignedValue(IOperation operation) => operation.ConstantValue switch
+        {
+            { HasValue: true, Value: true } => PropertyValue.True,
+            { HasValue: true, Value: false } => PropertyValue.False,
+            _ => PropertyValue.Unknown,
+        };
+
+        private static ISymbol? GetAssignmentTargetSymbol(IObjectCreationOperation operation) => operation.Parent switch
+        {
+            IVariableInitializerOperation { Parent: IVariableDeclaratorOperation declarator } => declarator.Symbol,
+            ISimpleAssignmentOperation assignment => GetReferencedSymbol(assignment.Target),
+            _ => null,
+        };
+
+        private static ISymbol? GetReferencedSymbol(IOperation? operation) => operation switch
+        {
+            ILocalReferenceOperation localReference => localReference.Local,
+            IParameterReferenceOperation parameterReference => parameterReference.Parameter,
+            IFieldReferenceOperation { Instance: null or IInstanceReferenceOperation } fieldReference => fieldReference.Field,
+            IPropertyReferenceOperation { Instance: null or IInstanceReferenceOperation } propertyReference => propertyReference.Property,
+            _ => null,
+        };
+
+        private static IOperation GetRootOperation(IOperation operation)
+        {
+            var result = operation;
+            while (result.Parent is not null)
+            {
+                result = result.Parent;
+            }
+
+            return result;
+        }
 
         private bool IsProcessStartInfo(IArgumentOperation operation)
             => operation.Value.Type.IsEqualTo(_processStartInfoSymbol);

--- a/tests/Meziantou.Analyzer.Test/Rules/ProcessStartAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ProcessStartAnalyzerTests.cs
@@ -234,8 +234,97 @@ public sealed class ProcessStartAnalyzerTests
         return test.RunAsync();
     }
 
+    [Theory]
+    [InlineData("false")]
+    [InlineData("true")]
+    public Task Process_start_should_not_report_when_use_shell_execute_is_set_after_the_creation(string value)
+    {
+        var test = new CodeFixTest();
+        test.TestCode = $$"""
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = new ProcessStartInfo();
+                    processStartInfo.UseShellExecute = {{value}};
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Fact]
-    public Task Process_start_should_report_false_positives()
+    public Task Process_start_should_not_report_when_use_shell_execute_is_set_after_the_creation_on_a_field()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                private ProcessStartInfo _processStartInfo;
+
+                public void Test()
+                {
+                    _processStartInfo = new ProcessStartInfo();
+                    _processStartInfo.UseShellExecute = false;
+                    Process.Start(_processStartInfo);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_not_report_when_use_shell_execute_is_set_after_the_creation_on_an_existing_variable()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    ProcessStartInfo processStartInfo;
+                    processStartInfo = new ProcessStartInfo();
+                    processStartInfo.UseShellExecute = false;
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_not_report_when_use_shell_execute_is_set_to_a_non_constant_value_after_the_creation()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test(bool useShellExecute)
+                {
+                    var processStartInfo = new ProcessStartInfo();
+                    processStartInfo.UseShellExecute = useShellExecute;
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_report_when_use_shell_execute_is_set_on_another_variable()
     {
         var test = new CodeFixTest();
         test.TestCode = """
@@ -246,12 +335,144 @@ public sealed class ProcessStartAnalyzerTests
                 public void Test()
                 {
                     var processStartInfo = {|#0:new ProcessStartInfo()|};
-                    processStartInfo.UseShellExecute = false;
+                    var other = new ProcessStartInfo();
+                    other.UseShellExecute = false;
                     Process.Start(processStartInfo);
                 }
             }
             """;
         test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0161", DiagnosticSeverity.Info).WithLocation(0).WithMessage("UseShellExecute must be explicitly set when initializing a ProcessStartInfo"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_report_when_use_shell_execute_is_only_set_before_the_creation()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = new ProcessStartInfo() { UseShellExecute = false };
+                    processStartInfo.UseShellExecute = false;
+                    processStartInfo = {|#0:new ProcessStartInfo()|};
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0161", DiagnosticSeverity.Info).WithLocation(0).WithMessage("UseShellExecute must be explicitly set when initializing a ProcessStartInfo"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_report_when_output_is_redirected_after_the_creation()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = {|#0:new ProcessStartInfo()|};
+                    processStartInfo.RedirectStandardOutput = true;
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0163", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("Set UseShellExecute to false when redirecting standard input or output"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_report_when_output_is_redirected_after_the_creation_and_use_shell_execute_is_true()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = {|#0:new ProcessStartInfo() { UseShellExecute = true }|};
+                    processStartInfo.RedirectStandardInput = true;
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0163", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("Set UseShellExecute to false when redirecting standard input or output"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_report_when_use_shell_execute_is_set_to_true_after_the_creation_and_output_is_redirected()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = {|#0:new ProcessStartInfo() { RedirectStandardError = true }|};
+                    processStartInfo.UseShellExecute = true;
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0163", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("Set UseShellExecute to false when redirecting standard input or output"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_not_report_when_use_shell_execute_is_set_to_false_after_the_creation_and_output_is_redirected()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = new ProcessStartInfo() { RedirectStandardOutput = true };
+                    processStartInfo.UseShellExecute = false;
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_not_report_when_the_redirection_is_disabled_after_the_creation()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = new ProcessStartInfo() { RedirectStandardOutput = true, UseShellExecute = true };
+                    processStartInfo.RedirectStandardOutput = false;
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
 
         return test.RunAsync();
     }


### PR DESCRIPTION
## What

`MA0161` (UseShellExecute must be explicitly set) and `MA0163` (UseShellExecute must be false when redirecting standard input or output) only looked at the object initializer of `new ProcessStartInfo(...)`. Any property set with a separate statement was invisible to them, which produced false positives such as:

```csharp
var psi = new ProcessStartInfo();
psi.UseShellExecute = false; // MA0161 was still reported on the creation
```

and false negatives such as:

```csharp
var psi = new ProcessStartInfo();
psi.RedirectStandardOutput = true; // MA0163 was not reported
```

The analyzer now collects the state of `UseShellExecute` and of the `RedirectStandard*` properties from two sources, in source order, with the last write winning:

- the object initializer,
- the assignments to the created instance that follow the creation in the same operation tree.

The instance is resolved by symbol, so locals (`var psi = new ...`), pre-declared locals (`psi = new ...`), fields and properties (`_psi = new ...; _psi.UseShellExecute = ...;`) are all supported. Only the assignments positioned after the creation are considered, so a reassigned variable is still reported.

Each property is tracked as `NotSet` / `True` / `False` / `Unknown` (non-constant value), which preserves the existing reporting semantics:

- `MA0161` is reported only when `UseShellExecute` is never assigned anywhere.
- `MA0163` is reported when a redirection is enabled while `UseShellExecute` is unset or constant `true`, including when the redirection and the flag are set in different statements.
- Assigning a non-constant value still silences both rules, and a redirection later set back to `false` no longer counts as a redirection.

The initializer is also read with `IPropertyReferenceOperation` and symbol comparison instead of matching the syntax of the identifier, so a property with the same name on another type no longer matches.

## Notes for the reviewer

- The test named `Process_start_should_report_false_positives`, which pinned the previous behavior, is replaced by tests asserting the opposite, plus 12 new cases (fields, pre-declared locals, another variable, reassignment, non-constant values, and the split redirection/flag combinations).
- The property names in `ProcessStartInfoProperties.Set` are string literals rather than `nameof`, because `System.Diagnostics.ProcessStartInfo` is banned in analyzers by `RS1035`. A comment says so.
- `var p = new Process(); p.StartInfo.RedirectStandardOutput = true;` is still not reported: covering it means reporting on `new Process()`, which would also require reworking `UseShellExecuteMustBeSetFixer` (it appends `UseShellExecute` to the initializer of the node the diagnostic is reported on, which would generate invalid code for a `Process`). Left out of this change.

## Validation

- `ProcessStartAnalyzerTests`: 27/27 pass on roslyn4.8, roslyn4.14, roslyn5.0, roslyn5.6 and roslyn5.9.
- Full test suite on roslyn5.9: 4180/4180 pass.
- `dotnet run --project src/DocumentationGenerator`: exit code 0, no markdown file changed.