### PR TITLE
Report MA0072 and MA0086 on throw expressions

### DIFF
--- a/docs/Rules/MA0072.md
+++ b/docs/Rules/MA0072.md
@@ -17,3 +17,27 @@ finally
     throw new Exception("Finally Exception");
 }
 ````
+
+Throw expressions are also reported:
+
+````c#
+try
+{
+}
+finally
+{
+    value = value ?? throw new Exception("Finally Exception"); // non-compliant
+}
+````
+
+A lambda or a local function declared in a `finally` block is not reported, as it is not executed by the `finally` block:
+
+````c#
+try
+{
+}
+finally
+{
+    Action action = () => throw new Exception(); // compliant
+}
+````

--- a/docs/Rules/MA0086.md
+++ b/docs/Rules/MA0086.md
@@ -12,3 +12,29 @@ class Test
     }
 }
 ````
+
+Throw expressions are also reported:
+
+````csharp
+class Test
+{
+    string _value;
+
+    ~Test()
+    {
+        _value = _value ?? throw new Exception(); // non-compliant
+    }
+}
+````
+
+A lambda or a local function declared in a finalizer is not reported, as it is not executed by the finalizer:
+
+````csharp
+class Test
+{
+    ~Test()
+    {
+        Action action = () => throw new Exception(); // compliant
+    }
+}
+````

--- a/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinalizerAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinalizerAnalyzer.cs
@@ -1,6 +1,3 @@
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -23,17 +20,22 @@ public sealed class DoNotThrowFromFinalizerAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSyntaxNodeAction(AnalyzeFinalizer, SyntaxKind.DestructorDeclaration);
+        context.RegisterOperationAction(AnalyzeThrow, OperationKind.Throw);
     }
 
-    private static void AnalyzeFinalizer(SyntaxNodeAnalysisContext context)
+    private static void AnalyzeThrow(OperationAnalysisContext context)
     {
-        var node = (DestructorDeclarationSyntax)context.Node;
-        foreach (var throwStatement in node.DescendantNodes().Where(IsThrowStatement))
-        {
-            context.ReportDiagnostic(Rule, throwStatement);
-        }
-    }
+        if (context.ContainingSymbol is not IMethodSymbol { MethodKind: MethodKind.Destructor })
+            return;
 
-    private static bool IsThrowStatement(SyntaxNode node) => node.IsKind(SyntaxKind.ThrowStatement);
+        var operation = context.Operation;
+        for (var parent = operation.Parent; parent is not null; parent = parent.Parent)
+        {
+            // A lambda or a local function declared in a finalizer is not executed by the finalizer
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+                return;
+        }
+
+        context.ReportDiagnostic(Rule, operation);
+    }
 }

--- a/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinallyBlockAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotThrowFromFinallyBlockAnalyzer.cs
@@ -1,6 +1,3 @@
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -23,23 +20,24 @@ public sealed class DoNotThrowFromFinallyBlockAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSyntaxNodeAction(AnalyzeFinallyClause, SyntaxKind.FinallyClause);
+        context.RegisterOperationAction(AnalyzeThrow, OperationKind.Throw);
     }
 
-    private static void AnalyzeFinallyClause(SyntaxNodeAnalysisContext context)
+    private static void AnalyzeThrow(OperationAnalysisContext context)
     {
-        if (context.Node is not FinallyClauseSyntax finallyClause)
-            return;
-
-        var finallyBlock = finallyClause.Block;
-        if (finallyBlock is null)
-            return;
-
-        foreach (var throwStatement in finallyBlock.DescendantNodes().Where(IsThrowStatement))
+        var operation = context.Operation;
+        var child = operation;
+        for (var parent = operation.Parent; parent is not null; child = parent, parent = parent.Parent)
         {
-            context.ReportDiagnostic(Rule, throwStatement);
+            // A lambda or a local function declared in a finally block is not executed by the finally block
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+                return;
+
+            if (parent is ITryOperation tryOperation && tryOperation.Finally == child)
+            {
+                context.ReportDiagnostic(Rule, operation);
+                return;
+            }
         }
     }
-
-    private static bool IsThrowStatement(SyntaxNode node) => node.IsKind(SyntaxKind.ThrowStatement);
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinalizerAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinalizerAnalyzerTests.cs
@@ -104,4 +104,94 @@ public sealed class DoNotThrowFromFinalizerAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task FinalizerThrowsFromThrowExpression_DiagnosticIsReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                ~TestClass()
+                {
+                    string value = null;
+                    value = value ?? {|MA0086:throw new System.Exception()|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinalizerRethrowsFromCatchBlock_DiagnosticIsReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                ~TestClass()
+                {
+                    try
+                    {
+                    }
+                    catch
+                    {
+                        {|MA0086:throw;|}
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinalizerDeclaresLambdaThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                ~TestClass()
+                {
+                    System.Action action = () => throw new System.Exception();
+                    System.Func<string> func = () => throw new System.Exception();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinalizerDeclaresLocalFunctionThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                ~TestClass()
+                {
+                    void LocalFunction() => throw new System.Exception();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MethodThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test() => throw new System.Exception();
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinallyBlockAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotThrowFromFinallyBlockAnalyzerTests.cs
@@ -172,4 +172,158 @@ public sealed class DoNotThrowFromFinallyBlockAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task FinallyThrowsFromThrowExpression_DiagnosticIsReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test(string value)
+                {
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        value = value ?? {|MA0072:throw new System.Exception()|};
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinallyRethrowsFromNestedCatchBlock_DiagnosticIsReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        try
+                        {
+                        }
+                        catch
+                        {
+                            {|MA0072:throw;|}
+                        }
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TryBlockThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    try
+                    {
+                        throw new System.Exception();
+                    }
+                    finally
+                    {
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinallyDeclaresLambdaThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        System.Action action = () => throw new System.Exception();
+                        System.Func<string> func = () => throw new System.Exception();
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FinallyDeclaresLocalFunctionThatThrows_NoDiagnosticReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        void LocalFunction() => throw new System.Exception();
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task LambdaDeclaredInFinallyHasItsOwnFinallyThatThrows_DiagnosticIsReported()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TestClass
+            {
+                void Test()
+                {
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        System.Action action = () =>
+                        {
+                            try
+                            {
+                            }
+                            finally
+                            {
+                                {|MA0072:throw new System.Exception();|}
+                            }
+                        };
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## What changed

`DoNotThrowFromFinallyBlockAnalyzer` (MA0072) and `DoNotThrowFromFinalizerAnalyzer` (MA0086) both filtered on `SyntaxKind.ThrowStatement`, so neither reported a *throw expression* executed by a `finally` block or by a finalizer:

```csharp
finally { s = s ?? throw new Exception(); }   // MA0072 was not reported
~C() { s = s ?? throw new Exception(); }      // MA0086 was not reported
```

These have exactly the exception behavior the two rules exist to catch.

Both analyzers now register on `OperationKind.Throw` and analyze `IThrowOperation`, which covers throw statements and throw expressions alike.

- **MA0072** walks the parent chain of the throw operation and reports when it reaches an `ITryOperation` whose `Finally` branch contains the throw.
- **MA0086** checks that `ContainingSymbol` is a `MethodKind.Destructor`.

## Behavior change: nested functions

Both analyzers previously used `DescendantNodes()`, which crossed nested function boundaries. They now stop at `IAnonymousFunctionOperation` and `ILocalFunctionOperation`, so a lambda or a local function merely *declared* in a `finally` block or in a finalizer is no longer reported — it is not executed there:

```csharp
finally
{
    Action action = () => throw new Exception(); // no longer reported
}
```

A nested function that has its own `finally` block is still reported, since the walk finds that inner `finally` first.

## Tests

11 cases added to the existing test classes, covering throw expressions, `throw;` rethrow from a nested `catch`, a throw in the `try` block (no diagnostic), lambdas and local functions declared in the `finally`/finalizer (no diagnostic), a lambda's own `finally` (diagnostic), and a plain method throwing (no MA0086).

## Verification

- `dotnet build` on the full solution: 0 warnings, 0 errors.
- The 21 tests of both classes pass on every supported Roslyn version (4.8, 4.14, 5.0, 5.6, 5.9).
- `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes.

Docs for both rules were updated with the throw-expression and nested-function behavior.