### PR TITLE
Do not report MA0192 when the HasFlag rewrite reorders an effectful operand

### DIFF
--- a/docs/Rules/MA0192.md
+++ b/docs/Rules/MA0192.md
@@ -23,6 +23,8 @@ The compared flag doesn't have to be a constant. `(value & flags) == flags` is r
 
 Expressions that may return a different value on each evaluation, such as properties, method calls, or `volatile` fields, are not reported.
 
+When the flag is not a constant, the rewrite must not change the order in which the operands are evaluated. `value.HasFlag(flags)` reads `value` before `flags` and drops the duplicated read of `flags`, so the check is only reported when `value` is already evaluated before every read of `flags`, or when evaluating `value` cannot change `flags`. For instance, `(flags & Compute()) == flags` is not reported, as `Compute()` could assign a new value to `flags`.
+
 For comparisons against `0`, the enum member used in the bitwise `&` must be a single-bit value (for example `1`, `2`, `4`, `8`, ...). Combined values are ignored.
 
 Zero-valued enum members are not reported by this rule. They are covered by [MA0201](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0201.md).

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseHasFlagMethodFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseHasFlagMethodFixer.cs
@@ -96,7 +96,7 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
         {
             if (TryGetComparedOperand(patternOperation, out var comparedOperand, out var negate))
             {
-                pattern = GetFromBitwiseAnd(andOperation, comparedOperand, operationExpression, negate);
+                pattern = GetFromBitwiseAnd(andOperation, comparedOperand, operationExpression, negate, comparedOperandEvaluatedFirst: false);
                 return pattern is not null;
             }
         }
@@ -137,14 +137,14 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
 
         if (leftOperand is IBinaryOperation { OperatorKind: BinaryOperatorKind.And } leftBitwiseAnd)
         {
-            var pattern = GetFromBitwiseAnd(leftBitwiseAnd, rightOperand, operationExpression, negate);
+            var pattern = GetFromBitwiseAnd(leftBitwiseAnd, rightOperand, operationExpression, negate, comparedOperandEvaluatedFirst: false);
             if (pattern is not null)
                 return pattern;
         }
 
         if (rightOperand is IBinaryOperation { OperatorKind: BinaryOperatorKind.And } rightBitwiseAnd)
         {
-            var pattern = GetFromBitwiseAnd(rightBitwiseAnd, leftOperand, operationExpression, negate);
+            var pattern = GetFromBitwiseAnd(rightBitwiseAnd, leftOperand, operationExpression, negate, comparedOperandEvaluatedFirst: true);
             if (pattern is not null)
                 return pattern;
         }
@@ -152,22 +152,24 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
         return null;
     }
 
-    private static HasFlagPattern? GetFromBitwiseAnd(IBinaryOperation bitwiseAndOperation, IOperation comparedOperand, ExpressionSyntax operationExpression, bool negate)
+    private static HasFlagPattern? GetFromBitwiseAnd(IBinaryOperation bitwiseAndOperation, IOperation comparedOperand, ExpressionSyntax operationExpression, bool negate, bool comparedOperandEvaluatedFirst)
     {
         var leftOperand = bitwiseAndOperation.LeftOperand.UnwrapImplicitConversions();
         var rightOperand = bitwiseAndOperation.RightOperand.UnwrapImplicitConversions();
         comparedOperand = comparedOperand.UnwrapImplicitConversions();
 
-        if (TryGetEnumFlagReference(rightOperand, comparedOperand, out var flagOperation, out var comparedWithZero) &&
+        if (TryGetEnumFlagReference(rightOperand, comparedOperand, out var flagOperation, out var comparedWithZero, out var isConstantFlag) &&
             IsValidPattern(leftOperand, flagOperation) &&
+            UseHasFlagMethodCommon.CanRewriteToHasFlag(leftOperand, isConstantFlag, preservesEvaluationOrder: !comparedOperandEvaluatedFirst) &&
             leftOperand.Syntax is ExpressionSyntax enumValueExpression &&
             flagOperation.Syntax is ExpressionSyntax flagExpression)
         {
             return new(operationExpression, enumValueExpression, flagExpression, comparedWithZero ? !negate : negate);
         }
 
-        if (TryGetEnumFlagReference(leftOperand, comparedOperand, out flagOperation, out comparedWithZero) &&
+        if (TryGetEnumFlagReference(leftOperand, comparedOperand, out flagOperation, out comparedWithZero, out isConstantFlag) &&
             IsValidPattern(rightOperand, flagOperation) &&
+            UseHasFlagMethodCommon.CanRewriteToHasFlag(rightOperand, isConstantFlag, preservesEvaluationOrder: false) &&
             rightOperand.Syntax is ExpressionSyntax enumValueExpression2 &&
             flagOperation.Syntax is ExpressionSyntax flagExpression2)
         {
@@ -177,7 +179,7 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
         return null;
     }
 
-    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IOperation? flagOperation, out bool comparedWithZero)
+    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IOperation? flagOperation, out bool comparedWithZero, out bool isConstantFlag)
     {
         potentialFlag = potentialFlag.UnwrapImplicitConversions();
         comparedOperand = comparedOperand.UnwrapImplicitConversions();
@@ -192,6 +194,7 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
             {
                 flagOperation = secondFieldReference;
                 comparedWithZero = false;
+                isConstantFlag = true;
                 return true;
             }
 
@@ -199,6 +202,7 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
             {
                 flagOperation = firstFieldReference;
                 comparedWithZero = true;
+                isConstantFlag = true;
                 return true;
             }
         }
@@ -207,11 +211,13 @@ public sealed class UseHasFlagMethodFixer : CodeFixProvider
         {
             flagOperation = comparedOperand;
             comparedWithZero = false;
+            isConstantFlag = comparedOperand.ConstantValue.HasValue;
             return true;
         }
 
         flagOperation = null;
         comparedWithZero = false;
+        isConstantFlag = false;
         return false;
     }
 

--- a/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseHasFlagMethodAnalyzer.cs
@@ -252,7 +252,7 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
         {
             if (TryGetComparedOperand(patternOperation, out var comparedOperand, out _))
             {
-                pattern = GetFromBitwiseAnd(andOperation, comparedOperand);
+                pattern = GetFromBitwiseAnd(andOperation, comparedOperand, comparedOperandEvaluatedFirst: false);
                 return pattern is not null;
             }
         }
@@ -268,14 +268,14 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
 
         if (leftOperand is IBinaryOperation { OperatorKind: BinaryOperatorKind.And } leftBitwiseAnd)
         {
-            var pattern = GetFromBitwiseAnd(leftBitwiseAnd, rightOperand);
+            var pattern = GetFromBitwiseAnd(leftBitwiseAnd, rightOperand, comparedOperandEvaluatedFirst: false);
             if (pattern is not null)
                 return pattern;
         }
 
         if (rightOperand is IBinaryOperation { OperatorKind: BinaryOperatorKind.And } rightBitwiseAnd)
         {
-            var pattern = GetFromBitwiseAnd(rightBitwiseAnd, leftOperand);
+            var pattern = GetFromBitwiseAnd(rightBitwiseAnd, leftOperand, comparedOperandEvaluatedFirst: true);
             if (pattern is not null)
                 return pattern;
         }
@@ -283,20 +283,22 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
-    private static HasFlagPattern? GetFromBitwiseAnd(IBinaryOperation bitwiseAndOperation, IOperation comparedOperand)
+    private static HasFlagPattern? GetFromBitwiseAnd(IBinaryOperation bitwiseAndOperation, IOperation comparedOperand, bool comparedOperandEvaluatedFirst)
     {
         var leftOperand = bitwiseAndOperation.LeftOperand.UnwrapImplicitConversions();
         var rightOperand = bitwiseAndOperation.RightOperand.UnwrapImplicitConversions();
         comparedOperand = comparedOperand.UnwrapImplicitConversions();
 
-        if (TryGetEnumFlagReference(rightOperand, comparedOperand, out var flagOperation) &&
-            IsValidPattern(leftOperand, flagOperation))
+        if (TryGetEnumFlagReference(rightOperand, comparedOperand, out var flagOperation, out var isConstantFlag) &&
+            IsValidPattern(leftOperand, flagOperation) &&
+            UseHasFlagMethodCommon.CanRewriteToHasFlag(leftOperand, isConstantFlag, preservesEvaluationOrder: !comparedOperandEvaluatedFirst))
         {
             return new(leftOperand, flagOperation);
         }
 
-        if (TryGetEnumFlagReference(leftOperand, comparedOperand, out flagOperation) &&
-            IsValidPattern(rightOperand, flagOperation))
+        if (TryGetEnumFlagReference(leftOperand, comparedOperand, out flagOperation, out isConstantFlag) &&
+            IsValidPattern(rightOperand, flagOperation) &&
+            UseHasFlagMethodCommon.CanRewriteToHasFlag(rightOperand, isConstantFlag, preservesEvaluationOrder: false))
         {
             return new(rightOperand, flagOperation);
         }
@@ -304,7 +306,7 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
-    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IOperation? flagOperation)
+    private static bool TryGetEnumFlagReference(IOperation potentialFlag, IOperation comparedOperand, [NotNullWhen(true)] out IOperation? flagOperation, out bool isConstantFlag)
     {
         potentialFlag = potentialFlag.UnwrapImplicitConversions();
         comparedOperand = comparedOperand.UnwrapImplicitConversions();
@@ -319,12 +321,14 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
                 !NumericHelpers.IsZero(firstFieldReference.Field.ConstantValue))
             {
                 flagOperation = secondFieldReference;
+                isConstantFlag = true;
                 return true;
             }
 
             if (comparedOperand.IsConstantZero() && NumericHelpers.IsSingleBitSet(firstFieldReference.Field.ConstantValue))
             {
                 flagOperation = firstFieldReference;
+                isConstantFlag = true;
                 return true;
             }
         }
@@ -332,10 +336,12 @@ public sealed class UseHasFlagMethodAnalyzer : DiagnosticAnalyzer
         if (!potentialFlag.IsConstantZero() && UseHasFlagMethodCommon.AreEquivalentOperands(potentialFlag, comparedOperand))
         {
             flagOperation = comparedOperand;
+            isConstantFlag = comparedOperand.ConstantValue.HasValue;
             return true;
         }
 
         flagOperation = null;
+        isConstantFlag = false;
         return false;
     }
 

--- a/src/Meziantou.Analyzer/Rules/UseHasFlagMethodCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseHasFlagMethodCommon.cs
@@ -23,4 +23,39 @@ internal static class UseHasFlagMethodCommon
             _ => false,
         };
     }
+
+    /// <summary>
+    /// Determines if replacing the flag check by <c>value.HasFlag(flag)</c> preserves the semantics of the check.
+    /// The rewrite evaluates the value operand before the flag operand and drops the duplicated read of the flag,
+    /// so it is only valid when evaluating the value operand cannot change the value of the flag.
+    /// </summary>
+    /// <param name="enumValueOperation">The operand the <c>HasFlag</c> method is called on.</param>
+    /// <param name="isConstantFlag">Whether the flag is a compile-time constant, in which case its reads are stable.</param>
+    /// <param name="preservesEvaluationOrder">Whether the value operand is already evaluated before every read of the flag.</param>
+    public static bool CanRewriteToHasFlag(IOperation enumValueOperation, bool isConstantFlag, bool preservesEvaluationOrder)
+    {
+        return isConstantFlag || preservesEvaluationOrder || IsSideEffectFree(enumValueOperation);
+    }
+
+    /// <summary>
+    /// Determines if evaluating the operation cannot have any observable side effect, so that it can be reordered with the read of the flag.
+    /// </summary>
+    private static bool IsSideEffectFree(IOperation? operation)
+    {
+        if (operation is null)
+            return false;
+
+        if (operation.ConstantValue.HasValue)
+            return true;
+
+        return operation switch
+        {
+            IParameterReferenceOperation or ILocalReferenceOperation or IInstanceReferenceOperation or ILiteralOperation => true,
+            IFieldReferenceOperation fieldReference => fieldReference.Field.IsStatic || IsSideEffectFree(fieldReference.Instance),
+            IConversionOperation conversion => conversion.OperatorMethod is null && IsSideEffectFree(conversion.Operand),
+            IUnaryOperation unary => unary.OperatorMethod is null && IsSideEffectFree(unary.Operand),
+            IBinaryOperation binary => binary.OperatorMethod is null && IsSideEffectFree(binary.LeftOperand) && IsSideEffectFree(binary.RightOperand),
+            _ => false,
+        };
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseHasFlagMethodAnalyzerTests.cs
@@ -963,6 +963,250 @@ public sealed class UseHasFlagMethodAnalyzerTests
         return test.RunAsync();
     }
 
+    [Fact]
+    public Task SideEffectBeforeFlagRead_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                private MyEnum _comparand = MyEnum.Flag1;
+
+                MyEnum Change()
+                {
+                    _comparand = MyEnum.Flag2;
+                    return MyEnum.Flag2;
+                }
+
+                bool M() => (_comparand & Change()) == _comparand;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task SideEffectAfterComparedOperandRead_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                private MyEnum _comparand = MyEnum.Flag1;
+
+                MyEnum Change()
+                {
+                    _comparand = MyEnum.Flag2;
+                    return MyEnum.Flag2;
+                }
+
+                bool M() => _comparand == (Change() & _comparand);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task SideEffectBeforeFlagRead_ReversedAndOperands_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                private MyEnum _comparand = MyEnum.Flag1;
+
+                MyEnum Change()
+                {
+                    _comparand = MyEnum.Flag2;
+                    return MyEnum.Flag2;
+                }
+
+                bool M() => _comparand == (_comparand & Change());
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task SideEffectWithPropertyFlag_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                private MyEnum _comparand = MyEnum.Flag1;
+
+                MyEnum Value => _comparand;
+
+                bool M(MyEnum comparand) => comparand == (Value & comparand);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task SideEffectBeforeConstantFlagRead_ReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                MyEnum Change() => MyEnum.Flag2;
+
+                bool M() => {|MA0192:MyEnum.Flag1 == (Change() & MyEnum.Flag1)|};
+            }
+            """;
+        test.FixedCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                MyEnum Change() => MyEnum.Flag2;
+
+                bool M() => Change().HasFlag(MyEnum.Flag1);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task SideEffectAfterFlagRead_ReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                private MyEnum _comparand = MyEnum.Flag1;
+
+                MyEnum Change()
+                {
+                    _comparand = MyEnum.Flag2;
+                    return MyEnum.Flag2;
+                }
+
+                bool M() => {|MA0192:(Change() & _comparand) == _comparand|};
+            }
+            """;
+        test.FixedCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                private MyEnum _comparand = MyEnum.Flag1;
+
+                MyEnum Change()
+                {
+                    _comparand = MyEnum.Flag2;
+                    return MyEnum.Flag2;
+                }
+
+                bool M() => Change().HasFlag(_comparand);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task SideEffectFreeValue_ReversedAndOperands_ReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                bool M(MyEnum value, MyEnum comparand) => {|MA0192:comparand == (comparand & (value | MyEnum.Flag2))|};
+            }
+            """;
+        test.FixedCode = """
+            [System.Flags]
+            enum MyEnum
+            {
+                None = 0,
+                Flag1 = 1,
+                Flag2 = 2,
+            }
+
+            class Sample
+            {
+                bool M(MyEnum value, MyEnum comparand) => (value | MyEnum.Flag2).HasFlag(comparand);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Theory]
     [InlineData("sbyte")]
     [InlineData("byte")]


### PR DESCRIPTION
## Problem

`value.HasFlag(flag)` evaluates the value operand **before** the flag operand, and drops the duplicated read of the flag. `AreEquivalentOperands` only proves that both flag reads target the same storage (parameter, local, field) — not that the value is stable across the evaluation of the other operand.

So MA0192 reported, and its fixer actually applied, an unsound rewrite:

```csharp
enum E { A = 1, B = 2 }
class C
{
    E flag = E.A;
    E Change() { flag = E.B; return E.B; }

    bool M() => (flag & Change()) == flag;   // false: flag is read as A, then as B
}
```

becomes

```csharp
bool M() => Change().HasFlag(flag);          // true: Change() runs before flag is read
```

Both versions compile, so the fix silently changes behaviour.

## Fix

The pattern is now gated on `UseHasFlagMethodCommon.CanRewriteToHasFlag`, used by both the analyzer and the fixer. The rewrite is accepted only when one of these holds:

- the flag is a compile-time constant — its reads are stable regardless of ordering;
- the value operand is already evaluated before every read of the flag. That is only `(value & flag) == flag` / `(value & flag) is …`, where the `&` is the first-evaluated side of the comparison **and** the flag is the right `&` operand;
- the value operand is side-effect free: constants, parameter / local / `this` / field references, and built-in conversions and unary/binary operators over those.

To support that, `TryGetEnumFlagReference` gained an `isConstantFlag` output and `GetFromBitwiseAnd` a `comparedOperandEvaluatedFirst` parameter, so **comparison** operand reversal (`flag == (… & …)`) is covered as well as **bitwise** operand reversal (`(flag & value)`). The three unsafe shapes — `(flag & value) == flag`, `flag == (value & flag)` and `flag == (flag & value)` — now require a pure value operand.

Constant-flag checks (`(Change() & E.A) == E.A`, the `== 0` / `!= 0` forms, the `is` patterns) are unaffected, since reading a constant cannot observe a mutation.

## Notes for the reviewer

- **Deliberate trade-off:** a property getter as the value operand is treated as effectful, so `comparand == (Value & comparand)` is no longer reported. That is a false negative when the getter is pure, but proving getter purity is not feasible here and the shape is unusual. False negatives are the safe side for a rule whose fixer rewrites code.
- `IParenthesizedOperation` is not part of the purity walk — the C# compiler does not produce it.
- `docs/Rules/MA0192.md` documents the new evaluation-order requirement.

## Tests

7 tests added to `UseHasFlagMethodAnalyzerTests`:

- 4 no-diagnostic: the reported repro, comparison reversal, bitwise reversal, and a property getter as the value operand.
- 3 still-reported: constant flag with an effectful value, the order-preserving shape with an effectful value, and a pure compound value operand (`value | E.Flag2`) in a reversed shape.

I verified the 4 negative tests genuinely cover the bug by temporarily stubbing `CanRewriteToHasFlag` to `true`: all 4 failed, then passed once restored.

## Verification

- `dotnet build` — clean.
- MA0192 test class (49 tests) — passes on roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- Full roslyn5.9 suite — 4187/4187 pass.
- `dotnet run --project src/DocumentationGenerator` — exits 0, no further markdown changes.