### PR TITLE
Evaluate every component of the TimeSpan factory methods and constructors

### DIFF
--- a/docs/Rules/MA0110.md
+++ b/docs/Rules/MA0110.md
@@ -14,10 +14,13 @@ private static partial Regex MyRegex();
 ````
 
 The rule is not reported when the `Regex` cannot be expressed with `[GeneratedRegex]`, such as when the match
-timeout is neither infinite nor strictly positive:
+timeout is neither infinite nor strictly positive, or when it is not an `Int32` number of milliseconds:
 
 ````c#
 // ok: GeneratedRegex does not accept this match timeout
 new Regex("constant pattern", RegexOptions.None, TimeSpan.Zero);
+
+// ok: GeneratedRegex takes an Int32 number of milliseconds, which cannot represent this match timeout
+new Regex("constant pattern", RegexOptions.None, TimeSpan.FromMicroseconds(500));
 ````
 

--- a/src/Meziantou.Analyzer/Internals/TimeSpanOperation.cs
+++ b/src/Meziantou.Analyzer/Internals/TimeSpanOperation.cs
@@ -2,10 +2,16 @@ namespace Meziantou.Analyzer.Internals;
 
 internal sealed class TimeSpanOperation(Compilation compilation)
 {
+    private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+
     private readonly ISymbol? _timeSpanSymbol = compilation.GetBestTypeByMetadataName("System.TimeSpan");
     private readonly ISymbol? _regexSymbol = compilation.GetBestTypeByMetadataName("System.Text.RegularExpressions.Regex");
     private readonly ISymbol? _timeoutSymbol = compilation.GetBestTypeByMetadataName("System.Threading.Timeout");
 
+    /// <summary>
+    /// Gets the duration of a <see cref="TimeSpan"/> expression, or <see langword="null"/> when the expression is not
+    /// supported or when its duration is not an exact number of milliseconds.
+    /// </summary>
     public long? GetMilliseconds(IOperation op)
     {
         if (op.SemanticModel is null)
@@ -14,134 +20,161 @@ internal sealed class TimeSpanOperation(Compilation compilation)
         if (!op.Type.IsEqualTo(_timeSpanSymbol))
             return null;
 
-        return GetMilliseconds(op, 1d);
+        long ticks;
+        try
+        {
+            if (GetTicks(op) is not long value)
+                return null;
+
+            ticks = value;
+        }
+        catch (OverflowException)
+        {
+            // The arithmetic of the components is checked, so a duration that cannot be represented by a
+            // TimeSpan, which the code creating it would report at runtime, is unknown
+            return null;
+        }
+
+        // The callers replace the expression with a number of milliseconds, so a duration that is not an exact
+        // number of milliseconds cannot be reported without changing the behavior of the code
+        if (ticks % TimeSpan.TicksPerMillisecond is not 0)
+            return null;
+
+        return ticks / TimeSpan.TicksPerMillisecond;
     }
 
-    private long? GetMilliseconds(IOperation op, double factor)
+    private long? GetTicks(IOperation op)
     {
-        const double TicksToMilliseconds = 1d / TimeSpan.TicksPerMillisecond;
-        const double SecondsToMilliseconds = 1000;
-        const double MinutesToMilliseconds = 60 * 1000;
-        const double HoursToMilliseconds = 60 * 60 * 1000;
-        const double DaysToMilliseconds = 24 * 60 * 60 * 1000;
-
         op = op.UnwrapImplicitConversions();
-        if (op.ConstantValue.HasValue)
-        {
-            if (op.ConstantValue.HasValue && op.ConstantValue.Value is long int64Value)
-                return (long)(int64Value * factor);
-
-            if (op.ConstantValue.HasValue && op.ConstantValue.Value is int int32Value)
-                return (long)(int32Value * factor);
-
-            if (op.ConstantValue.HasValue && op.ConstantValue.Value is double doubleValue)
-                return (long)(doubleValue * factor);
-        }
 
         if (op is IDefaultValueOperation)
             return 0L;
 
+        if (op is IFieldReferenceOperation fieldReferenceOperation)
+            return GetFieldTicks(fieldReferenceOperation.Member);
+
+        // TimeSpan.FromSeconds(1, milliseconds: 500)
         if (op is IInvocationOperation invocationOperation)
         {
             var method = invocationOperation.TargetMethod;
-            if (method.IsStatic && method.ContainingType.IsEqualTo(_timeSpanSymbol))
-            {
-                return method.Name switch
-                {
-                    "FromTicks" => GetMilliseconds(invocationOperation.Arguments[0].Value, TicksToMilliseconds),
-                    "FromMilliseconds" => GetMilliseconds(invocationOperation.Arguments[0].Value, 1),
-                    "FromSeconds" => GetMilliseconds(invocationOperation.Arguments[0].Value, SecondsToMilliseconds),
-                    "FromMinutes" => GetMilliseconds(invocationOperation.Arguments[0].Value, MinutesToMilliseconds),
-                    "FromHours" => GetMilliseconds(invocationOperation.Arguments[0].Value, HoursToMilliseconds),
-                    "FromDays" => GetMilliseconds(invocationOperation.Arguments[0].Value, DaysToMilliseconds),
-                    _ => null,
-                };
-            }
+            if (!method.IsStatic || !method.ContainingType.IsEqualTo(_timeSpanSymbol))
+                return null;
 
-            return null;
+            return GetComponentsTicks(invocationOperation.Arguments, GetTicksPerUnit(method.Name));
         }
 
-        if (op is IFieldReferenceOperation fieldReferenceOperation)
-        {
-            var member = fieldReferenceOperation.Member;
-            if (member.IsStatic && member.ContainingType.IsEqualTo(_timeSpanSymbol))
-            {
-                return member.Name switch
-                {
-                    "Zero" => 0,
-                    "MinValue" => (long)TimeSpan.MinValue.TotalMilliseconds,
-                    "MaxValue" => (long)TimeSpan.MaxValue.TotalMilliseconds,
-                    _ => null,
-                };
-            }
+        // new TimeSpan(hours: 1, minutes: 2, seconds: 3)
+        if (op is IObjectCreationOperation objectCreationOperation && objectCreationOperation.Type.IsEqualTo(_timeSpanSymbol))
+            return GetComponentsTicks(objectCreationOperation.Arguments, valueParameterTicksPerUnit: null);
 
-            if (member.IsStatic && member.ContainingType.IsEqualTo(_regexSymbol))
-            {
-                return member.Name switch
-                {
-                    "InfiniteMatchTimeout" => -1L,
-                    _ => null,
-                };
-            }
+        return null;
+    }
 
-            if (member.IsStatic && member.ContainingType.IsEqualTo(_timeoutSymbol))
-            {
-                return member.Name switch
-                {
-                    "InfiniteTimeSpan" => -1L,
-                    "Infinite" => -1L,
-                    _ => null,
-                };
-            }
-
+    private long? GetFieldTicks(ISymbol member)
+    {
+        if (!member.IsStatic)
             return null;
+
+        if (member.ContainingType.IsEqualTo(_timeSpanSymbol))
+        {
+            return member.Name switch
+            {
+                "Zero" => 0L,
+                "MinValue" => TimeSpan.MinValue.Ticks,
+                "MaxValue" => TimeSpan.MaxValue.Ticks,
+                _ => null,
+            };
         }
 
-        if (op is IObjectCreationOperation objectCreationOperation)
+        if (member.ContainingType.IsEqualTo(_regexSymbol))
         {
-            if (objectCreationOperation.Type.IsEqualTo(_timeSpanSymbol))
+            return member.Name switch
             {
-                return objectCreationOperation.Arguments.Length switch
-                {
-                    // new TimeSpan(long ticks)
-                    1 => GetMilliseconds(objectCreationOperation.Arguments[0].Value, 1d / TimeSpan.TicksPerMillisecond),
+                "InfiniteMatchTimeout" => -TimeSpan.TicksPerMillisecond,
+                _ => null,
+            };
+        }
 
-                    // new TimeSpan(int hours, int minutes, int seconds)
-                    3 => AddValues(GetMilliseconds(objectCreationOperation.Arguments[0].Value, HoursToMilliseconds),
-                                   GetMilliseconds(objectCreationOperation.Arguments[1].Value, MinutesToMilliseconds),
-                                   GetMilliseconds(objectCreationOperation.Arguments[2].Value, SecondsToMilliseconds)),
-
-                    // new TimeSpan(int days, int hours, int minutes, int seconds)
-                    4 => AddValues(GetMilliseconds(objectCreationOperation.Arguments[0].Value, DaysToMilliseconds),
-                                   GetMilliseconds(objectCreationOperation.Arguments[1].Value, HoursToMilliseconds),
-                                   GetMilliseconds(objectCreationOperation.Arguments[2].Value, MinutesToMilliseconds),
-                                   GetMilliseconds(objectCreationOperation.Arguments[3].Value, SecondsToMilliseconds)),
-
-                    // new TimeSpan(int days, int hours, int minutes, int seconds, int milliseconds)
-                    5 => AddValues(GetMilliseconds(objectCreationOperation.Arguments[0].Value, DaysToMilliseconds),
-                                   GetMilliseconds(objectCreationOperation.Arguments[1].Value, HoursToMilliseconds),
-                                   GetMilliseconds(objectCreationOperation.Arguments[2].Value, MinutesToMilliseconds),
-                                   GetMilliseconds(objectCreationOperation.Arguments[3].Value, SecondsToMilliseconds),
-                                   GetMilliseconds(objectCreationOperation.Arguments[4].Value, 1)),
-                    _ => null,
-                };
-            }
+        if (member.ContainingType.IsEqualTo(_timeoutSymbol))
+        {
+            return member.Name switch
+            {
+                "InfiniteTimeSpan" => -TimeSpan.TicksPerMillisecond,
+                _ => null,
+            };
         }
 
         return null;
+    }
 
-        static long? AddValues(params ReadOnlySpan<long?> values)
+    /// <summary>
+    /// Sums the components of a <c>TimeSpan.FromXXX</c> overload or of a <see cref="TimeSpan"/> constructor. The unit
+    /// of a component comes from the name of its parameter, so the optional components and the named arguments given
+    /// in any order are evaluated too, and an overload with an unknown component is unknown.
+    /// </summary>
+    /// <param name="valueParameterTicksPerUnit">
+    /// The unit of the <c>value</c> parameter of the overloads taking a single value, such as
+    /// <see cref="TimeSpan.FromSeconds(double)"/>, which is named after the method instead of the unit.
+    /// </param>
+    private static long? GetComponentsTicks(ImmutableArray<IArgumentOperation> arguments, long? valueParameterTicksPerUnit)
+    {
+        var ticks = 0L;
+        foreach (var argument in arguments)
         {
-            var result = 0L;
-            foreach (var value in values)
+            var parameter = argument.Parameter;
+            if (parameter is null)
+                return null;
+
+            var ticksPerUnit = parameter.Name is "value" ? valueParameterTicksPerUnit : GetTicksPerUnit(parameter.Name);
+            if (ticksPerUnit is null)
+                return null;
+
+            if (GetComponentTicks(argument.Value, ticksPerUnit.GetValueOrDefault()) is not long componentTicks)
+                return null;
+
+            checked
             {
-                if (!value.HasValue)
-                    return null;
-
-                result += value.GetValueOrDefault();
+                ticks += componentTicks;
             }
+        }
 
-            return result;
+        return ticks;
+    }
+
+    private static long? GetComponentTicks(IOperation operation, long ticksPerUnit)
+    {
+        var constantValue = operation.ConstantValue;
+        if (!constantValue.HasValue)
+            return null;
+
+        checked
+        {
+            return constantValue.Value switch
+            {
+                int int32Value => int32Value * ticksPerUnit,
+                long int64Value => int64Value * ticksPerUnit,
+
+                // The overloads taking a double multiply the value by the number of ticks of the unit and truncate the
+                // result. The conversion is checked, so a value that is out of range or NaN is unknown.
+                double doubleValue => (long)(doubleValue * ticksPerUnit),
+                _ => null,
+            };
         }
     }
+
+    /// <summary>
+    /// Gets the number of ticks of a unit named by the parameter of a <see cref="TimeSpan"/> component, such as
+    /// <c>seconds</c>, or by a <c>TimeSpan.FromXXX</c> method, such as <c>FromSeconds</c>.
+    /// </summary>
+    private static long? GetTicksPerUnit(string name) => name switch
+    {
+        "ticks" or "FromTicks" => 1L,
+        "microseconds" or "FromMicroseconds" => TicksPerMicrosecond,
+        "milliseconds" or "FromMilliseconds" => TimeSpan.TicksPerMillisecond,
+        "seconds" or "FromSeconds" => TimeSpan.TicksPerSecond,
+        "minutes" or "FromMinutes" => TimeSpan.TicksPerMinute,
+        "hours" or "FromHours" => TimeSpan.TicksPerHour,
+        "days" or "FromDays" => TimeSpan.TicksPerDay,
+        _ => null,
+    };
 }

--- a/src/Meziantou.Analyzer/Rules/UseRegexSourceGeneratorAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseRegexSourceGeneratorAnalyzer.cs
@@ -159,10 +159,11 @@ public sealed partial class UseRegexSourceGeneratorAnalyzer : DiagnosticAnalyzer
             if (valueOperation.Type.IsEqualTo(_timespanSymbol))
             {
                 // GeneratedRegex only accepts an infinite or strictly positive match timeout, so a Regex built with
-                // any other value cannot be converted: the source generator would reject the generated attribute
+                // any other value cannot be converted: the source generator would reject the generated attribute.
+                // Its timeout is an Int32 number of milliseconds, so a longer duration cannot be converted either.
                 const long Infinite = -1;
                 var milliseconds = _timeSpanOperation.GetMilliseconds(valueOperation);
-                return milliseconds is Infinite || milliseconds > 0;
+                return milliseconds is Infinite or (> 0 and <= int.MaxValue);
             }
 
             return false;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
@@ -53,6 +53,8 @@ public class UseDateTimeUnixEpochAnalyzerTests
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, 0, TimeSpan.Zero)")]
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, 0, default(TimeSpan))")]
     [InlineData("new DateTimeOffset(offset: TimeSpan.Zero, day: 1, month: 1, year: 1970, hour: 0, minute: 0, second: 0)")]
+    [InlineData("new DateTimeOffset(DateTime.UnixEpoch, TimeSpan.FromMinutes(0, 0))")]
+    [InlineData("new DateTimeOffset(DateTime.UnixEpoch, new TimeSpan(0, 0, 0, 0, 0, 0))")]
     public Task UnixEpoch_DateTimeOffset(string code)
     {
         var test = CreateTest();
@@ -115,6 +117,8 @@ public class UseDateTimeUnixEpochAnalyzerTests
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, 0, TimeSpan.FromHours(-1))")]
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, null, TimeSpan.Zero)")]
     [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, new System.Globalization.GregorianCalendar(), TimeSpan.Zero)")]
+    [InlineData("new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.FromMinutes(0, 60))")]
+    [InlineData("new DateTimeOffset(DateTime.UnixEpoch, new TimeSpan(1))")]
     public Task NonUnixEpoch_DateTimeOffset(string code)
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseRegexSourceGeneratorAnalyzerTests.cs
@@ -383,6 +383,76 @@ public class UseRegexSourceGeneratorAnalyzerTests
     }
 
     [Theory]
+    [InlineData("TimeSpan.FromSeconds(1, 500)", "1500")]
+    [InlineData("TimeSpan.FromSeconds(milliseconds: 500, seconds: 1)", "1500")]
+    [InlineData("TimeSpan.FromMilliseconds(1, 2000)", "3")]
+    [InlineData("TimeSpan.FromMinutes(1, 30)", "90000")]
+    [InlineData("TimeSpan.FromHours(1, 2, 3, 4)", "3723004")]
+    [InlineData("TimeSpan.FromDays(1, 2, 3, 4)", "93784000")]
+    [InlineData("new TimeSpan(seconds: 3, minutes: 2, hours: 1)", "3723000")]
+    [InlineData("new TimeSpan(1, 2, 3, 4, 5, 6000)", "93784011")]
+    public Task Timeout_MultipleComponents(string timeout, string milliseconds)
+    {
+        var test = CreateTest();
+
+        // The TimeSpan.FromXXX overloads taking multiple components were added in .NET 9, and the code fixer
+        // generates a partial method for the language versions that do not support partial properties
+        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
+        test.LanguageVersion = LanguageVersion.CSharp12;
+
+        test.TestCode = $$"""
+            using System;
+            using System.Text.RegularExpressions;
+
+            class Test
+            {
+                Regex a = {|MA0110:new Regex("testpattern", RegexOptions.None, {{timeout}})|};
+            }
+            """;
+        test.FixedCode = $$"""
+            using System;
+            using System.Text.RegularExpressions;
+
+            partial class Test
+            {
+                Regex a = MyRegex();
+
+                [GeneratedRegex("testpattern", RegexOptions.None, matchTimeoutMilliseconds: {{milliseconds}})]
+                private static partial Regex MyRegex();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("new TimeSpan(1)")]
+    [InlineData("TimeSpan.FromMilliseconds(0.5)")]
+    [InlineData("TimeSpan.MaxValue")]
+    [InlineData("TimeSpan.FromDays(30)")]
+    public Task Timeout_NotRepresentableInMilliseconds_NoDiagnostic(string timeout)
+    {
+        var test = CreateTest();
+
+        // The generator of .NET 11 requires C# 12, which is not the default language version of every supported Roslyn version
+        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+
+        // The generated attribute takes an Int32 number of milliseconds, so a duration that is not an exact
+        // number of milliseconds, or that is too long, cannot be converted without changing the timeout
+        test.TestCode = $$"""
+            using System;
+            using System.Text.RegularExpressions;
+
+            class Test
+            {
+                Regex a = new Regex("testpattern", RegexOptions.None, {{timeout}});
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
     [InlineData("System.Threading.Timeout.InfiniteTimeSpan")]
     [InlineData("Regex.InfiniteMatchTimeout")]
     public Task New_Timeout_Infinite(string timeout)


### PR DESCRIPTION
## What was wrong

`TimeSpanOperation` recognized the `TimeSpan.FromXXX` methods by name and read only `Arguments[0]`, and recognized the constructors by the *number* of their arguments. Every additional component was silently dropped.

```csharp
new Regex("a", RegexOptions.None, TimeSpan.FromSeconds(1, 500))
```

The timeout is 1500 ms, but MA0110 recorded `RegexTimeout=1000` and the code fixer generated:

```csharp
[GeneratedRegex("a", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
```

The fixed code compiles, but a workload that used to fit within the timeout can now time out.

The same helper backs MA0132 and MA0133, where the truncation to milliseconds produced a false positive: `new DateTimeOffset(DateTime.UnixEpoch, new TimeSpan(1))` has a one tick offset, which was evaluated as `0` and reported as `DateTimeOffset.UnixEpoch`.

## What changed

`TimeSpanOperation` now computes **ticks** and drives everything off parameter identity:

- The unit of a component comes from the **name of its parameter** (`days`, `hours`, `minutes`, `seconds`, `milliseconds`, `microseconds`, `ticks`), so the optional components, the additional components and the named arguments given in any order are all evaluated. The overloads taking a single value name their parameter `value`, so its unit comes from the method name. This also covers the microsecond constructor and `TimeSpan.FromMicroseconds`, which were previously unknown.
- A parameter that does not name a known unit makes the whole expression unknown, so an unsupported overload is unknown instead of being partially evaluated.
- The arithmetic of the components is `checked`, so a duration that no `TimeSpan` can hold, which the code creating it would reject at runtime, is unknown.
- `GetMilliseconds` returns a value only when the duration is an **exact** number of milliseconds, as the callers replace the expression with a number of milliseconds. `TimeSpan.MinValue`, `TimeSpan.MaxValue` and the durations shorter than a millisecond are now unknown rather than truncated.

`UseRegexSourceGeneratorAnalyzer.IsConstant` additionally rejects the timeouts longer than `Int32.MaxValue` milliseconds. That closes a second silent drop: `matchTimeoutMilliseconds` is an `Int32`, and the fixer's `TryParseInt32` returned `null` for a longer value, which removed the `TimeSpan` argument from the call **and** omitted the timeout from the generated attribute.

## Note for the reviewer

The `Timeout.Infinite` case of the field lookup is removed. It is a `const int`, so it can never be a `TimeSpan` typed operation, and as a component it was folded into the constant path: the case was unreachable. `Timeout.InfiniteTimeSpan` and `Regex.InfiniteMatchTimeout` are still evaluated as `-1`.

MA0110 no longer reports a few `Regex` constructions it used to report, all of which produced a fix that changed the timeout or dropped it: `TimeSpan.MinValue`, `TimeSpan.MaxValue`, the durations shorter than a millisecond and the durations longer than `Int32.MaxValue` milliseconds. [docs/Rules/MA0110.md](docs/Rules/MA0110.md) documents this.

## Tests

- `Timeout_MultipleComponents`, 8 cases: `FromSeconds(1, 500)`, the named arguments given in another order, `FromMilliseconds(1, 2000)`, `FromMinutes(1, 30)`, `FromHours(1, 2, 3, 4)`, `FromDays(1, 2, 3, 4)`, `new TimeSpan(seconds: 3, minutes: 2, hours: 1)` and the microsecond constructor. It pins the .NET 9 reference assemblies, which is where those overloads were added.
- `Timeout_NotRepresentableInMilliseconds_NoDiagnostic`: `new TimeSpan(1)`, `FromMilliseconds(0.5)`, `TimeSpan.MaxValue` and `FromDays(30)`.
- Two cases added to each of the MA0132/MA0133 theories, including the `new TimeSpan(1)` false positive and `FromMinutes(0, 60)`.

These are regression tests: reverting only `TimeSpanOperation` while keeping them produces 11 failures.

`dotnet test` passes for the five Roslyn versions (20689 tests). `dotnet run --project src/DocumentationGenerator` exits 0 with no further change.