### PR TITLE
Add MA0227: Avoid using 'Enumerable.Contains' on a set

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0224](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0224.md)|Design|JsonSerializerOptions should set RespectNullableAnnotations|⚠️|❌|✔️|❌|
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|⚠️|❌|✔️|❌|
 |[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|⚠️|❌|✔️|❌|
+|[MA0227](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0227.md)|Performance|Avoid using 'Enumerable.Contains' on a set|⚠️|❌|❌|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -225,6 +225,7 @@
 |[MA0224](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0224.md)|Design|JsonSerializerOptions should set RespectNullableAnnotations|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|<span title='Warning'>⚠️</span>|❌|✔️|❌|
+|[MA0227](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0227.md)|Performance|Avoid using 'Enumerable.Contains' on a set|<span title='Warning'>⚠️</span>|❌|❌|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0227.md
+++ b/docs/Rules/MA0227.md
@@ -1,0 +1,66 @@
+# MA0227 - Avoid using 'Enumerable.Contains' on a set
+<!-- sources -->
+Source: [AvoidEnumerableContainsOnSetAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/AvoidEnumerableContainsOnSetAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+A set such as `HashSet<T>` provides an O(1) lookup, but `Enumerable.Contains` does not always use it. `Enumerable.Contains(source, value)` uses the lookup of the set only when the source implements `ICollection<T>` for the type of the searched value; otherwise it enumerates the whole set and compares the items with `EqualityComparer<T>.Default`.
+
+This rule reports the calls to `Enumerable.Contains` on a set (`ISet<T>`, `IReadOnlySet<T>`, or `IImmutableSet<T>`) that do a linear search:
+
+- A comparer is provided. `Enumerable.Contains(source, value, comparer)` never uses the lookup of the set, and the provided comparer may not be consistent with the one of the set.
+- The searched value is not of the element type of the set. As `IEnumerable<T>` is covariant, a `HashSet<string>` can be used as an `IEnumerable<object>`. In that case the set does not implement `ICollection<object>`, so the search is linear and the items are compared with `EqualityComparer<object>.Default` instead of the comparer of the set.
+
+The calls that do use the lookup of the set, such as `Enumerable.Contains(hashSetOfString, "value")`, are not reported.
+
+## Motivation
+
+````c#
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+class Sample
+{
+    void Test(HashSet<string> set, string value, object obj)
+    {
+        // ❌ Linear search: the comparer of the set is not used
+        _ = set.Contains(value, StringComparer.Ordinal);
+
+        // ❌ Linear search: the set is used as an 'IEnumerable<object>'
+        _ = set.Contains(obj);
+
+        // ✅ Uses the lookup of the set
+        _ = set.Contains(value);
+    }
+}
+````
+
+## How to fix violations
+
+Use the `Contains` method of the set. When the searched value is not of the element type of the set, convert it before calling `Contains`:
+
+````c#
+using System.Collections.Generic;
+using System.Linq;
+
+class Sample
+{
+    void Test(HashSet<string> set, object obj)
+    {
+        // ✅ Uses the lookup of the set
+        _ = obj is string str && set.Contains(str);
+    }
+}
+````
+
+If the search must use a comparer that is not the one of the set, create the set with that comparer (`new HashSet<string>(StringComparer.Ordinal)`), or keep the call to `Enumerable.Contains` and suppress the diagnostic.
+
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0227.severity = warning
+````

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -673,3 +673,6 @@ dotnet_diagnostic.MA0225.severity = error
 
 # MA0226: EventSource class should be sealed
 dotnet_diagnostic.MA0226.severity = error
+
+# MA0227: Avoid using 'Enumerable.Contains' on a set
+dotnet_diagnostic.MA0227.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -673,3 +673,6 @@ dotnet_diagnostic.MA0225.severity = suggestion
 
 # MA0226: EventSource class should be sealed
 dotnet_diagnostic.MA0226.severity = suggestion
+
+# MA0227: Avoid using 'Enumerable.Contains' on a set
+dotnet_diagnostic.MA0227.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -673,3 +673,6 @@ dotnet_diagnostic.MA0225.severity = warning
 
 # MA0226: EventSource class should be sealed
 dotnet_diagnostic.MA0226.severity = warning
+
+# MA0227: Avoid using 'Enumerable.Contains' on a set
+dotnet_diagnostic.MA0227.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -673,3 +673,6 @@ dotnet_diagnostic.MA0225.severity = none
 
 # MA0226: EventSource class should be sealed
 dotnet_diagnostic.MA0226.severity = none
+
+# MA0227: Avoid using 'Enumerable.Contains' on a set
+dotnet_diagnostic.MA0227.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -673,3 +673,6 @@ dotnet_diagnostic.MA0225.severity = none
 
 # MA0226: EventSource class should be sealed
 dotnet_diagnostic.MA0226.severity = none
+
+# MA0227: Avoid using 'Enumerable.Contains' on a set
+dotnet_diagnostic.MA0227.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -226,6 +226,7 @@ internal static class RuleIdentifiers
     public const string SetRespectNullableAnnotationsOnJsonSerializerOptions = "MA0224";
     public const string SetRespectRequiredConstructorParametersOnJsonSerializerOptions = "MA0225";
     public const string EventSourceMustBeSealed = "MA0226";
+    public const string AvoidEnumerableContainsOnSet = "MA0227";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/AvoidEnumerableContainsOnSetAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidEnumerableContainsOnSetAnalyzer.cs
@@ -1,0 +1,96 @@
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class AvoidEnumerableContainsOnSetAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.AvoidEnumerableContainsOnSet,
+        title: "Avoid using 'Enumerable.Contains' on a set",
+        messageFormat: "Avoid using 'Enumerable.Contains' on a set as it does a linear search instead of using the set lookup ({0})",
+        RuleCategories.Performance,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.AvoidEnumerableContainsOnSet));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(ctx =>
+        {
+            var analyzerContext = new AnalyzerContext(ctx.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            ctx.RegisterOperationAction(analyzerContext.AnalyzeInvocation, OperationKind.Invocation);
+        });
+    }
+
+    private sealed class AnalyzerContext(Compilation compilation)
+    {
+        private INamedTypeSymbol? EnumerableSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Linq.Enumerable");
+        private INamedTypeSymbol? ISetSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Collections.Generic.ISet`1");
+        private INamedTypeSymbol? IReadOnlySetSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Collections.Generic.IReadOnlySet`1");
+        private INamedTypeSymbol? IImmutableSetSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Collections.Immutable.IImmutableSet`1");
+
+        public bool IsValid => EnumerableSymbol is not null && (ISetSymbol is not null || IReadOnlySetSymbol is not null || IImmutableSetSymbol is not null);
+
+        public void AnalyzeInvocation(OperationAnalysisContext context)
+        {
+            var operation = (IInvocationOperation)context.Operation;
+            var method = operation.TargetMethod;
+            if (method is not { Name: "Contains", IsExtensionMethod: true, TypeArguments: [var valueType] })
+                return;
+
+            if (!method.ContainingType.IsEqualTo(EnumerableSymbol))
+                return;
+
+            // Enumerable.Contains(source, value) or Enumerable.Contains(source, value, comparer)
+            if (operation.Arguments.Length is not (2 or 3))
+                return;
+
+            var sourceType = operation.Arguments[0].Value.GetActualType(useDataFlowAnalysis: true, context.CancellationToken);
+            if (sourceType is null)
+                return;
+
+            if (GetSetElementType(sourceType) is not { } elementType)
+                return;
+
+            // Enumerable.Contains(source, value) uses ICollection<T>.Contains when the source implements ICollection<T>,
+            // so the set lookup is used. This is not the case when a comparer is provided, or when the value type is not
+            // the element type of the set, such as when the set is used as a covariant IEnumerable<T>.
+            if (operation.Arguments.Length is 3)
+            {
+                context.ReportDiagnostic(Rule, operation, "the comparer of the set is not used");
+            }
+            else if (!elementType.IsEqualTo(valueType))
+            {
+                context.ReportDiagnostic(Rule, operation, $"the set is used as '{valueType.ToDisplayString()}' instead of '{elementType.ToDisplayString()}'");
+            }
+        }
+
+        private ITypeSymbol? GetSetElementType(ITypeSymbol type)
+        {
+            foreach (var setSymbol in (ReadOnlySpan<INamedTypeSymbol?>)[ISetSymbol, IReadOnlySetSymbol, IImmutableSetSymbol])
+            {
+                if (setSymbol is null)
+                    continue;
+
+                if (type.OriginalDefinition.IsEqualTo(setSymbol))
+                    return ((INamedTypeSymbol)type).TypeArguments[0];
+
+                foreach (var iface in type.AllInterfaces)
+                {
+                    if (iface.OriginalDefinition.IsEqualTo(setSymbol))
+                        return iface.TypeArguments[0];
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/AvoidEnumerableContainsOnSetAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/AvoidEnumerableContainsOnSetAnalyzerTests.cs
@@ -1,0 +1,305 @@
+using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
+    Meziantou.Analyzer.Rules.AvoidEnumerableContainsOnSetAnalyzer>;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class AvoidEnumerableContainsOnSetAnalyzerTests
+{
+    [Fact]
+    public Task HashSet_Contains_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(HashSet<string> set, string value) => set.Contains(value);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task HashSet_EnumerableContains_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(HashSet<string> set, string value) => Enumerable.Contains(set, value);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task IEnumerable_Contains_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(IEnumerable<string> source, string value) => source.Contains(value);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task List_ContainsWithComparer_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(List<string> list, string value) => list.Contains(value, StringComparer.Ordinal);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task HashSet_AssignedToIEnumerable_Contains_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(string value)
+                    {
+                        IEnumerable<string> source = new HashSet<string>();
+                        return source.Contains(value);
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task HashSet_ContainsWithComparer()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(HashSet<string> set, string value) => [|set.Contains(value, StringComparer.Ordinal)|];
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task HashSet_EnumerableContainsWithComparer()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(HashSet<string> set, string value) => [|Enumerable.Contains(set, value, StringComparer.Ordinal)|];
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task HashSet_AssignedToIEnumerable_ContainsWithComparer()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(string value)
+                    {
+                        IEnumerable<string> source = new HashSet<string>();
+                        return [|source.Contains(value, StringComparer.Ordinal)|];
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task HashSet_ContainsObject()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(HashSet<string> set, object value) => [|set.Contains(value)|];
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task HashSet_UsedAsCovariantEnumerable_Contains()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(object value)
+                    {
+                        IEnumerable<object> source = new HashSet<string>();
+                        return [|source.Contains(value)|];
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task SortedSet_ContainsWithComparer()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(SortedSet<string> set, string value) => [|set.Contains(value, StringComparer.Ordinal)|];
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task ImmutableHashSet_ContainsWithComparer()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Immutable;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(ImmutableHashSet<string> set, string value) => [|set.Contains(value, StringComparer.Ordinal)|];
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task FrozenSet_ContainsWithComparer()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Frozen;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(FrozenSet<string> set, string value) => [|set.Contains(value, StringComparer.Ordinal)|];
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task IReadOnlySet_ContainsWithComparer()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(IReadOnlySet<string> set, string value) => [|set.Contains(value, StringComparer.Ordinal)|];
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task ISet_ContainsWithComparer()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(ISet<string> set, string value) => [|set.Contains(value, StringComparer.Ordinal)|];
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task CustomSet_ContainsWithComparer()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class Sample
+                {
+                    bool Test(CustomSet set, string value) => [|set.Contains(value, StringComparer.Ordinal)|];
+                }
+
+                class CustomSet : HashSet<string>
+                {
+                }
+                """,
+        }.RunAsync();
+    }
+}


### PR DESCRIPTION
## What

New rule **MA0227 - Avoid using `Enumerable.Contains` on a set** (Performance, Warning, disabled by default).

There was no existing rule covering this: MA0020 only rewrites LINQ calls to the `List<T>` methods, and nothing looked at sets.

## Why

A set gives an O(1) lookup, but `Enumerable.Contains` does not always use it. `Enumerable.Contains(source, value)` delegates to `ICollection<T>.Contains` only when the source implements `ICollection<T>` **for the type of the searched value**; otherwise it enumerates the set and compares the items with `EqualityComparer<T>.Default`.

The rule reports the two cases where the search is actually linear:

- **A comparer is provided.** `Enumerable.Contains(source, value, comparer)` never uses the lookup of the set, and the provided comparer may not be consistent with the one of the set.
- **The searched value is not of the element type of the set.** As `IEnumerable<T>` is covariant, a `HashSet<string>` can be used as an `IEnumerable<object>`, so `set.Contains(obj)` silently binds to `Enumerable.Contains<object>`: the set does not implement `ICollection<object>`, the search is linear, and the items are compared with `EqualityComparer<object>.Default` instead of the comparer of the set.

```c#
void Test(HashSet<string> set, string value, object obj)
{
    _ = set.Contains(value, StringComparer.Ordinal); // ❌ linear, and the comparer of the set is not used
    _ = set.Contains(obj);                           // ❌ linear, the set is used as an 'IEnumerable<object>'
    _ = set.Contains(value);                         // ✅ uses the lookup of the set
}
```

The calls that do use the lookup of the set, such as `Enumerable.Contains(hashSetOfString, "value")`, are **not** reported, so the rule does not flag code that is already efficient.

## Notes for the reviewer

- The analyzer matches `System.Linq.Enumerable.Contains` on an `IInvocationOperation`, resolves the source with `GetActualType(useDataFlowAnalysis: true, ...)` so a set stored in an `IEnumerable<T>` local or field is also found, and looks for `ISet<T>`, `IReadOnlySet<T>` or `IImmutableSet<T>`. `HashSet<T>`, `SortedSet<T>`, `ImmutableHashSet<T>` and `FrozenSet<T>` are covered by those interfaces.
- **No code fixer**: neither case has a safe automatic rewrite. The covariant case needs a cast or a pattern the user has to choose, and changing the comparer of the search changes the semantics.
- Nothing was added to `docs/comparison-with-other-analyzers.md`: I did not find an equivalent or similar rule in the other analyzers (CA1841 is about `dictionary.Keys.Contains`, which is a different pattern).

## Validation

- `dotnet build` succeeds with 0 warnings.
- 16 new tests, passing on `roslyn4.8` and `roslyn5.9`.
- The full `roslyn5.9` test project passes (4256 tests).
- `dotnet run --project src/DocumentationGenerator` was run, and re-running it makes no further change.