### PR TITLE
Bound the regex cache, so it does not retain every configuration value

### DIFF
--- a/src/Meziantou.Analyzer/Configurations/AnalyzerOptionsExtensions.cs
+++ b/src/Meziantou.Analyzer/Configurations/AnalyzerOptionsExtensions.cs
@@ -54,8 +54,9 @@ public static class AnalyzerOptionsExtensions
     /// <summary>
     /// Gets the <see cref="Regex"/> of an option whose value is a regular expression (<see cref="ConfigurationDefinition{T}.IsRegex"/>).
     /// The regex is created with the <see cref="ConfigurationDefinition{T}.RegexOptions"/> of the option and cached, so a value is
-    /// parsed only once. Returns <see langword="false"/> when the option is not configured, when its value is empty, or when its
-    /// value is not a valid pattern. MA0220 reports the invalid patterns, so the rules can ignore them.
+    /// parsed once until its entry is evicted from the cache. Returns <see langword="false"/> when the option is not configured,
+    /// when its value is empty, or when its value is not a valid pattern. MA0220 reports the invalid patterns, so the rules can
+    /// ignore them.
     /// </summary>
     public static bool TryGetConfigurationRegex(this AnalyzerOptions options, SyntaxTree syntaxTree, ConfigurationDefinition<string> configuration, [NotNullWhen(true)] out Regex? regex)
     {

--- a/src/Meziantou.Analyzer/Internals/BoundedCache.cs
+++ b/src/Meziantou.Analyzer/Internals/BoundedCache.cs
@@ -1,0 +1,91 @@
+using System.Collections.Concurrent;
+
+namespace Meziantou.Analyzer.Internals;
+
+/// <summary>
+/// A thread-safe cache that keeps at most <see cref="Capacity"/> entries. When the capacity is exceeded, the least
+/// recently used entries are removed, so the values that are no longer used do not stay alive for the lifetime of
+/// the process. An entry can be removed at any time, so the values must be reproducible from their key.
+/// </summary>
+internal sealed class BoundedCache<TKey, TValue> where TKey : notnull
+{
+    private readonly ConcurrentDictionary<TKey, Entry> _entries = new();
+    private readonly Lock _evictionLock = new();
+    private long _lastUsage;
+
+    public BoundedCache(int capacity)
+    {
+        if (capacity < 1)
+            throw new ArgumentOutOfRangeException(nameof(capacity), capacity, message: "The capacity must be greater than 0");
+
+        Capacity = capacity;
+    }
+
+    /// <summary>
+    /// Gets the maximum number of entries kept by the cache. The cache can hold a few more entries for a short time,
+    /// as the eviction happens once an entry is added.
+    /// </summary>
+    public int Capacity { get; }
+
+    public int Count => _entries.Count;
+
+    /// <summary>
+    /// Gets the value associated with the key, or adds the value created by <paramref name="valueFactory"/>.
+    /// The factory can be invoked concurrently for the same key, and its value is then discarded.
+    /// </summary>
+    public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+    {
+        if (!_entries.TryGetValue(key, out var entry))
+        {
+            entry = _entries.GetOrAdd(key, key => new Entry(valueFactory(key)));
+            Touch(entry);
+            Evict();
+            return entry.Value;
+        }
+
+        Touch(entry);
+        return entry.Value;
+    }
+
+    private void Touch(Entry entry) => entry.LastUsage = Interlocked.Increment(ref _lastUsage);
+
+    private void Evict()
+    {
+        if (_entries.Count <= Capacity)
+            return;
+
+        lock (_evictionLock)
+        {
+            if (_entries.Count <= Capacity)
+                return;
+
+            // Remove a quarter of the entries, so the eviction does not run at every addition once the cache is full.
+            // The entries added while the snapshot is taken can be removed, which is fine as their value is recreated on demand.
+            var entries = _entries.ToArray();
+            Array.Sort(entries, static (a, b) => b.Value.LastUsage.CompareTo(a.Value.LastUsage));
+
+            var retainedCount = Math.Max(1, Capacity - (Capacity / 4));
+            for (var i = retainedCount; i < entries.Length; i++)
+            {
+                _entries.TryRemove(entries[i].Key, out _);
+            }
+        }
+    }
+
+    private sealed class Entry(TValue value)
+    {
+        private long _lastUsage;
+
+        public TValue Value { get; } = value;
+
+        /// <summary>
+        /// Gets or sets the value of the counter of the cache when the entry was last used. The accessors are
+        /// interlocked, so the value cannot tear when the entry is used concurrently.
+        /// </summary>
+        public long LastUsage
+        {
+            get => Interlocked.Read(ref _lastUsage);
+            set => Interlocked.Exchange(ref _lastUsage, value);
+        }
+    }
+}

--- a/src/Meziantou.Analyzer/Internals/RegexCache.cs
+++ b/src/Meziantou.Analyzer/Internals/RegexCache.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 
 namespace Meziantou.Analyzer.Internals;
@@ -8,11 +7,15 @@ internal static class RegexCache
     // The patterns come from the configuration, so they can be invalid or subject to catastrophic backtracking.
     // The timeout ensures a single pattern cannot hang the compilation.
     private static readonly TimeSpan MatchTimeout = TimeSpan.FromSeconds(1);
-    private static readonly ConcurrentDictionary<(string Pattern, RegexOptions Options), (Regex? Regex, string? ErrorMessage)> Cache = new();
+
+    // The patterns come from the configuration of the analyzed projects, and an editor provides a new value at every
+    // keystroke, including the invalid intermediate ones. The cache is bounded, so the patterns of the closed projects
+    // and of the outdated configuration values do not stay alive for the lifetime of the process.
+    private static readonly BoundedCache<(string Pattern, RegexOptions Options), (Regex? Regex, string? ErrorMessage)> Cache = new(capacity: 128);
 
     /// <summary>
     /// Gets a cached <see cref="Regex"/> for the pattern. Returns <see langword="false"/> when the pattern is invalid.
-    /// Invalid patterns are cached, so a pattern is parsed only once.
+    /// Invalid patterns are cached too, so a pattern is parsed once until its entry is evicted from the cache.
     /// </summary>
     public static bool TryGetOrCreate(string pattern, RegexOptions options, [NotNullWhen(true)] out Regex? regex)
     {

--- a/tests/Meziantou.Analyzer.Test/Internals/BoundedCacheTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Internals/BoundedCacheTests.cs
@@ -1,0 +1,72 @@
+using Meziantou.Analyzer.Internals;
+
+namespace Meziantou.Analyzer.Test.Internals;
+
+public sealed class BoundedCacheTests
+{
+    [Fact]
+    public void CreatingACacheWithAnInvalidCapacityThrows()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BoundedCache<string, string>(capacity: 0));
+    }
+
+    [Fact]
+    public void TheValueIsCreatedOncePerKey()
+    {
+        var invocations = 0;
+        var cache = new BoundedCache<string, string>(capacity: 4);
+
+        string Create(string key)
+        {
+            invocations++;
+            return key + "!";
+        }
+
+        Assert.Equal("a!", cache.GetOrAdd("a", Create));
+        Assert.Equal("a!", cache.GetOrAdd("a", Create));
+        Assert.Equal("b!", cache.GetOrAdd("b", Create));
+
+        Assert.Equal(2, invocations);
+        Assert.Equal(2, cache.Count);
+    }
+
+    [Fact]
+    public void TheNumberOfEntriesIsBounded()
+    {
+        var cache = new BoundedCache<int, int>(capacity: 8);
+
+        for (var i = 0; i < 1000; i++)
+        {
+            cache.GetOrAdd(i, static key => key);
+            Assert.True(cache.Count <= cache.Capacity, $"The cache contains {cache.Count} entries after adding {i + 1} keys");
+        }
+    }
+
+    [Fact]
+    public void TheLeastRecentlyUsedEntriesAreEvicted()
+    {
+        static int Fail(int key) => throw new InvalidOperationException("The entry should be cached");
+
+        var cache = new BoundedCache<int, int>(capacity: 4);
+        for (var i = 0; i < 4; i++)
+        {
+            cache.GetOrAdd(i, static key => key);
+        }
+
+        // Use every entry but the first one, then add an entry so the cache evicts the least recently used entries
+        for (var i = 1; i < 4; i++)
+        {
+            cache.GetOrAdd(i, Fail);
+        }
+
+        cache.GetOrAdd(4, static key => key);
+
+        cache.GetOrAdd(4, Fail);
+        cache.GetOrAdd(3, Fail);
+        cache.GetOrAdd(2, Fail);
+
+        var created = false;
+        cache.GetOrAdd(0, key => { created = true; return key; });
+        Assert.True(created);
+    }
+}


### PR DESCRIPTION
## What

`RegexCache` kept the compiled `Regex` (or the parse error message) of every pattern/options pair in a static `ConcurrentDictionary` with no limit and no eviction.

The patterns come from the configuration of the analyzed projects, and an editor provides a new value at every keystroke, including the invalid intermediate ones. In a long-lived analyzer host, the values of the closed projects and of the outdated configurations therefore stayed alive for the lifetime of the process.

## How

- Add `BoundedCache<TKey, TValue>` (`src/Meziantou.Analyzer/Internals/BoundedCache.cs`): a thread-safe cache that keeps at most `Capacity` entries and removes the least recently used ones when the capacity is exceeded.
  - The lookups stay lock-free: a `ConcurrentDictionary` plus an interlocked "last usage" stamp on each entry.
  - The eviction takes a lock, sorts a snapshot by last usage, and removes a quarter of the entries, so it runs at most once per `Capacity / 4` additions instead of at every addition once the cache is full.
- `RegexCache` uses it with a capacity of 128. The valid and the invalid patterns share the cache, so the parse errors are bounded too, and the transient invalid patterns age out because the configured patterns are used at every analysis while the transient ones are not.

The callers keep the `Regex` they were given, so an eviction never invalidates a regex in use: it only means that pattern is parsed again later. The doc comments that claimed a pattern is parsed "only once" were updated accordingly.

## Notes for the reviewer

- `lock (new object())` is rejected by this repository's own MA0158, so the eviction lock is a `System.Threading.Lock` (polyfilled for `netstandard2.0`).
- `BoundedCacheTests` covers the invalid capacity, one factory call per key, the count staying `<= Capacity` while adding 1000 distinct keys, and the least recently used entry being the one evicted.

## Validation

- `dotnet build` (all Roslyn versions, both target frameworks): succeeded, 0 warnings.
- Full test suites pass: roslyn5.9 (4184 tests) and roslyn4.8 (4068 tests), which include the 4 new tests.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown change.