### PR TITLE
Bound the pooled queues by the number of items they contained

### DIFF
--- a/src/Meziantou.Analyzer/Internals/ObjectPool.cs
+++ b/src/Meziantou.Analyzer/Internals/ObjectPool.cs
@@ -1,6 +1,7 @@
 #pragma warning disable MA0048 // File name must match type name
 #pragma warning disable RS1035 // Do not use APIs banned for analyzers
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Meziantou.Analyzer.Internals;
 
@@ -42,7 +43,7 @@ internal static class ObjectPool
         return provider.Create(new StringBuilderPooledObjectPolicy());
     }
 
-    public static ObjectPool<Queue<T>> CreateQueuePool<T>()
+    public static ObjectPool<PooledQueue<T>> CreateQueuePool<T>()
     {
         var provider = new DefaultObjectPoolProvider();
         return provider.Create(new QueuePooledObjectPolicy<T>());
@@ -354,30 +355,72 @@ internal sealed class StringBuilderPooledObjectPolicy : PooledObjectPolicy<Strin
 }
 
 /// <summary>
-/// A policy for pooling <see cref="Queue{T}"/> instances.
+/// A queue that keeps track of the maximum number of items it contained, so a pool can detect the instances whose
+/// backing array grew too much. <see cref="Queue{T}.Count"/> cannot be used for that purpose because the consumers
+/// usually dequeue all the items before returning the queue to the pool, and <see cref="Queue{T}.Clear"/> does not
+/// release the backing array.
+/// </summary>
+/// <typeparam name="T">The type of the items of the queue.</typeparam>
+internal sealed class PooledQueue<T>
+{
+    private readonly Queue<T> _queue = new();
+
+    /// <summary>
+    /// Gets the number of items contained in the queue.
+    /// </summary>
+    public int Count => _queue.Count;
+
+    /// <summary>
+    /// Gets the maximum number of items the queue contained since the last call to <see cref="Clear"/>.
+    /// </summary>
+    public int MaximumCount { get; private set; }
+
+    public void Enqueue(T item)
+    {
+        _queue.Enqueue(item);
+        if (_queue.Count > MaximumCount)
+        {
+            MaximumCount = _queue.Count;
+        }
+    }
+
+    public bool TryDequeue([MaybeNullWhen(false)] out T result)
+    {
+        return _queue.TryDequeue(out result);
+    }
+
+    public void Clear()
+    {
+        _queue.Clear();
+        MaximumCount = 0;
+    }
+}
+
+/// <summary>
+/// A policy for pooling <see cref="PooledQueue{T}"/> instances.
 /// </summary>
 /// <typeparam name="T">The type of the items of the pooled queues.</typeparam>
-internal sealed class QueuePooledObjectPolicy<T> : PooledObjectPolicy<Queue<T>>
+internal sealed class QueuePooledObjectPolicy<T> : PooledObjectPolicy<PooledQueue<T>>
 {
     /// <summary>
-    /// Gets or sets the maximum number of items a <see cref="Queue{T}"/> can contain to be retained,
-    /// when <see cref="Return(Queue{T})"/> is invoked.
+    /// Gets or sets the maximum number of items a <see cref="PooledQueue{T}"/> can have contained to be retained,
+    /// when <see cref="Return(PooledQueue{T})"/> is invoked.
     /// </summary>
     /// <value>Defaults to <c>1024</c>.</value>
     public int MaximumRetainedCount { get; set; } = 1024;
 
     /// <inheritdoc />
-    public override Queue<T> Create()
+    public override PooledQueue<T> Create()
     {
-        return new Queue<T>();
+        return new PooledQueue<T>();
     }
 
     /// <inheritdoc />
-    public override bool Return(Queue<T> obj)
+    public override bool Return(PooledQueue<T> obj)
     {
-        if (obj.Count > MaximumRetainedCount)
+        if (obj.MaximumCount > MaximumRetainedCount)
         {
-            // Too big. Discard this one.
+            // The backing array grew too much. Discard this one.
             return false;
         }
 

--- a/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
@@ -6,7 +6,7 @@ namespace Meziantou.Analyzer.Rules;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly ObjectPool<Queue<SyntaxNode>> NodeQueuePool = ObjectPool.CreateQueuePool<SyntaxNode>();
+    private static readonly ObjectPool<PooledQueue<SyntaxNode>> NodeQueuePool = ObjectPool.CreateQueuePool<SyntaxNode>();
 
     private static readonly HashSet<string> CSharpKeywords = new(StringComparer.Ordinal)
     {

--- a/tests/Meziantou.Analyzer.Test/Internals/ObjectPoolTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Internals/ObjectPoolTests.cs
@@ -12,7 +12,7 @@ public sealed class ObjectPoolTests
         queue.Enqueue(new object());
 
         Assert.True(policy.Return(queue));
-        Assert.Empty(queue);
+        Assert.Equal(0, queue.Count);
     }
 
     [Fact]
@@ -27,6 +27,33 @@ public sealed class ObjectPoolTests
     }
 
     [Fact]
+    public void QueuePooledObjectPolicy_DoesNotRetainOversizedQueuesThatWereDrained()
+    {
+        var policy = new QueuePooledObjectPolicy<object> { MaximumRetainedCount = 1 };
+        var queue = policy.Create();
+        queue.Enqueue(new object());
+        queue.Enqueue(new object());
+        while (queue.TryDequeue(out _))
+        {
+        }
+
+        Assert.Equal(0, queue.Count);
+        Assert.False(policy.Return(queue));
+    }
+
+    [Fact]
+    public void QueuePooledObjectPolicy_ResetsTheMaximumCountOnReturn()
+    {
+        var policy = new QueuePooledObjectPolicy<object> { MaximumRetainedCount = 1 };
+        var queue = policy.Create();
+        queue.Enqueue(new object());
+
+        Assert.True(policy.Return(queue));
+        Assert.Equal(0, queue.MaximumCount);
+        Assert.True(policy.Return(queue));
+    }
+
+    [Fact]
     public void QueuePool_DoesNotKeepTheItemsAlive()
     {
         var pool = ObjectPool.CreateQueuePool<object>();
@@ -34,6 +61,22 @@ public sealed class ObjectPoolTests
         queue.Enqueue(new object());
         pool.Return(queue);
 
-        Assert.Empty(pool.Get());
+        Assert.Equal(0, pool.Get().Count);
+    }
+
+    [Fact]
+    public void QueuePool_DoesNotReuseADrainedOversizedQueue()
+    {
+        var pool = ObjectPool.Create(new QueuePooledObjectPolicy<object> { MaximumRetainedCount = 1 });
+        var queue = pool.Get();
+        queue.Enqueue(new object());
+        queue.Enqueue(new object());
+        while (queue.TryDequeue(out _))
+        {
+        }
+
+        pool.Return(queue);
+
+        Assert.NotSame(queue, pool.Get());
     }
 }


### PR DESCRIPTION
## What

`QueuePooledObjectPolicy<T>.Return` discarded a queue when its `Count` was greater than `MaximumRetainedCount`, so it never discarded anything: the consumers dequeue all the items before returning the queue to the pool, so `Count` is `0` whatever the number of items the queue contained. As `Queue<T>.Clear` does not release the backing array, the static pool retained the array of a queue that grew a lot, such as the one `UseLangwordInXmlCommentAnalyzer` uses to walk an unusually wide documentation comment. The items themselves were released by `Clear`, so what was retained was the array storage, not the syntax nodes.

`PooledQueue<T>` now wraps the `Queue<T>` and keeps track of the maximum number of items it contained since it was last cleared, and the policy uses that high-water mark as its bound. `MaximumRetainedCount` keeps its default of `1024`, and is now an approximation of the capacity of the backing array, which is within a factor of about 2 of the peak count.

## Why not the capacity of the queue

The assembly loaded by Roslyn is the `netstandard2.0` one, where `Queue<T>.Capacity` does not exist: it was added in .NET 9. A check guarded by `#if NET9_0_OR_GREATER` would only have bounded the `net10.0` build used by the tests, and not the analyzer that ships. Tracking the high-water mark behaves the same way for all the target frameworks and needs no reflection.

## Notes for the reviewer

- `UseLangwordInXmlCommentAnalyzer` only changes the type of its pool field; the traversal itself is untouched.
- `PooledQueue<T>` exposes only what the consumers and the policy need (`Count`, `MaximumCount`, `Enqueue`, `TryDequeue`, `Clear`). It is not enumerable, so one existing assertion moved from `Assert.Empty` to `Assert.Equal(0, queue.Count)`.

## Tests

Two tests cover the grow, drain and return path the previous bound missed, one on the policy and one on the pool. Reverting only the `MaximumCount` comparison back to `Count` makes exactly those two fail.

- `dotnet build`: succeeded for the five Roslyn versions, 0 warnings.
- `dotnet test --filter "FullyQualifiedName~ObjectPoolTests|FullyQualifiedName~UseLangwordInXmlComment"`: 160 passed, 0 failed (32 tests for each of the 5 Roslyn versions).
- `dotnet run --project src/DocumentationGenerator`: exit code 0, no markdown change.