### PR TITLE
Match the MA0110 regex arguments by parameter instead of position

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexSourceGeneratorFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseRegexSourceGeneratorFixer.cs
@@ -21,6 +21,30 @@ public sealed class UseRegexSourceGeneratorFixer : CodeFixProvider
         if (nodeToFix is null)
             return;
 
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var compilation = semanticModel.Compilation;
+        if (compilation.GetBestTypeByMetadataName("System.Text.RegularExpressions.Regex") is null)
+            return;
+
+        if (compilation.GetBestTypeByMetadataName("System.Text.RegularExpressions.GeneratedRegexAttribute") is null)
+            return;
+
+        if (compilation.GetBestTypeByMetadataName("System.Text.RegularExpressions.RegexOptions") is null)
+            return;
+
+        var arguments = semanticModel.GetOperation(nodeToFix, context.CancellationToken) switch
+        {
+            IObjectCreationOperation objectCreationOperation => objectCreationOperation.Arguments,
+            IInvocationOperation invocationOperation => invocationOperation.Arguments,
+            _ => default,
+        };
+
+        if (arguments.IsDefault || !AreArgumentIndicesValid(arguments, context.Diagnostics[0].Properties))
+            return;
+
         // Check if C# 14 or later is available
         var isCSharp14OrAbove = false;
         if (context.Document.Project.ParseOptions is CSharpParseOptions parseOptions)
@@ -239,28 +263,18 @@ public sealed class UseRegexSourceGeneratorFixer : CodeFixProvider
         }
         else if (operation is IInvocationOperation invocationOperation)
         {
-            var arguments = invocationOperation.Arguments;
-            var indices = new[]
-            {
-                TryParseInt32(properties, UseRegexSourceGeneratorAnalyzerCommon.PatternIndexName),
-                TryParseInt32(properties, UseRegexSourceGeneratorAnalyzerCommon.RegexOptionsIndexName),
-                TryParseInt32(properties, UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutIndexName),
-            };
-            foreach (var index in indices.Where(value => value is not null).OrderDescending())
-            {
-                arguments = arguments.RemoveAt(index.GetValueOrDefault());
-            }
+            var arguments = GetRemainingArgumentSyntaxes(invocationOperation.Arguments, properties);
 
             if (usePartialProperty)
             {
                 var accessProperty = generator.IdentifierName(methodName);
-                var method = generator.InvocationExpression(generator.MemberAccessExpression(accessProperty, invocationOperation.TargetMethod.Name), [.. arguments.Select(arg => arg.Syntax)]);
+                var method = generator.InvocationExpression(generator.MemberAccessExpression(accessProperty, invocationOperation.TargetMethod.Name), arguments);
                 newTypeDeclaration = newTypeDeclaration.ReplaceNode(nodeToFix, method);
             }
             else
             {
                 var createRegexMethod = generator.InvocationExpression(generator.IdentifierName(methodName));
-                var method = generator.InvocationExpression(generator.MemberAccessExpression(createRegexMethod, invocationOperation.TargetMethod.Name), [.. arguments.Select(arg => arg.Syntax)]);
+                var method = generator.InvocationExpression(generator.MemberAccessExpression(createRegexMethod, invocationOperation.TargetMethod.Name), arguments);
                 newTypeDeclaration = newTypeDeclaration.ReplaceNode(nodeToFix, method);
             }
         }
@@ -369,9 +383,49 @@ public sealed class UseRegexSourceGeneratorFixer : CodeFixProvider
         return document.WithSyntaxRoot(root);
     }
 
-    private static SyntaxNode? GetNode(ImmutableArray<IArgumentOperation> args, ImmutableDictionary<string, string?> properties, string name)
+    /// <summary>
+    /// Returns the syntax of the arguments that must be kept on the instance method, in their source order, once the
+    /// arguments lifted to the <c>GeneratedRegex</c> attribute are removed.
+    /// </summary>
+    private static SyntaxNode[] GetRemainingArgumentSyntaxes(ImmutableArray<IArgumentOperation> args, ImmutableDictionary<string, string?> properties)
+    {
+        var liftedIndices = new[]
+        {
+            GetArgumentIndex(args, properties, UseRegexSourceGeneratorAnalyzerCommon.PatternIndexName),
+            GetArgumentIndex(args, properties, UseRegexSourceGeneratorAnalyzerCommon.RegexOptionsIndexName),
+            GetArgumentIndex(args, properties, UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutIndexName),
+        };
+
+        return [.. args.Where((_, index) => !liftedIndices.Contains(index)).Select(arg => arg.Syntax)];
+    }
+
+    /// <summary>
+    /// Ensures the argument indices reported by the analyzer can be applied to <paramref name="args"/>, so the fix is
+    /// only registered when it can produce a valid replacement.
+    /// </summary>
+    private static bool AreArgumentIndicesValid(ImmutableArray<IArgumentOperation> args, ImmutableDictionary<string, string?> properties)
+    {
+        if (GetArgumentIndex(args, properties, UseRegexSourceGeneratorAnalyzerCommon.PatternIndexName) is null)
+            return false;
+
+        return IsIndexValid(UseRegexSourceGeneratorAnalyzerCommon.RegexOptionsIndexName)
+            && IsIndexValid(UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutIndexName);
+
+        bool IsIndexValid(string name) => TryParseInt32(properties, name) is not { } index || (index >= 0 && index < args.Length);
+    }
+
+    private static int? GetArgumentIndex(ImmutableArray<IArgumentOperation> args, ImmutableDictionary<string, string?> properties, string name)
     {
         var index = TryParseInt32(properties, name);
+        if (index is null || index.Value < 0 || index.Value >= args.Length)
+            return null;
+
+        return index;
+    }
+
+    private static SyntaxNode? GetNode(ImmutableArray<IArgumentOperation> args, ImmutableDictionary<string, string?> properties, string name)
+    {
+        var index = GetArgumentIndex(args, properties, name);
         if (index is null)
             return null;
 
@@ -606,27 +660,17 @@ public sealed class UseRegexSourceGeneratorFixer : CodeFixProvider
         }
         else if (operation is IInvocationOperation invocationOperation)
         {
-            var arguments = invocationOperation.Arguments;
-            var indices = new[]
-            {
-                TryParseInt32(properties, UseRegexSourceGeneratorAnalyzerCommon.PatternIndexName),
-                TryParseInt32(properties, UseRegexSourceGeneratorAnalyzerCommon.RegexOptionsIndexName),
-                TryParseInt32(properties, UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutIndexName),
-            };
-            foreach (var index in indices.Where(value => value is not null).OrderDescending())
-            {
-                arguments = arguments.RemoveAt(index.GetValueOrDefault());
-            }
+            var arguments = GetRemainingArgumentSyntaxes(invocationOperation.Arguments, properties);
 
             if (usePartialProperty)
             {
                 var accessProperty = generator.IdentifierName(methodName);
-                replacementNode = generator.InvocationExpression(generator.MemberAccessExpression(accessProperty, invocationOperation.TargetMethod.Name), [.. arguments.Select(arg => arg.Syntax)]);
+                replacementNode = generator.InvocationExpression(generator.MemberAccessExpression(accessProperty, invocationOperation.TargetMethod.Name), arguments);
             }
             else
             {
                 var createRegexMethod = generator.InvocationExpression(generator.IdentifierName(methodName));
-                replacementNode = generator.InvocationExpression(generator.MemberAccessExpression(createRegexMethod, invocationOperation.TargetMethod.Name), [.. arguments.Select(arg => arg.Syntax)]);
+                replacementNode = generator.InvocationExpression(generator.MemberAccessExpression(createRegexMethod, invocationOperation.TargetMethod.Name), arguments);
             }
         }
         else

--- a/src/Meziantou.Analyzer/Rules/UseRegexSourceGeneratorAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseRegexSourceGeneratorAnalyzer.cs
@@ -30,6 +30,11 @@ public sealed partial class UseRegexSourceGeneratorAnalyzer : DiagnosticAnalyzer
 
     private sealed class AnalyzerContext(Compilation compilation)
     {
+        // The parameters lifted to the GeneratedRegex attribute
+        private const string PatternParameterName = "pattern";
+        private const string OptionsParameterName = "options";
+        private const string MatchTimeoutParameterName = "matchTimeout";
+
         private readonly TimeSpanOperation _timeSpanOperation = new(compilation);
         private readonly ITypeSymbol? _regexSymbol = compilation.GetBestTypeByMetadataName("System.Text.RegularExpressions.Regex");
         private readonly ITypeSymbol? _regexGeneratorAttributeSymbol = compilation.GetBestTypeByMetadataName("System.Text.RegularExpressions.GeneratedRegexAttribute");
@@ -59,19 +64,12 @@ public sealed partial class UseRegexSourceGeneratorAnalyzer : DiagnosticAnalyzer
             if (!op.Type.IsEqualTo(_regexSymbol))
                 return;
 
-            foreach (var arg in op.Arguments)
-            {
-                if (!IsConstant(arg))
-                    return;
-            }
-
-            var properties = ImmutableDictionary.CreateRange(
-            [
-                new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.PatternIndexName, "0"),
-                new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexOptionsIndexName, op.Arguments.Length > 1 ? "1" : null),
-                new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutIndexName, op.Arguments.Length > 2 ? "2" : null),
-                new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutName, op.Arguments.Length > 2 ? _timeSpanOperation.GetMilliseconds(op.Arguments[2].Value)?.ToString(CultureInfo.InvariantCulture) : null),
-            ]);
+            // Regex(string pattern)
+            // Regex(string pattern, RegexOptions options)
+            // Regex(string pattern, RegexOptions options, TimeSpan matchTimeout)
+            var properties = TryCreateProperties(op.Arguments);
+            if (properties is null)
+                return;
 
             context.ReportDiagnostic(RegexSourceGeneratorRule, properties, op);
         }
@@ -86,68 +84,73 @@ public sealed partial class UseRegexSourceGeneratorAnalyzer : DiagnosticAnalyzer
             if (!method.IsStatic || !method.ContainingType.IsEqualTo(_regexSymbol))
                 return;
 
-            if (method.Name is "IsMatch" or "Match" or "Matches" or "Split")
+            // IsMatch/Match/Matches/Split(string input, string pattern[, RegexOptions options[, TimeSpan matchTimeout]])
+            // Replace(string input, string pattern, string replacement[, RegexOptions options[, TimeSpan matchTimeout]])
+            // Replace(string input, string pattern, MatchEvaluator evaluator[, RegexOptions options[, TimeSpan matchTimeout]])
+            if (method.Name is not ("IsMatch" or "Match" or "Matches" or "Split" or "Replace"))
+                return;
+
+            var properties = TryCreateProperties(op.Arguments);
+            if (properties is null)
+                return;
+
+            context.ReportDiagnostic(RegexSourceGeneratorRule, properties, op);
+        }
+
+        /// <summary>
+        /// Computes the diagnostic properties describing the arguments the code fixer must lift to the
+        /// <c>GeneratedRegex</c> attribute, or <see langword="null"/> when the operation cannot be converted.
+        /// </summary>
+        /// <remarks>
+        /// The arguments are located from <see cref="IArgumentOperation.Parameter"/> instead of their position in
+        /// <paramref name="arguments"/>, as reordered named arguments are listed in evaluation order.
+        /// </remarks>
+        private ImmutableDictionary<string, string?>? TryCreateProperties(ImmutableArray<IArgumentOperation> arguments)
+        {
+            var patternIndex = GetArgumentIndex(arguments, PatternParameterName);
+            if (patternIndex is null)
+                return null;
+
+            var optionsIndex = GetArgumentIndex(arguments, OptionsParameterName);
+            var timeoutIndex = GetArgumentIndex(arguments, MatchTimeoutParameterName);
+
+            // An overload with an unknown parameter cannot be converted, as the parameter would be silently dropped
+            for (var i = 0; i < arguments.Length; i++)
             {
-                // IsMatch(string _, string)
-                // IsMatch(string _, string, RegexOptions)
-                // IsMatch(string _, string, RegexOptions, TimeSpan)
+                if (i == patternIndex || i == optionsIndex || i == timeoutIndex)
+                    continue;
 
-                // Match(string _, string)
-                // Match(string _, string, RegexOptions)
-                // Match(string _, string, RegexOptions, TimeSpan)
-
-                // Matches(string _, string)
-                // Matches(string _, string, RegexOptions)
-                // Matches(string _, string, RegexOptions, TimeSpan)
-
-                // Split(string _, string)
-                // Split(string _, string, RegexOptions)
-                // Split(string _, string, RegexOptions, TimeSpan)
-
-                for (var i = 1; i < op.Arguments.Length; i++)
-                {
-                    if (!IsConstant(op.Arguments[i]))
-                        return;
-                }
-
-                var properties = ImmutableDictionary.CreateRange(
-                [
-                    new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.PatternIndexName, "1"),
-                    new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexOptionsIndexName, op.Arguments.Length > 2 ? "2" : null),
-                    new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutIndexName, op.Arguments.Length > 3 ? "3" : null),
-                    new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutName, op.Arguments.Length > 3 ? _timeSpanOperation.GetMilliseconds(op.Arguments[3].Value)?.ToString(CultureInfo.InvariantCulture) : null),
-                ]);
-
-                context.ReportDiagnostic(RegexSourceGeneratorRule, properties, op);
+                if (arguments[i].Parameter?.Name is not ("input" or "replacement" or "evaluator"))
+                    return null;
             }
-            else if (method.Name is "Replace")
+
+            if (!IsConstant(arguments[patternIndex.Value]))
+                return null;
+
+            if (optionsIndex is not null && !IsConstant(arguments[optionsIndex.Value]))
+                return null;
+
+            if (timeoutIndex is not null && !IsConstant(arguments[timeoutIndex.Value]))
+                return null;
+
+            return ImmutableDictionary.CreateRange(
+            [
+                new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.PatternIndexName, patternIndex.Value.ToString(CultureInfo.InvariantCulture)),
+                new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexOptionsIndexName, optionsIndex?.ToString(CultureInfo.InvariantCulture)),
+                new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutIndexName, timeoutIndex?.ToString(CultureInfo.InvariantCulture)),
+                new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutName, timeoutIndex is null ? null : _timeSpanOperation.GetMilliseconds(arguments[timeoutIndex.Value].Value)?.ToString(CultureInfo.InvariantCulture)),
+            ]);
+        }
+
+        private static int? GetArgumentIndex(ImmutableArray<IArgumentOperation> arguments, string parameterName)
+        {
+            for (var i = 0; i < arguments.Length; i++)
             {
-                // Replace(string _, string, MatchEvaluator _, RegexOptions, TimeSpan)
-                // Replace(string _, string, MatchEvaluator _, RegexOptions)
-                // Replace(string _, string, MatchEvaluator _)
-                // Replace(string _, string, string _, RegexOptions, TimeSpan)
-                // Replace(string _, string, string _, RegexOptions)
-                // Replace(string _, string, string _)
-
-                for (var i = 1; i < op.Arguments.Length; i++)
-                {
-                    if (i == 2)
-                        continue;
-
-                    if (!IsConstant(op.Arguments[i]))
-                        return;
-                }
-
-                var properties = ImmutableDictionary.CreateRange(
-                [
-                    new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.PatternIndexName, "1"),
-                    new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexOptionsIndexName, op.Arguments.Length > 3 ? "3" : null),
-                    new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutIndexName, op.Arguments.Length > 4 ? "4" : null),
-                    new KeyValuePair<string, string?>(UseRegexSourceGeneratorAnalyzerCommon.RegexTimeoutName, op.Arguments.Length > 4 ? _timeSpanOperation.GetMilliseconds(op.Arguments[4].Value)?.ToString(CultureInfo.InvariantCulture) : null),
-                ]);
-
-                context.ReportDiagnostic(RegexSourceGeneratorRule, properties, op);
+                if (arguments[i].Parameter?.Name == parameterName)
+                    return i;
             }
+
+            return null;
         }
 
         private bool IsConstant(IArgumentOperation argumentOperation)

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
@@ -747,6 +747,35 @@ public class UseRegexSourceGeneratorAnalyzerTests
         return test.RunAsync();
     }
 
+    [Fact]
+    public Task RegexIsMatch_NamedArgumentsInReverseOrder_PartialProperty()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            class Test
+            {
+                bool a = {|MA0110:Regex.IsMatch(pattern: "testpattern", input: "test")|};
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            partial class Test
+            {
+                bool a = MyRegex.IsMatch(input: "test");
+
+                [GeneratedRegex("testpattern")]
+                private static partial Regex MyRegex { get; }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
 #endif
     [Fact]
     public Task Field_SuggestFieldName()
@@ -1382,4 +1411,138 @@ public class UseRegexSourceGeneratorAnalyzerTests
             """;
 
         return test.RunAsync();
-    }}
+    }
+
+    [Fact]
+    public Task RegexIsMatch_NamedArgumentsInReverseOrder()
+    {
+        var test = CreatePartialMethodTest();
+        test.TestCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            class Test
+            {
+                bool a = {|MA0110:Regex.IsMatch(pattern: "testpattern", input: "test")|};
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            partial class Test
+            {
+                bool a = MyRegex().IsMatch(input: "test");
+
+                [GeneratedRegex("testpattern")]
+                private static partial Regex MyRegex();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RegexIsMatch_Options_Timeout_NamedArgumentsInReverseOrder()
+    {
+        var test = CreatePartialMethodTest();
+        test.TestCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            class Test
+            {
+                bool a = {|MA0110:Regex.IsMatch(matchTimeout: TimeSpan.FromSeconds(1), options: RegexOptions.ExplicitCapture, pattern: "testpattern", input: "test")|};
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            partial class Test
+            {
+                bool a = MyRegex().IsMatch(input: "test");
+
+                [GeneratedRegex("testpattern", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)]
+                private static partial Regex MyRegex();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RegexReplace_NamedArgumentsInReverseOrder()
+    {
+        var test = CreatePartialMethodTest();
+        test.TestCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            class Test
+            {
+                string a = {|MA0110:Regex.Replace(replacement: "replacement", pattern: "testpattern", input: "test")|};
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            partial class Test
+            {
+                string a = MyRegex().Replace(replacement: "replacement", input: "test");
+
+                [GeneratedRegex("testpattern")]
+                private static partial Regex MyRegex();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RegexIsMatch_NonConstantPatternPassedAsNamedArgument()
+    {
+        var test = CreatePartialMethodTest();
+        test.TestCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            class Test
+            {
+                bool A(string pattern) => Regex.IsMatch(pattern: pattern, input: "test");
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task NewRegex_Options_Timeout_NamedArgumentsInReverseOrder()
+    {
+        var test = CreatePartialMethodTest();
+        test.TestCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            class Test
+            {
+                Regex a = {|MA0110:new Regex(matchTimeout: TimeSpan.FromSeconds(1), options: RegexOptions.ExplicitCapture, pattern: "testpattern")|};
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Text.RegularExpressions;
+
+            partial class Test
+            {
+                Regex a = MyRegex();
+
+                [GeneratedRegex("testpattern", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)]
+                private static partial Regex MyRegex();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+}


### PR DESCRIPTION
## Problem

Roslyn lists the arguments of an operation in **evaluation order**, so explicitly reordered named arguments do not line up with the parameters. `UseRegexSourceGeneratorAnalyzer` nevertheless recorded fixed indices for the pattern, the options and the match timeout, and `UseRegexSourceGeneratorFixer` removed and lifted the arguments at those indices.

For this valid input:

```csharp
Regex.IsMatch(pattern: "a", input: "b")
```

the fix produced:

```csharp
[GeneratedRegex("b")]
private static partial Regex MyRegex { get; }
// ...
MyRegex.IsMatch(pattern: "a")
```

The pattern was taken from the wrong argument, and the generated call does not compile (**CS1501**) even after the real Regex source generator runs. The constructor and every supported static `Regex` method shared the same positional assumption. The analyzer's constant check was positional too, so it validated `input` instead of `pattern`.

## What changed

**`UseRegexSourceGeneratorAnalyzer`**

- The pattern, the options and the match timeout arguments are located from `IArgumentOperation.Parameter` (`pattern`, `options`, `matchTimeout`) instead of a hardcoded position, and the resolved indices are what the diagnostic properties carry.
- The constant check applies to exactly those three arguments, replacing the positional *skip index 0 (and index 2 for `Replace`)* loops.
- An overload with a parameter that is neither lifted nor a known runtime parameter (`input`, `replacement`, `evaluator`) is no longer reported: the code fixer would otherwise silently drop that argument.
- The `IsMatch`/`Match`/`Matches`/`Split` and `Replace` branches collapse into a single path, as parameter identity makes the per-method shapes irrelevant.

**`UseRegexSourceGeneratorFixer`**

- Argument removal moves to a shared `GetRemainingArgumentSyntaxes` helper used by both the type-declaration and the top-level-statement paths. It keeps the surviving arguments in their source (evaluation) order with their `name:` colons intact, so the evaluation order of the runtime arguments is preserved.
- `RegisterCodeFixesAsync` validates the semantic model, the `Regex` / `GeneratedRegexAttribute` / `RegexOptions` symbols, the operation kind and the reported indices **before** registering either code action, following the fixer convention in `AGENTS.md`. Index lookups are bounds checked.

No name translation is needed when switching from the static to the instance overload: the two sets of parameters use identical names (`input`, `replacement`, `evaluator`). The tests compile the fixed code with the real source generator, so any mismatch would surface as CS1501.

## Tests

Six tests added to `UseRegexSourceGeneratorAnalyzerTests`:

- `RegexIsMatch_NamedArgumentsInReverseOrder` (the reported case, partial method)
- `RegexIsMatch_NamedArgumentsInReverseOrder_PartialProperty` (the reported case, partial property)
- `RegexIsMatch_Options_Timeout_NamedArgumentsInReverseOrder` (all four arguments reversed)
- `RegexReplace_NamedArgumentsInReverseOrder`
- `NewRegex_Options_Timeout_NamedArgumentsInReverseOrder` (constructor)
- `RegexIsMatch_NonConstantPatternPassedAsNamedArgument` (no diagnostic; previously the positional check looked at `input`)

## Verification

- `dotnet build` — succeeded, 0 warnings.
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn5.9.csproj` — 4186/4186 passing.
- MA0110 tests on every Roslyn version — 41/41 on roslyn4.8 and roslyn4.14, 59/59 on roslyn5.0, roslyn5.6 and roslyn5.9.
- `dotnet run --project src/DocumentationGenerator` — exit code 0, no markdown changes (no rule metadata changed).