### PR TITLE
Do not report MA0072 and MA0086 on the nested lambdas and local functions

### DIFF
--- a/docs/Rules/MA0072.md
+++ b/docs/Rules/MA0072.md
@@ -17,3 +17,16 @@ finally
     throw new Exception("Finally Exception");
 }
 ````
+
+The rule does not report the `throw` statements that are only declared in the `finally` block, such as the ones in the body of a lambda, an anonymous method or a local function, as they are not executed by the `finally` block itself.
+
+````c#
+try
+{
+}
+finally
+{
+    // compliant: creating the delegate does not throw
+    Action action = () => throw new Exception();
+}
+````

--- a/docs/Rules/MA0086.md
+++ b/docs/Rules/MA0086.md
@@ -12,3 +12,16 @@ class Test
     }
 }
 ````
+
+The rule does not report the `throw` statements that are only declared in the finalizer, such as the ones in the body of a lambda, an anonymous method or a local function, as they are not executed by the finalizer itself.
+
+````csharp
+class Test
+{
+    ~Test()
+    {
+        // compliant: creating the delegate does not throw
+        Action action = () => throw new Exception();
+    }
+}
+````

--- a/src/Meziantou.Analyzer/Internals/SyntaxNodeExtensions.cs
+++ b/src/Meziantou.Analyzer/Internals/SyntaxNodeExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Meziantou.Analyzer.Internals;
+
+internal static class SyntaxNodeExtensions
+{
+    /// <summary>
+    /// Enumerates the descendant nodes of <paramref name="node"/> that are part of its execution flow.
+    /// The bodies of the nested lambdas, anonymous methods and local functions are not enumerated as
+    /// they are only declared, not executed, at that location.
+    /// </summary>
+    public static IEnumerable<SyntaxNode> DescendantNodesInSameExecutionFlow(this SyntaxNode node)
+        => node.DescendantNodes(descendIntoChildren: child => child == node || child is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax));
+}

--- a/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinalizerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinalizerAnalyzer.cs
@@ -29,7 +29,7 @@ public sealed class DoNotThrowFromFinalizerAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeFinalizer(SyntaxNodeAnalysisContext context)
     {
         var node = (DestructorDeclarationSyntax)context.Node;
-        foreach (var throwStatement in node.DescendantNodes().Where(IsThrowStatement))
+        foreach (var throwStatement in node.DescendantNodesInSameExecutionFlow().Where(IsThrowStatement))
         {
             context.ReportDiagnostic(Rule, throwStatement);
         }

--- a/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinallyBlockAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinallyBlockAnalyzer.cs
@@ -35,7 +35,7 @@ public sealed class DoNotThrowFromFinallyBlockAnalyzer : DiagnosticAnalyzer
         if (finallyBlock is null)
             return;
 
-        foreach (var throwStatement in finallyBlock.DescendantNodes().Where(IsThrowStatement))
+        foreach (var throwStatement in finallyBlock.DescendantNodesInSameExecutionFlow().Where(IsThrowStatement))
         {
             context.ReportDiagnostic(Rule, throwStatement);
         }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinalizerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinalizerAnalyzerTests.cs
@@ -77,6 +77,60 @@ public sealed class DoNotThrowFromFinalizerAnalyzerTests
     }
 
     [Fact]
+    public Task FinalizerDeclaresLambdaThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                ~TestClass()
+                {
+                    System.Action action = () => { throw new System.Exception(); };
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinalizerDeclaresAnonymousMethodThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                ~TestClass()
+                {
+                    System.Action action = delegate { throw new System.Exception(); };
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinalizerDeclaresLocalFunctionThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                ~TestClass()
+                {
+                    void LocalFunction()
+                    {
+                        throw new System.Exception();
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task FinalizerThrowsFromNestedTryCatchBlock_ExceptionIsHandled_DiagnosticIsReported()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinallyBlockAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinallyBlockAnalyzerTests.cs
@@ -144,6 +144,79 @@ public sealed class DoNotThrowFromFinallyBlockAnalyzerTests
     }
 
     [Fact]
+    public Task FinallyDeclaresLambdaThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        System.Action action = () => { throw new System.Exception(); };
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinallyDeclaresAnonymousMethodThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        System.Action action = delegate { throw new System.Exception(); };
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinallyDeclaresLocalFunctionThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        void LocalFunction() => Throw();
+                        void Throw()
+                        {
+                            throw new System.Exception();
+                        }
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task FinallyThrowsFromSeveralLocations_DiagnosticIsReportedForEachOne()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

`DoNotThrowFromFinallyBlockAnalyzer` (MA0072) and `DoNotThrowFromFinalizerAnalyzer` (MA0086) walked all the descendant nodes of the `finally` block / of the finalizer, so the traversal entered the bodies of the nested lambdas, anonymous methods and local functions.

```csharp
try
{
}
finally
{
    // MA0072 was reported here, although creating the delegate does not throw
    System.Action action = () => { throw new System.Exception(); };
}
```

Both rules now stop the traversal at those nested bodies, through a new `SyntaxNodeExtensions.DescendantNodesInSameExecutionFlow` extension method shared by the two analyzers. The traversal still enters the nested blocks, the `if`/`else` and the nested `try`/`catch`, so the existing true positives are unchanged.

## Why

Declaring a lambda, an anonymous method or a local function does not execute its body, so a `throw` there is not thrown by the `finally` block or by the finalizer.

## Notes for the reviewer

- A local function that throws **and** is invoked from the `finally` block is no longer reported. Following the invocations back to the declaration needs a different (operation or dataflow based) design, so it is out of scope here; the rules stay conservative and no longer report the declaration itself.
- The finalizer had the same traversal pattern as the `finally` rule; the false positive is reproduced by a test for both rules.
- 6 new tests (lambda, anonymous method and local function, for each rule). They all fail against the analyzers before the change and pass after it.
- `docs/Rules/MA0072.md` and `docs/Rules/MA0086.md` document the compliant case. `dotnet run --project src/DocumentationGenerator` exits 0 with no further change.
- Tests pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9; the full test suite of the default version passes (4186 tests).