### PR TITLE
Add MA0226: EventSource class should be sealed

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0223](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0223.md)|Design|JsonSourceGenerationOptions should set RespectRequiredConstructorParameters|⚠️|❌|✔️|❌|
 |[MA0224](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0224.md)|Design|JsonSerializerOptions should set RespectNullableAnnotations|⚠️|❌|✔️|❌|
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|⚠️|❌|✔️|❌|
+|[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|⚠️|❌|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -224,6 +224,7 @@
 |[MA0223](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0223.md)|Design|JsonSourceGenerationOptions should set RespectRequiredConstructorParameters|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0224](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0224.md)|Design|JsonSerializerOptions should set RespectNullableAnnotations|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|<span title='Warning'>⚠️</span>|❌|✔️|❌|
+|[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0226.md
+++ b/docs/Rules/MA0226.md
@@ -1,0 +1,71 @@
+# MA0226 - EventSource class should be sealed
+<!-- sources -->
+Sources: [EventSourceMustBeSealedAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceMustBeSealedAnalyzer.cs), [EventSourceMustBeSealedFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/EventSourceMustBeSealedFixer.cs)
+<!-- sources -->
+
+## Description
+
+A class that derives from `EventSource` should be `sealed`. The only supported exception is the "Utility EventSource" pattern, where an `abstract` class shares code between event sources; `abstract` classes are not reported.
+
+Sealing an event source is a documented convention, and the runtime validates it: `EventSource.GenerateManifest` reports `Event source types must be sealed or abstract.` when the type is neither `sealed` nor `abstract`.
+
+Deriving from a concrete event source also breaks the derived type at runtime:
+
+- `EventSource` only walks through `abstract` base types when looking for the `EventSource` base class, so a class deriving from a concrete event source is not a valid event source.
+- The event metadata is built from the methods declared on the type itself, so the events declared by the base class are not registered for the derived type.
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+// ❌ Not sealed
+class SampleEventSource : EventSource
+{
+    public static SampleEventSource Log { get; } = new();
+
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+}
+
+// ✅ Sealed
+sealed class SampleEventSource : EventSource
+{
+    public static SampleEventSource Log { get; } = new();
+
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+}
+
+// ✅ "Utility EventSource": the shared code is in an abstract class
+abstract class UtilityEventSource : EventSource
+{
+    protected unsafe void WriteEvent(int eventId, int arg1, long arg2)
+    {
+        // Custom WriteEvent overload shared by the derived event sources
+    }
+}
+
+sealed class OptimizedEventSource : UtilityEventSource
+{
+    [Event(1)]
+    public void Start(int arg1, long arg2) => WriteEvent(1, arg1, arg2);
+}
+````
+
+## How to fix violations
+
+Add the `sealed` modifier to the class, or make it `abstract` when it is a "Utility EventSource" shared by other event sources.
+
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0226.severity = warning
+````
+
+## References
+
+- [EventSource class conventions](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventsource?WT.mc_id=DT-MVP-5003978#conventions)
+- [Instrument code to create EventSource events](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/eventsource-instrumentation?WT.mc_id=DT-MVP-5003978#best-practices)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/EventSourceMustBeSealedFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/EventSourceMustBeSealedFixer.cs
@@ -1,0 +1,38 @@
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class EventSourceMustBeSealedFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.EventSourceMustBeSealed);
+
+    public override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root?.FindNode(context.Span, getInnermostNodeForTie: true) is not TypeDeclarationSyntax nodeToFix)
+            return;
+
+        var title = "Add sealed modifier";
+        var codeAction = CodeAction.Create(
+            title,
+            ct => AddSealedModifier(context.Document, nodeToFix, ct),
+            equivalenceKey: title);
+
+        context.RegisterCodeFix(codeAction, context.Diagnostics);
+    }
+
+    private static async Task<Document> AddSealedModifier(Document document, TypeDeclarationSyntax nodeToFix, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        var modifiers = nodeToFix.Modifiers.Add(SyntaxKind.SealedKeyword);
+        editor.ReplaceNode(nodeToFix, nodeToFix.WithModifiers(modifiers).WithAdditionalAnnotations(Formatter.Annotation));
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -670,3 +670,6 @@ dotnet_diagnostic.MA0224.severity = error
 
 # MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0225.severity = error
+
+# MA0226: EventSource class should be sealed
+dotnet_diagnostic.MA0226.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -670,3 +670,6 @@ dotnet_diagnostic.MA0224.severity = suggestion
 
 # MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0225.severity = suggestion
+
+# MA0226: EventSource class should be sealed
+dotnet_diagnostic.MA0226.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -670,3 +670,6 @@ dotnet_diagnostic.MA0224.severity = warning
 
 # MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0225.severity = warning
+
+# MA0226: EventSource class should be sealed
+dotnet_diagnostic.MA0226.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -670,3 +670,6 @@ dotnet_diagnostic.MA0224.severity = none
 
 # MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0225.severity = none
+
+# MA0226: EventSource class should be sealed
+dotnet_diagnostic.MA0226.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -670,3 +670,6 @@ dotnet_diagnostic.MA0224.severity = none
 
 # MA0225: JsonSerializerOptions should set RespectRequiredConstructorParameters
 dotnet_diagnostic.MA0225.severity = none
+
+# MA0226: EventSource class should be sealed
+dotnet_diagnostic.MA0226.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -225,6 +225,7 @@ internal static class RuleIdentifiers
     public const string SetRespectRequiredConstructorParameters = "MA0223";
     public const string SetRespectNullableAnnotationsOnJsonSerializerOptions = "MA0224";
     public const string SetRespectRequiredConstructorParametersOnJsonSerializerOptions = "MA0225";
+    public const string EventSourceMustBeSealed = "MA0226";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/EventSourceMustBeSealedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventSourceMustBeSealedAnalyzer.cs
@@ -1,0 +1,52 @@
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class EventSourceMustBeSealedAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.EventSourceMustBeSealed,
+        title: "EventSource class should be sealed",
+        messageFormat: "EventSource class should be sealed",
+        RuleCategories.Design,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.EventSourceMustBeSealed));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(ctx =>
+        {
+            // "Microsoft.Diagnostics.Tracing.EventSource" is the type of the EventSource NuGet package
+            INamedTypeSymbol?[] eventSourceSymbols =
+            [
+                ctx.Compilation.GetBestTypeByMetadataName("System.Diagnostics.Tracing.EventSource"),
+                ctx.Compilation.GetBestTypeByMetadataName("Microsoft.Diagnostics.Tracing.EventSource"),
+            ];
+
+            if (Array.TrueForAll(eventSourceSymbols, symbol => symbol is null))
+                return;
+
+            ctx.RegisterSymbolAction(ctx =>
+            {
+                var symbol = (INamedTypeSymbol)ctx.Symbol;
+                if (symbol.TypeKind is not TypeKind.Class)
+                    return;
+
+                // Abstract EventSource classes are the supported way to share code between event sources ("Utility EventSource")
+                if (symbol.IsSealed || symbol.IsAbstract || symbol.IsStatic || symbol.IsImplicitlyDeclared)
+                    return;
+
+                if (Array.Exists(eventSourceSymbols, eventSourceSymbol => symbol.InheritsFrom(eventSourceSymbol)))
+                {
+                    ctx.ReportDiagnostic(Rule, symbol);
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/EventSourceMustBeSealedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventSourceMustBeSealedAnalyzer.cs
@@ -22,31 +22,39 @@ public sealed class EventSourceMustBeSealedAnalyzer : DiagnosticAnalyzer
 
         context.RegisterCompilationStartAction(ctx =>
         {
-            // "Microsoft.Diagnostics.Tracing.EventSource" is the type of the EventSource NuGet package
-            INamedTypeSymbol?[] eventSourceSymbols =
-            [
-                ctx.Compilation.GetBestTypeByMetadataName("System.Diagnostics.Tracing.EventSource"),
-                ctx.Compilation.GetBestTypeByMetadataName("Microsoft.Diagnostics.Tracing.EventSource"),
-            ];
-
-            if (Array.TrueForAll(eventSourceSymbols, symbol => symbol is null))
+            var analyzerContext = new AnalyzerContext(ctx.Compilation);
+            if (!analyzerContext.IsValid)
                 return;
 
-            ctx.RegisterSymbolAction(ctx =>
-            {
-                var symbol = (INamedTypeSymbol)ctx.Symbol;
-                if (symbol.TypeKind is not TypeKind.Class)
-                    return;
-
-                // Abstract EventSource classes are the supported way to share code between event sources ("Utility EventSource")
-                if (symbol.IsSealed || symbol.IsAbstract || symbol.IsStatic || symbol.IsImplicitlyDeclared)
-                    return;
-
-                if (Array.Exists(eventSourceSymbols, eventSourceSymbol => symbol.InheritsFrom(eventSourceSymbol)))
-                {
-                    ctx.ReportDiagnostic(Rule, symbol);
-                }
-            }, SymbolKind.NamedType);
+            ctx.RegisterSymbolAction(analyzerContext.AnalyzeNamedType, SymbolKind.NamedType);
         });
+    }
+
+    private sealed class AnalyzerContext(Compilation compilation)
+    {
+        private INamedTypeSymbol? EventSourceSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Diagnostics.Tracing.EventSource");
+
+        /// <summary>
+        /// The <c>EventSource</c> of the <c>Microsoft.Diagnostics.Tracing.EventSource</c> NuGet package.
+        /// </summary>
+        private INamedTypeSymbol? NuGetEventSourceSymbol { get; } = compilation.GetBestTypeByMetadataName("Microsoft.Diagnostics.Tracing.EventSource");
+
+        public bool IsValid => EventSourceSymbol is not null || NuGetEventSourceSymbol is not null;
+
+        public void AnalyzeNamedType(SymbolAnalysisContext context)
+        {
+            var symbol = (INamedTypeSymbol)context.Symbol;
+            if (symbol.TypeKind is not TypeKind.Class)
+                return;
+
+            // Abstract EventSource classes are the supported way to share code between event sources ("Utility EventSource")
+            if (symbol.IsSealed || symbol.IsAbstract || symbol.IsStatic || symbol.IsImplicitlyDeclared)
+                return;
+
+            if (symbol.InheritsFrom(EventSourceSymbol) || symbol.InheritsFrom(NuGetEventSourceSymbol))
+            {
+                context.ReportDiagnostic(Rule, symbol);
+            }
+        }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/EventSourceMustBeSealedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EventSourceMustBeSealedAnalyzerTests.cs
@@ -1,0 +1,158 @@
+using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
+    Meziantou.Analyzer.Rules.EventSourceMustBeSealedAnalyzer,
+    Meziantou.Analyzer.Rules.EventSourceMustBeSealedFixer>;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class EventSourceMustBeSealedAnalyzerTests
+{
+    [Fact]
+    public Task SealedEventSource_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task AbstractEventSource_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                abstract class Sample : EventSource
+                {
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task NotAnEventSource_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task UnsealedEventSource_Diagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                class [|Sample|] : EventSource
+                {
+                }
+                """,
+            FixedCode = """
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task UnsealedEventSource_InheritsFromAbstractEventSource_Diagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                abstract class BaseSample : EventSource
+                {
+                }
+
+                class [|Sample|] : BaseSample
+                {
+                }
+                """,
+            FixedCode = """
+                using System.Diagnostics.Tracing;
+
+                abstract class BaseSample : EventSource
+                {
+                }
+
+                sealed class Sample : BaseSample
+                {
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task SealedEventSource_InheritsFromAbstractEventSource_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                abstract class BaseSample : EventSource
+                {
+                }
+
+                sealed class Sample : BaseSample
+                {
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task UnsealedEventSourceFromNuGetPackage_Diagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                using Microsoft.Diagnostics.Tracing;
+
+                class [|Sample|] : EventSource
+                {
+                }
+
+                namespace Microsoft.Diagnostics.Tracing
+                {
+                    public class EventSource
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using Microsoft.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                }
+
+                namespace Microsoft.Diagnostics.Tracing
+                {
+                    public class EventSource
+                    {
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+}


### PR DESCRIPTION
## What

New rule **MA0226 - EventSource class should be sealed**, reported on a class that inherits from `EventSource` and is neither `sealed` nor `abstract`. **Disabled by default** (`Warning` severity when enabled), with a code fix adding the `sealed` modifier.

## Why

Sealing a derived event source is not only a documented convention — the runtime validates it:

- `EventSource.CreateManifestAndDescriptors` reports `Event source types must be sealed or abstract.` when the type is neither `sealed` nor `abstract` (only under `EventManifestOptions.Strict`, i.e. `GenerateManifest` validation, so an unsealed source does not throw at construction on its own).
- `GetEventSourceBaseType` walks up the base chain skipping **only abstract** types and requires the first non-abstract ancestor to be exactly `EventSource`, so a class deriving from a concrete event source is not a valid event source.
- Descriptors are built from `eventSourceType.GetMethods(BindingFlags.DeclaredOnly | ...)`, so events declared on a concrete base class are never registered for the derived provider (which also gets its own provider name/GUID).

The `abstract` "Utility EventSource" pattern is explicitly supported by the framework, so abstract classes are not reported.

## Notes for reviewers

- The rule also recognizes `Microsoft.Diagnostics.Tracing.EventSource` (the EventSource NuGet redist type), matching the runtime's own namespace-tolerant handling of `Diagnostics.Tracing` attributes.
- This is not covered by [MA0053](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0053.md): MA0053 only fires when there is no inheritor in the compilation, skips `public` types by default, and is `Info`. An unsealed concrete `EventSource` is wrong regardless of visibility or whether anything derives from it today.
- No entry added to `docs/comparison-with-other-analyzers.md`: no equivalent or similar rule found in the CA/IDE/Sonar rule sets.

## Verification

- `dotnet build` (all Roslyn versions): succeeded, 0 warnings.
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn5.9.csproj`: 4240/4240 passed.
- `dotnet test tests/Meziantou.Analyzer.Test/Meziantou.Analyzer.Test.roslyn4.8.csproj --filter "FullyQualifiedName~EventSourceMustBeSealedAnalyzerTests"`: 7/7 passed.
- `dotnet run --project src/DocumentationGenerator` re-run after the doc edits: exit code 0, no further markdown changes.