### PR TITLE
Add MA0228-MA0238: EventSource implementation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,17 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|⚠️|❌|✔️|❌|
 |[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|⚠️|❌|✔️|❌|
 |[MA0227](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0227.md)|Performance|Avoid using 'Enumerable.Contains' on a set|⚠️|❌|❌|❌|
-|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|Invalid EventSource implementation|⚠️|✔️|❌|❌|
+|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|The event id of an EventSource must be greater than zero|⚠️|✔️|❌|❌|
+|[MA0229](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0229.md)|Usage|The event id of an EventSource is already used by another event|⚠️|✔️|❌|❌|
+|[MA0230](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0230.md)|Usage|The event name of an EventSource is already used by another event|⚠️|✔️|❌|❌|
+|[MA0231](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0231.md)|Usage|An EventSource event method must not be static|⚠️|✔️|❌|❌|
+|[MA0232](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0232.md)|Usage|An EventSource event method must not be an explicit interface implementation|⚠️|✔️|❌|❌|
+|[MA0233](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0233.md)|Usage|An abstract EventSource must not declare event methods|⚠️|✔️|❌|❌|
+|[MA0234](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0234.md)|Usage|The event id written by an EventSource event method must match its \[Event\] attribute|⚠️|✔️|❌|❌|
+|[MA0235](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0235.md)|Usage|The payload written by an EventSource event method must match its parameters|⚠️|✔️|❌|❌|
+|[MA0236](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0236.md)|Usage|The payload written by an EventSource event method must use the order of its parameters|⚠️|✔️|❌|❌|
+|[MA0237](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0237.md)|Usage|An EventSource event method writing a related activity id must declare it as its first parameter|⚠️|✔️|❌|❌|
+|[MA0238](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0238.md)|Usage|The parameter type of an EventSource event method is not supported|⚠️|✔️|❌|❌|
 
 <!-- rules -->
 

--- a/README.md
+++ b/README.md
@@ -256,17 +256,17 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|⚠️|❌|✔️|❌|
 |[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|⚠️|❌|✔️|❌|
 |[MA0227](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0227.md)|Performance|Avoid using 'Enumerable.Contains' on a set|⚠️|❌|❌|❌|
-|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|The event id of an EventSource must be greater than zero|⚠️|✔️|❌|❌|
-|[MA0229](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0229.md)|Usage|The event id of an EventSource is already used by another event|⚠️|✔️|❌|❌|
-|[MA0230](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0230.md)|Usage|The event name of an EventSource is already used by another event|⚠️|✔️|❌|❌|
-|[MA0231](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0231.md)|Usage|An EventSource event method must not be static|⚠️|✔️|❌|❌|
-|[MA0232](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0232.md)|Usage|An EventSource event method must not be an explicit interface implementation|⚠️|✔️|❌|❌|
-|[MA0233](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0233.md)|Usage|An abstract EventSource must not declare event methods|⚠️|✔️|❌|❌|
-|[MA0234](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0234.md)|Usage|The event id written by an EventSource event method must match its \[Event\] attribute|⚠️|✔️|❌|❌|
-|[MA0235](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0235.md)|Usage|The payload written by an EventSource event method must match its parameters|⚠️|✔️|❌|❌|
-|[MA0236](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0236.md)|Usage|The payload written by an EventSource event method must use the order of its parameters|⚠️|✔️|❌|❌|
-|[MA0237](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0237.md)|Usage|An EventSource event method writing a related activity id must declare it as its first parameter|⚠️|✔️|❌|❌|
-|[MA0238](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0238.md)|Usage|The parameter type of an EventSource event method is not supported|⚠️|✔️|❌|❌|
+|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|The event id of an EventSource must be greater than zero|⚠️|❌|❌|❌|
+|[MA0229](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0229.md)|Usage|The event id of an EventSource is already used by another event|⚠️|❌|❌|❌|
+|[MA0230](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0230.md)|Usage|The event name of an EventSource is already used by another event|⚠️|❌|❌|❌|
+|[MA0231](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0231.md)|Usage|An EventSource event method must not be static|⚠️|❌|❌|❌|
+|[MA0232](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0232.md)|Usage|An EventSource event method must not be an explicit interface implementation|⚠️|❌|❌|❌|
+|[MA0233](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0233.md)|Usage|An abstract EventSource must not declare event methods|⚠️|❌|❌|❌|
+|[MA0234](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0234.md)|Usage|The event id written by an EventSource event method must match its \[Event\] attribute|⚠️|❌|❌|❌|
+|[MA0235](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0235.md)|Usage|The payload written by an EventSource event method must match its parameters|⚠️|❌|❌|❌|
+|[MA0236](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0236.md)|Usage|The payload written by an EventSource event method must use the order of its parameters|⚠️|❌|❌|❌|
+|[MA0237](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0237.md)|Usage|An EventSource event method writing a related activity id must declare it as its first parameter|⚠️|❌|❌|❌|
+|[MA0238](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0238.md)|Usage|The parameter type of an EventSource event method is not supported|⚠️|❌|❌|❌|
 
 <!-- rules -->
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|⚠️|❌|✔️|❌|
 |[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|⚠️|❌|✔️|❌|
 |[MA0227](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0227.md)|Performance|Avoid using 'Enumerable.Contains' on a set|⚠️|❌|❌|❌|
+|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|Invalid EventSource implementation|⚠️|✔️|❌|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -226,7 +226,17 @@
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0227](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0227.md)|Performance|Avoid using 'Enumerable.Contains' on a set|<span title='Warning'>⚠️</span>|❌|❌|❌|
-|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|Invalid EventSource implementation|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|The event id of an EventSource must be greater than zero|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0229](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0229.md)|Usage|The event id of an EventSource is already used by another event|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0230](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0230.md)|Usage|The event name of an EventSource is already used by another event|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0231](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0231.md)|Usage|An EventSource event method must not be static|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0232](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0232.md)|Usage|An EventSource event method must not be an explicit interface implementation|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0233](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0233.md)|Usage|An abstract EventSource must not declare event methods|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0234](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0234.md)|Usage|The event id written by an EventSource event method must match its \[Event\] attribute|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0235](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0235.md)|Usage|The payload written by an EventSource event method must match its parameters|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0236](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0236.md)|Usage|The payload written by an EventSource event method must use the order of its parameters|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0237](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0237.md)|Usage|An EventSource event method writing a related activity id must declare it as its first parameter|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0238](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0238.md)|Usage|The parameter type of an EventSource event method is not supported|<span title='Warning'>⚠️</span>|✔️|❌|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/README.md
+++ b/docs/README.md
@@ -226,6 +226,7 @@
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0227](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0227.md)|Performance|Avoid using 'Enumerable.Contains' on a set|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|Invalid EventSource implementation|<span title='Warning'>⚠️</span>|✔️|❌|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/README.md
+++ b/docs/README.md
@@ -226,17 +226,17 @@
 |[MA0225](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0225.md)|Design|JsonSerializerOptions should set RespectRequiredConstructorParameters|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0226](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0226.md)|Design|EventSource class should be sealed|<span title='Warning'>⚠️</span>|❌|✔️|❌|
 |[MA0227](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0227.md)|Performance|Avoid using 'Enumerable.Contains' on a set|<span title='Warning'>⚠️</span>|❌|❌|❌|
-|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|The event id of an EventSource must be greater than zero|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0229](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0229.md)|Usage|The event id of an EventSource is already used by another event|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0230](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0230.md)|Usage|The event name of an EventSource is already used by another event|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0231](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0231.md)|Usage|An EventSource event method must not be static|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0232](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0232.md)|Usage|An EventSource event method must not be an explicit interface implementation|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0233](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0233.md)|Usage|An abstract EventSource must not declare event methods|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0234](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0234.md)|Usage|The event id written by an EventSource event method must match its \[Event\] attribute|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0235](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0235.md)|Usage|The payload written by an EventSource event method must match its parameters|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0236](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0236.md)|Usage|The payload written by an EventSource event method must use the order of its parameters|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0237](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0237.md)|Usage|An EventSource event method writing a related activity id must declare it as its first parameter|<span title='Warning'>⚠️</span>|✔️|❌|❌|
-|[MA0238](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0238.md)|Usage|The parameter type of an EventSource event method is not supported|<span title='Warning'>⚠️</span>|✔️|❌|❌|
+|[MA0228](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0228.md)|Usage|The event id of an EventSource must be greater than zero|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0229](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0229.md)|Usage|The event id of an EventSource is already used by another event|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0230](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0230.md)|Usage|The event name of an EventSource is already used by another event|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0231](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0231.md)|Usage|An EventSource event method must not be static|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0232](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0232.md)|Usage|An EventSource event method must not be an explicit interface implementation|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0233](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0233.md)|Usage|An abstract EventSource must not declare event methods|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0234](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0234.md)|Usage|The event id written by an EventSource event method must match its \[Event\] attribute|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0235](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0235.md)|Usage|The payload written by an EventSource event method must match its parameters|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0236](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0236.md)|Usage|The payload written by an EventSource event method must use the order of its parameters|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0237](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0237.md)|Usage|An EventSource event method writing a related activity id must declare it as its first parameter|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0238](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0238.md)|Usage|The parameter type of an EventSource event method is not supported|<span title='Warning'>⚠️</span>|❌|❌|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0228.md
+++ b/docs/Rules/MA0228.md
@@ -35,6 +35,14 @@ sealed class SampleEventSource : EventSource
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0228.severity = warning
+````
+
 ## Related rules
 
 - [MA0229](MA0229.md) - The event id of an EventSource is already used by another event

--- a/docs/Rules/MA0228.md
+++ b/docs/Rules/MA0228.md
@@ -1,25 +1,11 @@
-# MA0228 - Invalid EventSource implementation
+# MA0228 - The event id of an EventSource must be greater than zero
 <!-- sources -->
-Source: [InvalidEventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InvalidEventSourceImplementationAnalyzer.cs)
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
 <!-- sources -->
 
 ## Description
 
-`EventSource` builds the metadata of the events from the methods of the type at runtime, using reflection. The compiler cannot validate that the declaration of an event matches what the method writes, so a mistake is only reported at runtime, as an `EventSourceException`, an error in the `EventSource` event source, or a payload that does not match the manifest.
-
-This rule reports the errors the runtime detects when it creates the manifest and the descriptors of an event source:
-
-- The event id is not greater than 0.
-- The event id is already used by another event of the same event source.
-- The event name is already used by another event of the same event source, which happens when two event methods are overloads.
-- The `[Event]` attribute is applied to a `static` method or to an explicit interface implementation, which the runtime never considers as an event.
-- The `[Event]` attribute is applied to a method of an `abstract` event source. The runtime only looks at the methods declared by the type itself, so the events must be declared by the derived types.
-- The event id passed to `WriteEvent`, `WriteEventCore`, `WriteEventWithRelatedActivityId`, or `WriteEventWithRelatedActivityIdCore` is not the id of the `[Event]` attribute of the method.
-- The payload written by the method does not match its parameters: the number of arguments, the number of event data of `WriteEventCore`, or the order of the parameters.
-- A method calling `WriteEventWithRelatedActivityId` does not declare a `Guid` named `relatedActivityId` as its first parameter. The runtime removes that parameter from the payload, so it must be there for the payload to match the manifest.
-- The type of a parameter cannot be written to the manifest. The supported types are the primitive types, `string`, `DateTime`, `Guid`, `IntPtr`, `byte[]`, `byte*`, and the enumerations.
-
-The parameter types are not validated when the event source may use the self-describing format, which does not use a manifest: when it provides `EventSourceSettings` to its base constructor, or when it derives from another event source declared in the same compilation.
+`EventSource` builds the metadata of the events from the methods of the type at runtime. An event id must be greater than zero: the runtime reports `Event IDs must be positive integers.` and drops the event when it is not.
 
 ## Motivation
 
@@ -28,75 +14,28 @@ using System.Diagnostics.Tracing;
 
 sealed class SampleEventSource : EventSource
 {
-    public static SampleEventSource Log { get; } = new();
-
-    [Event(1)]
-    public void Start() => WriteEvent(1);
-
-    // ❌ The event id of the attribute is 2, but the event 1 is written
-    [Event(2)]
-    public void Stop() => WriteEvent(1);
-
-    // ❌ The event id 1 is already used by 'Start'
-    [Event(1)]
-    public void Pause() => WriteEvent(1);
-
-    // ❌ The method declares 2 parameters, but only 1 is written
-    [Event(3)]
-    public void Resume(string name, int count) => WriteEvent(3, name);
-
-    // ❌ The parameters are not written in the order they are declared
-    [Event(4)]
-    public void Fail(string name, string category) => WriteEvent(4, category, name);
+    // ❌ 0 is not a valid event id
+    [Event(0)]
+    public void Start() => WriteEvent(0);
 }
 ````
 
 ## How to fix violations
 
-Make the implementation of the method match its declaration:
+Use an id greater than zero, that no other event of the event source uses:
 
 ````c#
 using System.Diagnostics.Tracing;
 
 sealed class SampleEventSource : EventSource
 {
-    public static SampleEventSource Log { get; } = new();
-
+    // ✅
     [Event(1)]
     public void Start() => WriteEvent(1);
-
-    // ✅ The event id of the attribute is written
-    [Event(2)]
-    public void Stop() => WriteEvent(2);
-
-    // ✅ The event id is unique
-    [Event(3)]
-    public void Pause() => WriteEvent(3);
-
-    // ✅ Every parameter is written, in the order they are declared
-    [Event(4)]
-    public void Resume(string name, int count) => WriteEvent(4, name, count);
 }
 ````
 
-The methods that are not events must be marked with the `[NonEvent]` attribute, so that the runtime does not validate them:
+## Related rules
 
-````c#
-using System;
-using System.Diagnostics.Tracing;
-
-sealed class SampleEventSource : EventSource
-{
-    // ✅ Not an event, so it can call an event method with the arguments it wants
-    [NonEvent]
-    public void Failed(Exception exception) => Failed(exception.ToString());
-
-    [Event(1)]
-    public void Failed(string message) => WriteEvent(1, message);
-}
-````
-
-## References
-
-- [Instrument code to create EventSource events](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/eventsource-instrumentation?WT.mc_id=DT-MVP-5003978)
-- [EventSource class](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventsource?WT.mc_id=DT-MVP-5003978)
+- [MA0229](MA0229.md) - The event id of an EventSource is already used by another event
+- [MA0234](MA0234.md) - The event id written by an EventSource event method must match its [Event] attribute

--- a/docs/Rules/MA0228.md
+++ b/docs/Rules/MA0228.md
@@ -1,0 +1,102 @@
+# MA0228 - Invalid EventSource implementation
+<!-- sources -->
+Source: [InvalidEventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/InvalidEventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+`EventSource` builds the metadata of the events from the methods of the type at runtime, using reflection. The compiler cannot validate that the declaration of an event matches what the method writes, so a mistake is only reported at runtime, as an `EventSourceException`, an error in the `EventSource` event source, or a payload that does not match the manifest.
+
+This rule reports the errors the runtime detects when it creates the manifest and the descriptors of an event source:
+
+- The event id is not greater than 0.
+- The event id is already used by another event of the same event source.
+- The event name is already used by another event of the same event source, which happens when two event methods are overloads.
+- The `[Event]` attribute is applied to a `static` method or to an explicit interface implementation, which the runtime never considers as an event.
+- The `[Event]` attribute is applied to a method of an `abstract` event source. The runtime only looks at the methods declared by the type itself, so the events must be declared by the derived types.
+- The event id passed to `WriteEvent`, `WriteEventCore`, `WriteEventWithRelatedActivityId`, or `WriteEventWithRelatedActivityIdCore` is not the id of the `[Event]` attribute of the method.
+- The payload written by the method does not match its parameters: the number of arguments, the number of event data of `WriteEventCore`, or the order of the parameters.
+- A method calling `WriteEventWithRelatedActivityId` does not declare a `Guid` named `relatedActivityId` as its first parameter. The runtime removes that parameter from the payload, so it must be there for the payload to match the manifest.
+- The type of a parameter cannot be written to the manifest. The supported types are the primitive types, `string`, `DateTime`, `Guid`, `IntPtr`, `byte[]`, `byte*`, and the enumerations.
+
+The parameter types are not validated when the event source may use the self-describing format, which does not use a manifest: when it provides `EventSourceSettings` to its base constructor, or when it derives from another event source declared in the same compilation.
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    public static SampleEventSource Log { get; } = new();
+
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+
+    // ❌ The event id of the attribute is 2, but the event 1 is written
+    [Event(2)]
+    public void Stop() => WriteEvent(1);
+
+    // ❌ The event id 1 is already used by 'Start'
+    [Event(1)]
+    public void Pause() => WriteEvent(1);
+
+    // ❌ The method declares 2 parameters, but only 1 is written
+    [Event(3)]
+    public void Resume(string name, int count) => WriteEvent(3, name);
+
+    // ❌ The parameters are not written in the order they are declared
+    [Event(4)]
+    public void Fail(string name, string category) => WriteEvent(4, category, name);
+}
+````
+
+## How to fix violations
+
+Make the implementation of the method match its declaration:
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    public static SampleEventSource Log { get; } = new();
+
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+
+    // ✅ The event id of the attribute is written
+    [Event(2)]
+    public void Stop() => WriteEvent(2);
+
+    // ✅ The event id is unique
+    [Event(3)]
+    public void Pause() => WriteEvent(3);
+
+    // ✅ Every parameter is written, in the order they are declared
+    [Event(4)]
+    public void Resume(string name, int count) => WriteEvent(4, name, count);
+}
+````
+
+The methods that are not events must be marked with the `[NonEvent]` attribute, so that the runtime does not validate them:
+
+````c#
+using System;
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ✅ Not an event, so it can call an event method with the arguments it wants
+    [NonEvent]
+    public void Failed(Exception exception) => Failed(exception.ToString());
+
+    [Event(1)]
+    public void Failed(string message) => WriteEvent(1, message);
+}
+````
+
+## References
+
+- [Instrument code to create EventSource events](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/eventsource-instrumentation?WT.mc_id=DT-MVP-5003978)
+- [EventSource class](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventsource?WT.mc_id=DT-MVP-5003978)

--- a/docs/Rules/MA0229.md
+++ b/docs/Rules/MA0229.md
@@ -1,0 +1,47 @@
+# MA0229 - The event id of an EventSource is already used by another event
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+`EventSource` builds the metadata of the events from the methods of the type at runtime, and it indexes them by their event id. Two events of the same event source cannot share an id: the runtime reports `Event {name} is givien event ID {id} which is already in use.` and the event source cannot be used.
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+
+    // ❌ The event id 1 is already used by 'Start'
+    [Event(1)]
+    public void Stop() => WriteEvent(1);
+}
+````
+
+## How to fix violations
+
+Give a unique id to every event of the event source:
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+
+    // ✅
+    [Event(2)]
+    public void Stop() => WriteEvent(2);
+}
+````
+
+## Related rules
+
+- [MA0228](MA0228.md) - The event id of an EventSource must be greater than zero
+- [MA0230](MA0230.md) - The event name of an EventSource is already used by another event

--- a/docs/Rules/MA0229.md
+++ b/docs/Rules/MA0229.md
@@ -41,6 +41,14 @@ sealed class SampleEventSource : EventSource
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0229.severity = warning
+````
+
 ## Related rules
 
 - [MA0228](MA0228.md) - The event id of an EventSource must be greater than zero

--- a/docs/Rules/MA0230.md
+++ b/docs/Rules/MA0230.md
@@ -1,0 +1,52 @@
+# MA0230 - The event name of an EventSource is already used by another event
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+The name of an event is the name of the method that writes it, and the runtime requires it to be unique: it reports `Event name {name} used more than once.` when two event methods are overloads.
+
+A method is an event when it is not `static`, and either it has the `[Event]` attribute, or it is a public non-virtual method returning `void` that is not marked with `[NonEvent]`.
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+
+    // ❌ Two events cannot be named 'Start'
+    [Event(2)]
+    public void Start(string name) => WriteEvent(2, name);
+}
+````
+
+## How to fix violations
+
+Give a different name to every event, or mark the methods that are not events with the `[NonEvent]` attribute:
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+
+    // ✅ A different event name
+    [Event(2)]
+    public void StartNamed(string name) => WriteEvent(2, name);
+
+    // ✅ Not an event, so its name does not have to be unique
+    [NonEvent]
+    public void Start(object value) => StartNamed(value.ToString());
+}
+````
+
+## Related rules
+
+- [MA0229](MA0229.md) - The event id of an EventSource is already used by another event

--- a/docs/Rules/MA0230.md
+++ b/docs/Rules/MA0230.md
@@ -47,6 +47,14 @@ sealed class SampleEventSource : EventSource
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0230.severity = warning
+````
+
 ## Related rules
 
 - [MA0229](MA0229.md) - The event id of an EventSource is already used by another event

--- a/docs/Rules/MA0231.md
+++ b/docs/Rules/MA0231.md
@@ -1,0 +1,44 @@
+# MA0231 - An EventSource event method must not be static
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+The runtime only looks at the instance methods of an event source when it builds the metadata of the events. A `static` method marked with the `[Event]` attribute is silently ignored, so the event it seems to declare is never written.
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    public static SampleEventSource Log { get; } = new();
+
+    // ❌ Never registered as an event
+    [Event(1)]
+    public static void Start() => Log.WriteEvent(1);
+}
+````
+
+## How to fix violations
+
+Declare the event as an instance method, and use the singleton instance of the event source at the call site:
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    public static SampleEventSource Log { get; } = new();
+
+    // ✅
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+}
+````
+
+## Related rules
+
+- [MA0232](MA0232.md) - An EventSource event method must not be an explicit interface implementation

--- a/docs/Rules/MA0231.md
+++ b/docs/Rules/MA0231.md
@@ -39,6 +39,14 @@ sealed class SampleEventSource : EventSource
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0231.severity = warning
+````
+
 ## Related rules
 
 - [MA0232](MA0232.md) - An EventSource event method must not be an explicit interface implementation

--- a/docs/Rules/MA0232.md
+++ b/docs/Rules/MA0232.md
@@ -45,6 +45,14 @@ sealed class SampleEventSource : EventSource, ISampleEvents
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0232.severity = warning
+````
+
 ## Related rules
 
 - [MA0231](MA0231.md) - An EventSource event method must not be static

--- a/docs/Rules/MA0232.md
+++ b/docs/Rules/MA0232.md
@@ -1,0 +1,50 @@
+# MA0232 - An EventSource event method must not be an explicit interface implementation
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+The name of an event is the name of the method that writes it. The name of an explicit interface implementation is qualified by the interface, which is not a valid event name: the runtime reports `Event method {name} (with ID {id}) is an explicit interface method implementation.`
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+interface ISampleEvents
+{
+    void Start();
+}
+
+sealed class SampleEventSource : EventSource, ISampleEvents
+{
+    // ❌ The event name would be 'ISampleEvents.Start'
+    [Event(1)]
+    void ISampleEvents.Start() => WriteEvent(1);
+}
+````
+
+## How to fix violations
+
+Use an implicit implementation, which the interface is satisfied by too:
+
+````c#
+using System.Diagnostics.Tracing;
+
+interface ISampleEvents
+{
+    void Start();
+}
+
+sealed class SampleEventSource : EventSource, ISampleEvents
+{
+    // ✅
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+}
+````
+
+## Related rules
+
+- [MA0231](MA0231.md) - An EventSource event method must not be static

--- a/docs/Rules/MA0233.md
+++ b/docs/Rules/MA0233.md
@@ -46,6 +46,14 @@ sealed class SampleEventSource : UtilityEventSource
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0233.severity = warning
+````
+
 ## Related rules
 
 - [MA0226](MA0226.md) - EventSource class should be sealed

--- a/docs/Rules/MA0233.md
+++ b/docs/Rules/MA0233.md
@@ -1,0 +1,51 @@
+# MA0233 - An abstract EventSource must not declare event methods
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+The runtime builds the metadata of the events from the methods declared by the event source type itself; it does not look at the ones its base types declare. An `abstract` event source, the "Utility EventSource" pattern, can therefore only share code between event sources, not events: the runtime reports `Abstract event source must not declare event methods ({name} with ID {id}).`
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+abstract class UtilityEventSource : EventSource
+{
+    // ❌ The derived event sources would not write this event
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+}
+````
+
+## How to fix violations
+
+Declare the event in the derived event sources, and keep only the shared code in the `abstract` class:
+
+````c#
+using System.Diagnostics.Tracing;
+
+abstract class UtilityEventSource : EventSource
+{
+    // ✅ Shared code, not an event
+    protected unsafe void WriteEvent(int eventId, int arg1, long arg2)
+    {
+        EventData* data = stackalloc EventData[2];
+        // Fill the event data
+        WriteEventCore(eventId, 2, data);
+    }
+}
+
+sealed class SampleEventSource : UtilityEventSource
+{
+    // ✅
+    [Event(1)]
+    public void Start(int arg1, long arg2) => WriteEvent(1, arg1, arg2);
+}
+````
+
+## Related rules
+
+- [MA0226](MA0226.md) - EventSource class should be sealed

--- a/docs/Rules/MA0234.md
+++ b/docs/Rules/MA0234.md
@@ -1,0 +1,49 @@
+# MA0234 - The event id written by an EventSource event method must match its \[Event\] attribute
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+The `[Event]` attribute of a method declares the id of the event, and the method must write that id. The runtime reports `Event {name} is givien event ID {id} but {other} was passed to WriteEvent.` when they differ, which usually happens when an event method is copied and its id is only updated in one of the two places.
+
+The rule reports the calls to `WriteEvent`, `WriteEventCore`, `WriteEventWithRelatedActivityId`, and `WriteEventWithRelatedActivityIdCore` whose event id is a constant that is not the one of the attribute.
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+
+    // ❌ The event 1 is written, but the method declares the event 2
+    [Event(2)]
+    public void Stop() => WriteEvent(1);
+}
+````
+
+## How to fix violations
+
+Write the event id of the attribute:
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    [Event(1)]
+    public void Start() => WriteEvent(1);
+
+    // ✅
+    [Event(2)]
+    public void Stop() => WriteEvent(2);
+}
+````
+
+## Related rules
+
+- [MA0229](MA0229.md) - The event id of an EventSource is already used by another event
+- [MA0235](MA0235.md) - The payload written by an EventSource event method must match its parameters

--- a/docs/Rules/MA0234.md
+++ b/docs/Rules/MA0234.md
@@ -43,6 +43,14 @@ sealed class SampleEventSource : EventSource
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0234.severity = warning
+````
+
 ## Related rules
 
 - [MA0229](MA0229.md) - The event id of an EventSource is already used by another event

--- a/docs/Rules/MA0235.md
+++ b/docs/Rules/MA0235.md
@@ -1,0 +1,80 @@
+# MA0235 - The payload written by an EventSource event method must match its parameters
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+The parameters of an event method describe the payload of the event in the manifest, and the method must write exactly those parameters. When it does not, the runtime reports `Event {id} was called with {n} argument(s), but it is defined with {m} parameter(s).`, and the consumers of the event source read a payload that does not match the manifest.
+
+This rule reports the calls to `WriteEvent` and `WriteEventWithRelatedActivityId` that do not write as many values as the method declares, and the calls to `WriteEventCore` and `WriteEventWithRelatedActivityIdCore` whose `eventDataCount` is not the number of parameters.
+
+A `Guid` parameter named `relatedActivityId` is not part of the payload: the runtime removes it from the parameters of the event, so it must not be counted.
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ❌ The method declares 2 parameters, but only 1 is written
+    [Event(1)]
+    public void Start(string name, int count) => WriteEvent(1, name);
+
+    // ❌ The method declares 2 parameters, but the event data count is 1
+    [Event(2)]
+    public unsafe void Stop(int arg1, long arg2)
+    {
+        EventData* data = stackalloc EventData[2];
+        // Fill the event data
+        WriteEventCore(2, 1, data);
+    }
+}
+````
+
+## How to fix violations
+
+Write every parameter of the method:
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ✅
+    [Event(1)]
+    public void Start(string name, int count) => WriteEvent(1, name, count);
+
+    // ✅
+    [Event(2)]
+    public unsafe void Stop(int arg1, long arg2)
+    {
+        EventData* data = stackalloc EventData[2];
+        // Fill the event data
+        WriteEventCore(2, 2, data);
+    }
+}
+````
+
+If the method is a helper that should not be an event, mark it with the `[NonEvent]` attribute:
+
+````c#
+using System;
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ✅ Not an event, so it can call an event method with the arguments it wants
+    [NonEvent]
+    public void Failed(Exception exception) => Failed(exception.ToString());
+
+    [Event(1)]
+    public void Failed(string message) => WriteEvent(1, message);
+}
+````
+
+## Related rules
+
+- [MA0236](MA0236.md) - The payload written by an EventSource event method must use the order of its parameters
+- [MA0237](MA0237.md) - An EventSource event method writing a related activity id must declare it as its first parameter

--- a/docs/Rules/MA0235.md
+++ b/docs/Rules/MA0235.md
@@ -74,6 +74,14 @@ sealed class SampleEventSource : EventSource
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0235.severity = warning
+````
+
 ## Related rules
 
 - [MA0236](MA0236.md) - The payload written by an EventSource event method must use the order of its parameters

--- a/docs/Rules/MA0236.md
+++ b/docs/Rules/MA0236.md
@@ -37,6 +37,14 @@ sealed class SampleEventSource : EventSource
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0236.severity = warning
+````
+
 ## Related rules
 
 - [MA0235](MA0235.md) - The payload written by an EventSource event method must match its parameters

--- a/docs/Rules/MA0236.md
+++ b/docs/Rules/MA0236.md
@@ -1,0 +1,42 @@
+# MA0236 - The payload written by an EventSource event method must use the order of its parameters
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+The parameters of an event method describe the payload of the event in the manifest, in the order they are declared. Writing them in another order compiles when their types are compatible, but the consumers of the event source then read each value under the name of another one.
+
+The rule only reports the calls whose arguments are all parameters of the method, as the other expressions cannot be matched to a parameter.
+
+## Motivation
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ❌ 'category' is written as the 'name' of the event, and the other way around
+    [Event(1)]
+    public void Start(string name, string category) => WriteEvent(1, category, name);
+}
+````
+
+## How to fix violations
+
+Write the parameters in the order they are declared, or declare them in the order they are written:
+
+````c#
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ✅
+    [Event(1)]
+    public void Start(string name, string category) => WriteEvent(1, name, category);
+}
+````
+
+## Related rules
+
+- [MA0235](MA0235.md) - The payload written by an EventSource event method must match its parameters

--- a/docs/Rules/MA0237.md
+++ b/docs/Rules/MA0237.md
@@ -1,0 +1,44 @@
+# MA0237 - An EventSource event method writing a related activity id must declare it as its first parameter
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+`WriteEventWithRelatedActivityId` writes an activity id that is not part of the payload of the event. The runtime only knows that by removing the first parameter of the method when it is a `Guid` named `relatedActivityId` (the comparison is case-insensitive). When the method does not declare it that way, the payload has one more value than the manifest declares, and the runtime throws an `ArgumentException` with the message `WriteEventWithRelatedActivityId called with a related activity ID, but the event method does not declare a 'relatedActivityId' parameter.`
+
+## Motivation
+
+````c#
+using System;
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ❌ The first parameter is not named 'relatedActivityId'
+    [Event(1)]
+    public void Start(Guid activityId, string name)
+        => WriteEventWithRelatedActivityId(1, activityId, name);
+}
+````
+
+## How to fix violations
+
+Name the first parameter `relatedActivityId`:
+
+````c#
+using System;
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ✅
+    [Event(1)]
+    public void Start(Guid relatedActivityId, string name)
+        => WriteEventWithRelatedActivityId(1, relatedActivityId, name);
+}
+````
+
+## Related rules
+
+- [MA0235](MA0235.md) - The payload written by an EventSource event method must match its parameters

--- a/docs/Rules/MA0237.md
+++ b/docs/Rules/MA0237.md
@@ -39,6 +39,14 @@ sealed class SampleEventSource : EventSource
 }
 ````
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0237.severity = warning
+````
+
 ## Related rules
 
 - [MA0235](MA0235.md) - The payload written by an EventSource event method must match its parameters

--- a/docs/Rules/MA0238.md
+++ b/docs/Rules/MA0238.md
@@ -1,0 +1,54 @@
+# MA0238 - The parameter type of an EventSource event method is not supported
+<!-- sources -->
+Source: [EventSourceImplementationAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs)
+<!-- sources -->
+
+## Description
+
+The parameters of an event method are written to the manifest of the event source, which only supports a fixed set of types. The runtime reports `Unsupported type {name} in event source.` for the other ones, and the whole event source becomes unusable.
+
+The supported types are `bool`, `byte`, `sbyte`, `char`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `string`, `DateTime`, `Guid`, `IntPtr`, `byte[]`, `byte*`, and the enumerations.
+
+The parameter types are not validated when the event source may use the self-describing format, which does not use a manifest: when it provides `EventSourceSettings` to its base constructor, or when it derives from another event source declared in the same compilation.
+
+A method is an event when it is not `static`, and either it has the `[Event]` attribute, or it is a public non-virtual method returning `void` that is not marked with `[NonEvent]`. This rule therefore also reports the public helper methods that are not meant to be events.
+
+## Motivation
+
+````c#
+using System;
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ❌ 'Uri' cannot be written to the manifest
+    [Event(1)]
+    public void Start(Uri uri) => WriteEvent(1, uri);
+}
+````
+
+## How to fix violations
+
+Convert the value to a supported type before writing it:
+
+````c#
+using System;
+using System.Diagnostics.Tracing;
+
+sealed class SampleEventSource : EventSource
+{
+    // ✅
+    [Event(1)]
+    public void Start(string uri) => WriteEvent(1, uri);
+
+    // ✅ Not an event, so its parameters are not written to the manifest
+    [NonEvent]
+    public void Start(Uri uri) => Start(uri.AbsoluteUri);
+}
+````
+
+The helper methods that are not events must be marked with the `[NonEvent]` attribute, or be non-public.
+
+## Related rules
+
+- [MA0235](MA0235.md) - The payload written by an EventSource event method must match its parameters

--- a/docs/Rules/MA0238.md
+++ b/docs/Rules/MA0238.md
@@ -49,6 +49,14 @@ sealed class SampleEventSource : EventSource
 
 The helper methods that are not events must be marked with the `[NonEvent]` attribute, or be non-public.
 
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0238.severity = warning
+````
+
 ## Related rules
 
 - [MA0235](MA0235.md) - The payload written by an EventSource event method must match its parameters

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -677,5 +677,35 @@ dotnet_diagnostic.MA0226.severity = error
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = error
 
-# MA0228: Invalid EventSource implementation
+# MA0228: The event id of an EventSource must be greater than zero
 dotnet_diagnostic.MA0228.severity = error
+
+# MA0229: The event id of an EventSource is already used by another event
+dotnet_diagnostic.MA0229.severity = error
+
+# MA0230: The event name of an EventSource is already used by another event
+dotnet_diagnostic.MA0230.severity = error
+
+# MA0231: An EventSource event method must not be static
+dotnet_diagnostic.MA0231.severity = error
+
+# MA0232: An EventSource event method must not be an explicit interface implementation
+dotnet_diagnostic.MA0232.severity = error
+
+# MA0233: An abstract EventSource must not declare event methods
+dotnet_diagnostic.MA0233.severity = error
+
+# MA0234: The event id written by an EventSource event method must match its [Event] attribute
+dotnet_diagnostic.MA0234.severity = error
+
+# MA0235: The payload written by an EventSource event method must match its parameters
+dotnet_diagnostic.MA0235.severity = error
+
+# MA0236: The payload written by an EventSource event method must use the order of its parameters
+dotnet_diagnostic.MA0236.severity = error
+
+# MA0237: An EventSource event method writing a related activity id must declare it as its first parameter
+dotnet_diagnostic.MA0237.severity = error
+
+# MA0238: The parameter type of an EventSource event method is not supported
+dotnet_diagnostic.MA0238.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -676,3 +676,6 @@ dotnet_diagnostic.MA0226.severity = error
 
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = error
+
+# MA0228: Invalid EventSource implementation
+dotnet_diagnostic.MA0228.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -676,3 +676,6 @@ dotnet_diagnostic.MA0226.severity = suggestion
 
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = suggestion
+
+# MA0228: Invalid EventSource implementation
+dotnet_diagnostic.MA0228.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -677,5 +677,35 @@ dotnet_diagnostic.MA0226.severity = suggestion
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = suggestion
 
-# MA0228: Invalid EventSource implementation
+# MA0228: The event id of an EventSource must be greater than zero
 dotnet_diagnostic.MA0228.severity = suggestion
+
+# MA0229: The event id of an EventSource is already used by another event
+dotnet_diagnostic.MA0229.severity = suggestion
+
+# MA0230: The event name of an EventSource is already used by another event
+dotnet_diagnostic.MA0230.severity = suggestion
+
+# MA0231: An EventSource event method must not be static
+dotnet_diagnostic.MA0231.severity = suggestion
+
+# MA0232: An EventSource event method must not be an explicit interface implementation
+dotnet_diagnostic.MA0232.severity = suggestion
+
+# MA0233: An abstract EventSource must not declare event methods
+dotnet_diagnostic.MA0233.severity = suggestion
+
+# MA0234: The event id written by an EventSource event method must match its [Event] attribute
+dotnet_diagnostic.MA0234.severity = suggestion
+
+# MA0235: The payload written by an EventSource event method must match its parameters
+dotnet_diagnostic.MA0235.severity = suggestion
+
+# MA0236: The payload written by an EventSource event method must use the order of its parameters
+dotnet_diagnostic.MA0236.severity = suggestion
+
+# MA0237: An EventSource event method writing a related activity id must declare it as its first parameter
+dotnet_diagnostic.MA0237.severity = suggestion
+
+# MA0238: The parameter type of an EventSource event method is not supported
+dotnet_diagnostic.MA0238.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -677,5 +677,35 @@ dotnet_diagnostic.MA0226.severity = warning
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = warning
 
-# MA0228: Invalid EventSource implementation
+# MA0228: The event id of an EventSource must be greater than zero
 dotnet_diagnostic.MA0228.severity = warning
+
+# MA0229: The event id of an EventSource is already used by another event
+dotnet_diagnostic.MA0229.severity = warning
+
+# MA0230: The event name of an EventSource is already used by another event
+dotnet_diagnostic.MA0230.severity = warning
+
+# MA0231: An EventSource event method must not be static
+dotnet_diagnostic.MA0231.severity = warning
+
+# MA0232: An EventSource event method must not be an explicit interface implementation
+dotnet_diagnostic.MA0232.severity = warning
+
+# MA0233: An abstract EventSource must not declare event methods
+dotnet_diagnostic.MA0233.severity = warning
+
+# MA0234: The event id written by an EventSource event method must match its [Event] attribute
+dotnet_diagnostic.MA0234.severity = warning
+
+# MA0235: The payload written by an EventSource event method must match its parameters
+dotnet_diagnostic.MA0235.severity = warning
+
+# MA0236: The payload written by an EventSource event method must use the order of its parameters
+dotnet_diagnostic.MA0236.severity = warning
+
+# MA0237: An EventSource event method writing a related activity id must declare it as its first parameter
+dotnet_diagnostic.MA0237.severity = warning
+
+# MA0238: The parameter type of an EventSource event method is not supported
+dotnet_diagnostic.MA0238.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -676,3 +676,6 @@ dotnet_diagnostic.MA0226.severity = warning
 
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = warning
+
+# MA0228: Invalid EventSource implementation
+dotnet_diagnostic.MA0228.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -676,3 +676,6 @@ dotnet_diagnostic.MA0226.severity = none
 
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = none
+
+# MA0228: Invalid EventSource implementation
+dotnet_diagnostic.MA0228.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -678,34 +678,34 @@ dotnet_diagnostic.MA0226.severity = none
 dotnet_diagnostic.MA0227.severity = none
 
 # MA0228: The event id of an EventSource must be greater than zero
-dotnet_diagnostic.MA0228.severity = warning
+dotnet_diagnostic.MA0228.severity = none
 
 # MA0229: The event id of an EventSource is already used by another event
-dotnet_diagnostic.MA0229.severity = warning
+dotnet_diagnostic.MA0229.severity = none
 
 # MA0230: The event name of an EventSource is already used by another event
-dotnet_diagnostic.MA0230.severity = warning
+dotnet_diagnostic.MA0230.severity = none
 
 # MA0231: An EventSource event method must not be static
-dotnet_diagnostic.MA0231.severity = warning
+dotnet_diagnostic.MA0231.severity = none
 
 # MA0232: An EventSource event method must not be an explicit interface implementation
-dotnet_diagnostic.MA0232.severity = warning
+dotnet_diagnostic.MA0232.severity = none
 
 # MA0233: An abstract EventSource must not declare event methods
-dotnet_diagnostic.MA0233.severity = warning
+dotnet_diagnostic.MA0233.severity = none
 
 # MA0234: The event id written by an EventSource event method must match its [Event] attribute
-dotnet_diagnostic.MA0234.severity = warning
+dotnet_diagnostic.MA0234.severity = none
 
 # MA0235: The payload written by an EventSource event method must match its parameters
-dotnet_diagnostic.MA0235.severity = warning
+dotnet_diagnostic.MA0235.severity = none
 
 # MA0236: The payload written by an EventSource event method must use the order of its parameters
-dotnet_diagnostic.MA0236.severity = warning
+dotnet_diagnostic.MA0236.severity = none
 
 # MA0237: An EventSource event method writing a related activity id must declare it as its first parameter
-dotnet_diagnostic.MA0237.severity = warning
+dotnet_diagnostic.MA0237.severity = none
 
 # MA0238: The parameter type of an EventSource event method is not supported
-dotnet_diagnostic.MA0238.severity = warning
+dotnet_diagnostic.MA0238.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -677,5 +677,35 @@ dotnet_diagnostic.MA0226.severity = none
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = none
 
-# MA0228: Invalid EventSource implementation
+# MA0228: The event id of an EventSource must be greater than zero
 dotnet_diagnostic.MA0228.severity = warning
+
+# MA0229: The event id of an EventSource is already used by another event
+dotnet_diagnostic.MA0229.severity = warning
+
+# MA0230: The event name of an EventSource is already used by another event
+dotnet_diagnostic.MA0230.severity = warning
+
+# MA0231: An EventSource event method must not be static
+dotnet_diagnostic.MA0231.severity = warning
+
+# MA0232: An EventSource event method must not be an explicit interface implementation
+dotnet_diagnostic.MA0232.severity = warning
+
+# MA0233: An abstract EventSource must not declare event methods
+dotnet_diagnostic.MA0233.severity = warning
+
+# MA0234: The event id written by an EventSource event method must match its [Event] attribute
+dotnet_diagnostic.MA0234.severity = warning
+
+# MA0235: The payload written by an EventSource event method must match its parameters
+dotnet_diagnostic.MA0235.severity = warning
+
+# MA0236: The payload written by an EventSource event method must use the order of its parameters
+dotnet_diagnostic.MA0236.severity = warning
+
+# MA0237: An EventSource event method writing a related activity id must declare it as its first parameter
+dotnet_diagnostic.MA0237.severity = warning
+
+# MA0238: The parameter type of an EventSource event method is not supported
+dotnet_diagnostic.MA0238.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -676,3 +676,6 @@ dotnet_diagnostic.MA0226.severity = none
 
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = none
+
+# MA0228: Invalid EventSource implementation
+dotnet_diagnostic.MA0228.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -677,5 +677,35 @@ dotnet_diagnostic.MA0226.severity = none
 # MA0227: Avoid using 'Enumerable.Contains' on a set
 dotnet_diagnostic.MA0227.severity = none
 
-# MA0228: Invalid EventSource implementation
+# MA0228: The event id of an EventSource must be greater than zero
 dotnet_diagnostic.MA0228.severity = none
+
+# MA0229: The event id of an EventSource is already used by another event
+dotnet_diagnostic.MA0229.severity = none
+
+# MA0230: The event name of an EventSource is already used by another event
+dotnet_diagnostic.MA0230.severity = none
+
+# MA0231: An EventSource event method must not be static
+dotnet_diagnostic.MA0231.severity = none
+
+# MA0232: An EventSource event method must not be an explicit interface implementation
+dotnet_diagnostic.MA0232.severity = none
+
+# MA0233: An abstract EventSource must not declare event methods
+dotnet_diagnostic.MA0233.severity = none
+
+# MA0234: The event id written by an EventSource event method must match its [Event] attribute
+dotnet_diagnostic.MA0234.severity = none
+
+# MA0235: The payload written by an EventSource event method must match its parameters
+dotnet_diagnostic.MA0235.severity = none
+
+# MA0236: The payload written by an EventSource event method must use the order of its parameters
+dotnet_diagnostic.MA0236.severity = none
+
+# MA0237: An EventSource event method writing a related activity id must declare it as its first parameter
+dotnet_diagnostic.MA0237.severity = none
+
+# MA0238: The parameter type of an EventSource event method is not supported
+dotnet_diagnostic.MA0238.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -227,7 +227,17 @@ internal static class RuleIdentifiers
     public const string SetRespectRequiredConstructorParametersOnJsonSerializerOptions = "MA0225";
     public const string EventSourceMustBeSealed = "MA0226";
     public const string AvoidEnumerableContainsOnSet = "MA0227";
-    public const string InvalidEventSourceImplementation = "MA0228";
+    public const string EventSourceEventIdMustBePositive = "MA0228";
+    public const string EventSourceDuplicateEventId = "MA0229";
+    public const string EventSourceDuplicateEventName = "MA0230";
+    public const string EventSourceEventMethodMustNotBeStatic = "MA0231";
+    public const string EventSourceEventMethodMustNotBeAnExplicitInterfaceImplementation = "MA0232";
+    public const string EventSourceAbstractTypeMustNotDeclareEventMethods = "MA0233";
+    public const string EventSourceMismatchedEventId = "MA0234";
+    public const string EventSourceMismatchedPayload = "MA0235";
+    public const string EventSourceMismatchedPayloadOrder = "MA0236";
+    public const string EventSourceMissingRelatedActivityIdParameter = "MA0237";
+    public const string EventSourceUnsupportedParameterType = "MA0238";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -227,6 +227,7 @@ internal static class RuleIdentifiers
     public const string SetRespectRequiredConstructorParametersOnJsonSerializerOptions = "MA0225";
     public const string EventSourceMustBeSealed = "MA0226";
     public const string AvoidEnumerableContainsOnSet = "MA0227";
+    public const string InvalidEventSourceImplementation = "MA0228";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs
@@ -3,19 +3,85 @@ using System.Globalization;
 namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyzer
+public sealed class EventSourceImplementationAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor Rule = new(
-        RuleIdentifiers.InvalidEventSourceImplementation,
-        title: "Invalid EventSource implementation",
-        messageFormat: "{0}",
+    private static readonly DiagnosticDescriptor EventIdMustBePositiveRule = CreateRule(
+        RuleIdentifiers.EventSourceEventIdMustBePositive,
+        title: "The event id of an EventSource must be greater than zero",
+        messageFormat: "The event id must be greater than zero");
+
+    private static readonly DiagnosticDescriptor DuplicateEventIdRule = CreateRule(
+        RuleIdentifiers.EventSourceDuplicateEventId,
+        title: "The event id of an EventSource is already used by another event",
+        messageFormat: "The event id '{0}' is already used by the event '{1}'");
+
+    private static readonly DiagnosticDescriptor DuplicateEventNameRule = CreateRule(
+        RuleIdentifiers.EventSourceDuplicateEventName,
+        title: "The event name of an EventSource is already used by another event",
+        messageFormat: "The event name '{0}' is already used by another event");
+
+    private static readonly DiagnosticDescriptor EventMethodMustNotBeStaticRule = CreateRule(
+        RuleIdentifiers.EventSourceEventMethodMustNotBeStatic,
+        title: "An EventSource event method must not be static",
+        messageFormat: "An event method must not be static");
+
+    private static readonly DiagnosticDescriptor EventMethodMustNotBeAnExplicitInterfaceImplementationRule = CreateRule(
+        RuleIdentifiers.EventSourceEventMethodMustNotBeAnExplicitInterfaceImplementation,
+        title: "An EventSource event method must not be an explicit interface implementation",
+        messageFormat: "An event method must not be an explicit interface implementation");
+
+    private static readonly DiagnosticDescriptor AbstractTypeMustNotDeclareEventMethodsRule = CreateRule(
+        RuleIdentifiers.EventSourceAbstractTypeMustNotDeclareEventMethods,
+        title: "An abstract EventSource must not declare event methods",
+        messageFormat: "An abstract EventSource must not declare event methods");
+
+    private static readonly DiagnosticDescriptor MismatchedEventIdRule = CreateRule(
+        RuleIdentifiers.EventSourceMismatchedEventId,
+        title: "The event id written by an EventSource event method must match its [Event] attribute",
+        messageFormat: "'{0}' is called with the event id '{1}' but the method declares the event id '{2}'");
+
+    private static readonly DiagnosticDescriptor MismatchedPayloadRule = CreateRule(
+        RuleIdentifiers.EventSourceMismatchedPayload,
+        title: "The payload written by an EventSource event method must match its parameters",
+        messageFormat: "'{0}' writes {1} payload item(s) but the event method declares {2} payload parameter(s)");
+
+    private static readonly DiagnosticDescriptor MismatchedPayloadOrderRule = CreateRule(
+        RuleIdentifiers.EventSourceMismatchedPayloadOrder,
+        title: "The payload written by an EventSource event method must use the order of its parameters",
+        messageFormat: "'{0}' must write the payload parameters of the event method in the order they are declared");
+
+    private static readonly DiagnosticDescriptor MissingRelatedActivityIdParameterRule = CreateRule(
+        RuleIdentifiers.EventSourceMissingRelatedActivityIdParameter,
+        title: "An EventSource event method writing a related activity id must declare it as its first parameter",
+        messageFormat: "The first parameter of an event method calling '{0}' must be a 'Guid' named 'relatedActivityId'");
+
+    private static readonly DiagnosticDescriptor UnsupportedParameterTypeRule = CreateRule(
+        RuleIdentifiers.EventSourceUnsupportedParameterType,
+        title: "The parameter type of an EventSource event method is not supported",
+        messageFormat: "The type '{0}' is not supported by EventSource");
+
+    private static DiagnosticDescriptor CreateRule(string ruleIdentifier, string title, string messageFormat) => new(
+        ruleIdentifier,
+        title: title,
+        messageFormat: messageFormat,
         RuleCategories.Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "",
-        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InvalidEventSourceImplementation));
+        helpLinkUri: RuleIdentifiers.GetHelpUri(ruleIdentifier));
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        EventIdMustBePositiveRule,
+        DuplicateEventIdRule,
+        DuplicateEventNameRule,
+        EventMethodMustNotBeStaticRule,
+        EventMethodMustNotBeAnExplicitInterfaceImplementationRule,
+        AbstractTypeMustNotDeclareEventMethodsRule,
+        MismatchedEventIdRule,
+        MismatchedPayloadRule,
+        MismatchedPayloadOrderRule,
+        MissingRelatedActivityIdParameterRule,
+        UnsupportedParameterTypeRule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -130,7 +196,7 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
                 return false;
 
             // Without the [Event] attribute, the runtime ignores the methods that do not return void and the virtual methods.
-            // Non-public methods are only ignored by this rule, as reporting them would be too noisy.
+            // Non-public methods are only ignored by these rules, as reporting them would be too noisy.
             return method is { IsStatic: false, ReturnsVoid: true, IsVirtual: false, IsOverride: false, IsAbstract: false, DeclaredAccessibility: Accessibility.Public };
         }
 
@@ -226,7 +292,7 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
             if (TryGetEventId(eventAttribute, out var declaredEventId) && declaredEventId > 0 &&
                 arguments[0].ConstantValue is { HasValue: true, Value: int writtenEventId } && writtenEventId != declaredEventId)
             {
-                context.ReportDiagnostic(Rule, arguments[0], $"'{targetMethod.Name}' is called with the event id '{writtenEventId.ToString(CultureInfo.InvariantCulture)}' but the method declares the event id '{declaredEventId.ToString(CultureInfo.InvariantCulture)}'");
+                context.ReportDiagnostic(MismatchedEventIdRule, arguments[0], targetMethod.Name, writtenEventId.ToString(CultureInfo.InvariantCulture), declaredEventId.ToString(CultureInfo.InvariantCulture));
             }
 
             // The runtime removes the first parameter from the payload when it is the related activity id
@@ -239,7 +305,7 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
 
             if (targetMethod.Name is "WriteEventWithRelatedActivityId" or "WriteEventWithRelatedActivityIdCore" && !hasRelatedActivityIdParameter)
             {
-                context.ReportDiagnostic(Rule, invocation, $"The first parameter of an event method calling '{targetMethod.Name}' must be a 'Guid' named 'relatedActivityId'");
+                context.ReportDiagnostic(MissingRelatedActivityIdParameterRule, invocation, targetMethod.Name);
                 return;
             }
 
@@ -249,7 +315,7 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
                 return;
             }
 
-            AnalyzePayloadArguments(context, invocation, arguments, payloadParameters, hasRelatedActivityIdParameter);
+            AnalyzePayloadArguments(context, invocation, arguments, payloadParameters);
         }
 
         private static void AnalyzeEventDataCount(OperationBlockAnalysisContext context, IInvocationOperation invocation, int payloadParameterCount)
@@ -261,14 +327,14 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
 
                 if (argument.Value.ConstantValue is { HasValue: true, Value: int eventDataCount } && eventDataCount != payloadParameterCount)
                 {
-                    context.ReportDiagnostic(Rule, argument, $"'{invocation.TargetMethod.Name}' is called with an event data count of '{eventDataCount.ToString(CultureInfo.InvariantCulture)}' but the method declares {payloadParameterCount.ToString(CultureInfo.InvariantCulture)} payload parameter(s)");
+                    context.ReportDiagnostic(MismatchedPayloadRule, argument, invocation.TargetMethod.Name, eventDataCount.ToString(CultureInfo.InvariantCulture), payloadParameterCount.ToString(CultureInfo.InvariantCulture));
                 }
 
                 return;
             }
         }
 
-        private static void AnalyzePayloadArguments(OperationBlockAnalysisContext context, IInvocationOperation invocation, List<IOperation> arguments, ImmutableArray<IParameterSymbol> payloadParameters, bool hasRelatedActivityIdParameter)
+        private static void AnalyzePayloadArguments(OperationBlockAnalysisContext context, IInvocationOperation invocation, List<IOperation> arguments, ImmutableArray<IParameterSymbol> payloadParameters)
         {
             // Skip the event id, and the related activity id which is not part of the payload
             var firstPayloadArgument = string.Equals(invocation.TargetMethod.Name, "WriteEventWithRelatedActivityId", StringComparison.Ordinal) ? 2 : 1;
@@ -278,11 +344,7 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
 
             if (payloadArgumentCount != payloadParameters.Length)
             {
-                var message = hasRelatedActivityIdParameter
-                    ? $"'{invocation.TargetMethod.Name}' is called with {payloadArgumentCount.ToString(CultureInfo.InvariantCulture)} payload argument(s) but the method declares {payloadParameters.Length.ToString(CultureInfo.InvariantCulture)} payload parameter(s), excluding the related activity id"
-                    : $"'{invocation.TargetMethod.Name}' is called with {payloadArgumentCount.ToString(CultureInfo.InvariantCulture)} payload argument(s) but the method declares {payloadParameters.Length.ToString(CultureInfo.InvariantCulture)} payload parameter(s)";
-
-                context.ReportDiagnostic(Rule, invocation, message);
+                context.ReportDiagnostic(MismatchedPayloadRule, invocation, invocation.TargetMethod.Name, payloadArgumentCount.ToString(CultureInfo.InvariantCulture), payloadParameters.Length.ToString(CultureInfo.InvariantCulture));
                 return;
             }
 
@@ -299,7 +361,7 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
 
             if (!isSameOrder)
             {
-                context.ReportDiagnostic(Rule, invocation, $"'{invocation.TargetMethod.Name}' must be called with the payload parameters of the method in the order they are declared");
+                context.ReportDiagnostic(MismatchedPayloadOrderRule, invocation, invocation.TargetMethod.Name);
             }
         }
 
@@ -362,7 +424,7 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
                     // The events must be declared by the derived types, as the runtime only looks at the methods declared by the type itself
                     if (eventAttribute is not null)
                     {
-                        context.ReportDiagnostic(Rule, GetLocation(eventAttribute, method, context.CancellationToken), "An abstract EventSource must not declare event methods");
+                        context.ReportDiagnostic(AbstractTypeMustNotDeclareEventMethodsRule, GetLocation(eventAttribute, method, context.CancellationToken));
                     }
 
                     continue;
@@ -372,26 +434,26 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
                 {
                     if (method.IsStatic)
                     {
-                        context.ReportDiagnostic(Rule, method, "An event method must not be static");
+                        context.ReportDiagnostic(EventMethodMustNotBeStaticRule, method);
                         continue;
                     }
 
                     if (method.MethodKind is MethodKind.ExplicitInterfaceImplementation)
                     {
-                        context.ReportDiagnostic(Rule, method, "An event method must not be an explicit interface implementation");
+                        context.ReportDiagnostic(EventMethodMustNotBeAnExplicitInterfaceImplementationRule, method);
                     }
 
                     if (TryGetEventId(eventAttribute, out var eventId))
                     {
                         if (eventId <= 0)
                         {
-                            context.ReportDiagnostic(Rule, GetLocation(eventAttribute, method, context.CancellationToken), "The event id must be greater than 0");
+                            context.ReportDiagnostic(EventIdMustBePositiveRule, GetLocation(eventAttribute, method, context.CancellationToken));
                             continue;
                         }
 
                         if (eventIds.TryGetValue(eventId, out var otherEventName))
                         {
-                            context.ReportDiagnostic(Rule, GetLocation(eventAttribute, method, context.CancellationToken), $"The event id '{eventId.ToString(CultureInfo.InvariantCulture)}' is already used by the event '{otherEventName}'");
+                            context.ReportDiagnostic(DuplicateEventIdRule, GetLocation(eventAttribute, method, context.CancellationToken), eventId.ToString(CultureInfo.InvariantCulture), otherEventName);
                         }
                         else
                         {
@@ -402,7 +464,7 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
 
                 if (!eventNames.Add(method.Name))
                 {
-                    context.ReportDiagnostic(Rule, method, $"The event name '{method.Name}' is already used by another event");
+                    context.ReportDiagnostic(DuplicateEventNameRule, method, method.Name);
                 }
 
                 if (validateParameterTypes)
@@ -411,7 +473,7 @@ public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyze
                     {
                         if (!analyzerContext.IsSupportedParameterType(parameter.Type))
                         {
-                            context.ReportDiagnostic(Rule, parameter, $"The type '{parameter.Type.ToDisplayString()}' is not supported by EventSource");
+                            context.ReportDiagnostic(UnsupportedParameterTypeRule, parameter, parameter.Type.ToDisplayString());
                         }
                     }
                 }

--- a/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EventSourceImplementationAnalyzer.cs
@@ -66,7 +66,7 @@ public sealed class EventSourceImplementationAnalyzer : DiagnosticAnalyzer
         messageFormat: messageFormat,
         RuleCategories.Usage,
         DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
+        isEnabledByDefault: false,
         description: "",
         helpLinkUri: RuleIdentifiers.GetHelpUri(ruleIdentifier));
 

--- a/src/Meziantou.Analyzer/Rules/InvalidEventSourceImplementationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/InvalidEventSourceImplementationAnalyzer.cs
@@ -1,0 +1,436 @@
+using System.Globalization;
+
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidEventSourceImplementationAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.InvalidEventSourceImplementation,
+        title: "Invalid EventSource implementation",
+        messageFormat: "{0}",
+        RuleCategories.Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.InvalidEventSourceImplementation));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(ctx =>
+        {
+            var analyzerContext = new AnalyzerContext(ctx.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            ctx.RegisterSymbolStartAction(analyzerContext.AnalyzeNamedType, SymbolKind.NamedType);
+        });
+    }
+
+    private sealed class AnalyzerContext
+    {
+        // The Microsoft.Diagnostics.Tracing.EventSource NuGet package is a copy of the BCL implementation in another namespace
+        private static readonly string[] Namespaces = ["System.Diagnostics.Tracing", "Microsoft.Diagnostics.Tracing"];
+
+        private readonly ImmutableArray<INamedTypeSymbol> _eventSourceSymbols;
+        private readonly ImmutableArray<INamedTypeSymbol> _eventAttributeSymbols;
+        private readonly ImmutableArray<INamedTypeSymbol> _nonEventAttributeSymbols;
+        private readonly ImmutableArray<INamedTypeSymbol> _eventSourceSettingsSymbols;
+        private readonly INamedTypeSymbol? _guidSymbol;
+
+        public AnalyzerContext(Compilation compilation)
+        {
+            _eventSourceSymbols = GetSymbols(compilation, "EventSource");
+            _eventAttributeSymbols = GetSymbols(compilation, "EventAttribute");
+            _nonEventAttributeSymbols = GetSymbols(compilation, "NonEventAttribute");
+            _eventSourceSettingsSymbols = GetSymbols(compilation, "EventSourceSettings");
+            _guidSymbol = compilation.GetBestTypeByMetadataName("System.Guid");
+        }
+
+        public bool IsValid => !_eventSourceSymbols.IsEmpty;
+
+        private static ImmutableArray<INamedTypeSymbol> GetSymbols(Compilation compilation, string typeName)
+        {
+            var result = ImmutableArray.CreateBuilder<INamedTypeSymbol>(Namespaces.Length);
+            foreach (var ns in Namespaces)
+            {
+                var symbol = compilation.GetBestTypeByMetadataName(ns + "." + typeName);
+                if (symbol is not null)
+                {
+                    result.Add(symbol);
+                }
+            }
+
+            return result.ToImmutable();
+        }
+
+        private static bool IsAnyOf(ITypeSymbol? symbol, ImmutableArray<INamedTypeSymbol> expectedSymbols)
+        {
+            foreach (var expectedSymbol in expectedSymbols)
+            {
+                if (symbol.IsEqualTo(expectedSymbol))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public bool IsEventSourceBaseType(ITypeSymbol? symbol) => IsAnyOf(symbol, _eventSourceSymbols);
+
+        public bool IsEventSourceSettings(ITypeSymbol? symbol) => IsAnyOf(symbol, _eventSourceSettingsSymbols);
+
+        public bool InheritsFromEventSource(ITypeSymbol? symbol)
+        {
+            if (symbol is null)
+                return false;
+
+            foreach (var eventSourceSymbol in _eventSourceSymbols)
+            {
+                if (symbol.InheritsFrom(eventSourceSymbol))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public bool IsEventSourceOrDerived(ITypeSymbol? symbol) => IsEventSourceBaseType(symbol) || InheritsFromEventSource(symbol);
+
+        private static AttributeData? GetAttribute(ISymbol symbol, ImmutableArray<INamedTypeSymbol> attributeSymbols)
+        {
+            foreach (var attribute in symbol.GetAttributes())
+            {
+                if (IsAnyOf(attribute.AttributeClass, attributeSymbols))
+                    return attribute;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Determines if the method is considered as an event by the runtime, using the same rules as
+        /// <c>EventSource.CreateManifestAndDescriptors</c>.
+        /// </summary>
+        public bool IsEventMethod(IMethodSymbol method, out AttributeData? eventAttribute)
+        {
+            eventAttribute = null;
+            if (method.MethodKind is not (MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation))
+                return false;
+
+            // The [Event] attribute takes precedence over everything else, including [NonEvent]
+            eventAttribute = GetAttribute(method, _eventAttributeSymbols);
+            if (eventAttribute is not null)
+                return true;
+
+            if (GetAttribute(method, _nonEventAttributeSymbols) is not null)
+                return false;
+
+            // Without the [Event] attribute, the runtime ignores the methods that do not return void and the virtual methods.
+            // Non-public methods are only ignored by this rule, as reporting them would be too noisy.
+            return method is { IsStatic: false, ReturnsVoid: true, IsVirtual: false, IsOverride: false, IsAbstract: false, DeclaredAccessibility: Accessibility.Public };
+        }
+
+        public bool IsRelatedActivityIdParameter(IParameterSymbol parameter)
+            => parameter.Type.IsEqualTo(_guidSymbol) && string.Equals(parameter.Name, "relatedActivityId", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Determines if the type can be written to the manifest of an event source, using the same rules as
+        /// <c>ManifestBuilder.GetTypeName</c>.
+        /// </summary>
+        public bool IsSupportedParameterType(ITypeSymbol type)
+        {
+            if (type.TypeKind is TypeKind.Enum && type is INamedTypeSymbol { EnumUnderlyingType: not null } enumType)
+            {
+                type = enumType.EnumUnderlyingType;
+            }
+
+            if (type.SpecialType is SpecialType.System_Boolean or SpecialType.System_Byte or SpecialType.System_SByte
+                or SpecialType.System_Char or SpecialType.System_Int16 or SpecialType.System_UInt16
+                or SpecialType.System_Int32 or SpecialType.System_UInt32 or SpecialType.System_Int64
+                or SpecialType.System_UInt64 or SpecialType.System_Single or SpecialType.System_Double
+                or SpecialType.System_String or SpecialType.System_DateTime or SpecialType.System_IntPtr)
+            {
+                return true;
+            }
+
+            if (type.IsEqualTo(_guidSymbol))
+                return true;
+
+            // byte[] and byte* are written as a binary blob
+            return type is IArrayTypeSymbol { Rank: 1, ElementType.SpecialType: SpecialType.System_Byte }
+                or IPointerTypeSymbol { PointedAtType.SpecialType: SpecialType.System_Byte };
+        }
+
+        public void AnalyzeNamedType(SymbolStartAnalysisContext context)
+        {
+            var symbol = (INamedTypeSymbol)context.Symbol;
+            if (symbol.TypeKind is not TypeKind.Class || symbol.IsStatic)
+                return;
+
+            if (!InheritsFromEventSource(symbol))
+                return;
+
+            var typeContext = new EventSourceTypeContext(this, symbol);
+            context.RegisterOperationBlockAction(typeContext.AnalyzeOperationBlock);
+            context.RegisterSymbolEndAction(typeContext.ReportTypeDiagnostics);
+        }
+    }
+
+    private sealed class EventSourceTypeContext(AnalyzerContext analyzerContext, INamedTypeSymbol symbol)
+    {
+        // Written by the operation block actions, which run before the symbol end action
+        private volatile bool _useSelfDescribingEvents;
+
+        public void AnalyzeOperationBlock(OperationBlockAnalysisContext context)
+        {
+            AttributeData? eventAttribute = null;
+            var eventMethod = !symbol.IsAbstract && context.OwningSymbol is IMethodSymbol method && analyzerContext.IsEventMethod(method, out eventAttribute) ? method : null;
+
+            foreach (var block in context.OperationBlocks)
+            {
+                foreach (var operation in block.DescendantsAndSelf())
+                {
+                    // EventSourceSettings is provided to the base constructor, and it may enable self-describing
+                    // events, in which case the payload is not validated against a manifest
+                    if (analyzerContext.IsEventSourceSettings(operation.Type))
+                    {
+                        _useSelfDescribingEvents = true;
+                    }
+
+                    if (eventMethod is not null && operation is IInvocationOperation invocation)
+                    {
+                        AnalyzeWriteEventInvocation(context, eventMethod, eventAttribute, invocation);
+                    }
+                }
+            }
+        }
+
+        private void AnalyzeWriteEventInvocation(OperationBlockAnalysisContext context, IMethodSymbol eventMethod, AttributeData? eventAttribute, IInvocationOperation invocation)
+        {
+            var targetMethod = invocation.TargetMethod;
+            if (targetMethod.Name is not ("WriteEvent" or "WriteEventCore" or "WriteEventWithRelatedActivityId" or "WriteEventWithRelatedActivityIdCore"))
+                return;
+
+            // Custom overloads can be declared by a "Utility EventSource"
+            if (!analyzerContext.IsEventSourceOrDerived(targetMethod.ContainingType))
+                return;
+
+            var arguments = GetArguments(invocation);
+            if (arguments is null || arguments.Count is 0)
+                return;
+
+            if (TryGetEventId(eventAttribute, out var declaredEventId) && declaredEventId > 0 &&
+                arguments[0].ConstantValue is { HasValue: true, Value: int writtenEventId } && writtenEventId != declaredEventId)
+            {
+                context.ReportDiagnostic(Rule, arguments[0], $"'{targetMethod.Name}' is called with the event id '{writtenEventId.ToString(CultureInfo.InvariantCulture)}' but the method declares the event id '{declaredEventId.ToString(CultureInfo.InvariantCulture)}'");
+            }
+
+            // The runtime removes the first parameter from the payload when it is the related activity id
+            var payloadParameters = eventMethod.Parameters;
+            var hasRelatedActivityIdParameter = payloadParameters.Length > 0 && analyzerContext.IsRelatedActivityIdParameter(payloadParameters[0]);
+            if (hasRelatedActivityIdParameter)
+            {
+                payloadParameters = payloadParameters.RemoveAt(0);
+            }
+
+            if (targetMethod.Name is "WriteEventWithRelatedActivityId" or "WriteEventWithRelatedActivityIdCore" && !hasRelatedActivityIdParameter)
+            {
+                context.ReportDiagnostic(Rule, invocation, $"The first parameter of an event method calling '{targetMethod.Name}' must be a 'Guid' named 'relatedActivityId'");
+                return;
+            }
+
+            if (targetMethod.Name is "WriteEventCore" or "WriteEventWithRelatedActivityIdCore")
+            {
+                AnalyzeEventDataCount(context, invocation, payloadParameters.Length);
+                return;
+            }
+
+            AnalyzePayloadArguments(context, invocation, arguments, payloadParameters, hasRelatedActivityIdParameter);
+        }
+
+        private static void AnalyzeEventDataCount(OperationBlockAnalysisContext context, IInvocationOperation invocation, int payloadParameterCount)
+        {
+            foreach (var argument in invocation.Arguments)
+            {
+                if (argument.Parameter is null || !string.Equals(argument.Parameter.Name, "eventDataCount", StringComparison.Ordinal))
+                    continue;
+
+                if (argument.Value.ConstantValue is { HasValue: true, Value: int eventDataCount } && eventDataCount != payloadParameterCount)
+                {
+                    context.ReportDiagnostic(Rule, argument, $"'{invocation.TargetMethod.Name}' is called with an event data count of '{eventDataCount.ToString(CultureInfo.InvariantCulture)}' but the method declares {payloadParameterCount.ToString(CultureInfo.InvariantCulture)} payload parameter(s)");
+                }
+
+                return;
+            }
+        }
+
+        private static void AnalyzePayloadArguments(OperationBlockAnalysisContext context, IInvocationOperation invocation, List<IOperation> arguments, ImmutableArray<IParameterSymbol> payloadParameters, bool hasRelatedActivityIdParameter)
+        {
+            // Skip the event id, and the related activity id which is not part of the payload
+            var firstPayloadArgument = string.Equals(invocation.TargetMethod.Name, "WriteEventWithRelatedActivityId", StringComparison.Ordinal) ? 2 : 1;
+            var payloadArgumentCount = arguments.Count - firstPayloadArgument;
+            if (payloadArgumentCount < 0)
+                return;
+
+            if (payloadArgumentCount != payloadParameters.Length)
+            {
+                var message = hasRelatedActivityIdParameter
+                    ? $"'{invocation.TargetMethod.Name}' is called with {payloadArgumentCount.ToString(CultureInfo.InvariantCulture)} payload argument(s) but the method declares {payloadParameters.Length.ToString(CultureInfo.InvariantCulture)} payload parameter(s), excluding the related activity id"
+                    : $"'{invocation.TargetMethod.Name}' is called with {payloadArgumentCount.ToString(CultureInfo.InvariantCulture)} payload argument(s) but the method declares {payloadParameters.Length.ToString(CultureInfo.InvariantCulture)} payload parameter(s)";
+
+                context.ReportDiagnostic(Rule, invocation, message);
+                return;
+            }
+
+            // Only report the order when every argument is a parameter of the method, as the other expressions
+            // cannot be matched to a parameter
+            var isSameOrder = true;
+            for (var i = 0; i < payloadParameters.Length; i++)
+            {
+                if (UnwrapConversions(arguments[firstPayloadArgument + i]) is not IParameterReferenceOperation parameterReference)
+                    return;
+
+                isSameOrder &= parameterReference.Parameter.IsEqualTo(payloadParameters[i]);
+            }
+
+            if (!isSameOrder)
+            {
+                context.ReportDiagnostic(Rule, invocation, $"'{invocation.TargetMethod.Name}' must be called with the payload parameters of the method in the order they are declared");
+            }
+        }
+
+        private static IOperation UnwrapConversions(IOperation operation)
+        {
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            return operation;
+        }
+
+        /// <summary>
+        /// Gets the arguments of the invocation in the order of the parameters, the ones of the <c>params</c> parameter
+        /// being expanded. Returns <see langword="null"/> when the arguments cannot be matched to the parameters.
+        /// </summary>
+        private static List<IOperation>? GetArguments(IInvocationOperation invocation)
+        {
+            var result = new List<IOperation>(invocation.Arguments.Length);
+            foreach (var argument in invocation.Arguments)
+            {
+                if (argument.Parameter?.IsParams is true)
+                {
+                    // An array can be provided instead of the expanded arguments
+                    if (argument is not { ArgumentKind: ArgumentKind.ParamArray, Value: IArrayCreationOperation { Initializer: not null } arrayCreation })
+                        return null;
+
+                    foreach (var elementValue in arrayCreation.Initializer.ElementValues)
+                    {
+                        result.Add(elementValue);
+                    }
+                }
+                else if (argument.ArgumentKind is ArgumentKind.Explicit)
+                {
+                    result.Add(argument.Value);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            return result;
+        }
+
+        public void ReportTypeDiagnostics(SymbolAnalysisContext context)
+        {
+            var validateParameterTypes = !_useSelfDescribingEvents && analyzerContext.IsEventSourceBaseType(symbol.BaseType);
+            var eventIds = new Dictionary<int, string>();
+            var eventNames = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var member in symbol.GetMembers())
+            {
+                if (member is not IMethodSymbol method || !analyzerContext.IsEventMethod(method, out var eventAttribute))
+                    continue;
+
+                if (symbol.IsAbstract)
+                {
+                    // The events must be declared by the derived types, as the runtime only looks at the methods declared by the type itself
+                    if (eventAttribute is not null)
+                    {
+                        context.ReportDiagnostic(Rule, GetLocation(eventAttribute, method, context.CancellationToken), "An abstract EventSource must not declare event methods");
+                    }
+
+                    continue;
+                }
+
+                if (eventAttribute is not null)
+                {
+                    if (method.IsStatic)
+                    {
+                        context.ReportDiagnostic(Rule, method, "An event method must not be static");
+                        continue;
+                    }
+
+                    if (method.MethodKind is MethodKind.ExplicitInterfaceImplementation)
+                    {
+                        context.ReportDiagnostic(Rule, method, "An event method must not be an explicit interface implementation");
+                    }
+
+                    if (TryGetEventId(eventAttribute, out var eventId))
+                    {
+                        if (eventId <= 0)
+                        {
+                            context.ReportDiagnostic(Rule, GetLocation(eventAttribute, method, context.CancellationToken), "The event id must be greater than 0");
+                            continue;
+                        }
+
+                        if (eventIds.TryGetValue(eventId, out var otherEventName))
+                        {
+                            context.ReportDiagnostic(Rule, GetLocation(eventAttribute, method, context.CancellationToken), $"The event id '{eventId.ToString(CultureInfo.InvariantCulture)}' is already used by the event '{otherEventName}'");
+                        }
+                        else
+                        {
+                            eventIds.Add(eventId, method.Name);
+                        }
+                    }
+                }
+
+                if (!eventNames.Add(method.Name))
+                {
+                    context.ReportDiagnostic(Rule, method, $"The event name '{method.Name}' is already used by another event");
+                }
+
+                if (validateParameterTypes)
+                {
+                    foreach (var parameter in method.Parameters)
+                    {
+                        if (!analyzerContext.IsSupportedParameterType(parameter.Type))
+                        {
+                            context.ReportDiagnostic(Rule, parameter, $"The type '{parameter.Type.ToDisplayString()}' is not supported by EventSource");
+                        }
+                    }
+                }
+            }
+        }
+
+        private static Location GetLocation(AttributeData attribute, ISymbol fallbackSymbol, CancellationToken cancellationToken)
+            => attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken).GetLocation() ?? fallbackSymbol.Locations[0];
+
+        private static bool TryGetEventId(AttributeData? attribute, out int eventId)
+        {
+            if (attribute is { ConstructorArguments: [{ Kind: TypedConstantKind.Primitive, Value: int value }, ..] })
+            {
+                eventId = value;
+                return true;
+            }
+
+            eventId = 0;
+            return false;
+        }
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/EventSourceImplementationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/EventSourceImplementationAnalyzerTests.cs
@@ -1,16 +1,16 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
-    Meziantou.Analyzer.Rules.InvalidEventSourceImplementationAnalyzer>;
+    Meziantou.Analyzer.Rules.EventSourceImplementationAnalyzer>;
 
 namespace Meziantou.Analyzer.Test.Rules;
 
-public sealed class InvalidEventSourceImplementationAnalyzerTests
+public sealed class EventSourceImplementationAnalyzerTests
 {
-    private static Task RunAsync(string testCode, string expectedMessage)
+    private static Task RunAsync(string testCode, string expectedRuleId, string expectedMessage)
     {
         var test = new AnalyzerTest { TestCode = testCode };
-        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0228", DiagnosticSeverity.Warning).WithLocation(0).WithMessage(expectedMessage));
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(expectedRuleId, DiagnosticSeverity.Warning).WithLocation(0).WithMessage(expectedMessage));
         return test.RunAsync();
     }
 
@@ -238,7 +238,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [Event(1)]
                 public void Start() => WriteEvent({|#0:2|});
             }
-            """, "'WriteEvent' is called with the event id '2' but the method declares the event id '1'");
+            """, "MA0234", "'WriteEvent' is called with the event id '2' but the method declares the event id '1'");
     }
 
     [Fact]
@@ -255,7 +255,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [{|#0:Event(1)|}]
                 public void Stop() => WriteEvent(1);
             }
-            """, "The event id '1' is already used by the event 'Start'");
+            """, "MA0229", "The event id '1' is already used by the event 'Start'");
     }
 
     [Fact]
@@ -269,7 +269,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [{|#0:Event(0)|}]
                 public void Start() => WriteEvent(0);
             }
-            """, "The event id must be greater than 0");
+            """, "MA0228", "The event id must be greater than zero");
     }
 
     [Fact]
@@ -286,7 +286,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [Event(2)]
                 public void {|#0:Start|}(string name) => WriteEvent(2, name);
             }
-            """, "The event name 'Start' is already used by another event");
+            """, "MA0230", "The event name 'Start' is already used by another event");
     }
 
     [Fact]
@@ -300,7 +300,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [Event(1)]
                 public void Start(string name, int count) => {|#0:WriteEvent(1, name)|};
             }
-            """, "'WriteEvent' is called with 1 payload argument(s) but the method declares 2 payload parameter(s)");
+            """, "MA0235", "'WriteEvent' writes 1 payload item(s) but the event method declares 2 payload parameter(s)");
     }
 
     [Fact]
@@ -314,7 +314,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [Event(1)]
                 public void Start(string name) => {|#0:WriteEvent(1, name, name)|};
             }
-            """, "'WriteEvent' is called with 2 payload argument(s) but the method declares 1 payload parameter(s)");
+            """, "MA0235", "'WriteEvent' writes 2 payload item(s) but the event method declares 1 payload parameter(s)");
     }
 
     [Fact]
@@ -328,7 +328,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [Event(1)]
                 public void Start(string name, string category) => {|#0:WriteEvent(1, category, name)|};
             }
-            """, "'WriteEvent' must be called with the payload parameters of the method in the order they are declared");
+            """, "MA0236", "'WriteEvent' must write the payload parameters of the event method in the order they are declared");
     }
 
     [Fact]
@@ -343,7 +343,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [Event(1)]
                 public void Start(Uri {|#0:uri|}) => WriteEvent(1, uri);
             }
-            """, "The type 'System.Uri' is not supported by EventSource");
+            """, "MA0238", "The type 'System.Uri' is not supported by EventSource");
     }
 
     [Fact]
@@ -357,7 +357,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [Event(1)]
                 public static void {|#0:Start|}() { }
             }
-            """, "An event method must not be static");
+            """, "MA0231", "An event method must not be static");
     }
 
     [Fact]
@@ -371,7 +371,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [{|#0:Event(1)|}]
                 public void Start() => WriteEvent(1);
             }
-            """, "An abstract EventSource must not declare event methods");
+            """, "MA0233", "An abstract EventSource must not declare event methods");
     }
 
     [Fact]
@@ -390,7 +390,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [Event(1)]
                 void ISample.{|#0:Start|}() => WriteEvent(1);
             }
-            """, "An event method must not be an explicit interface implementation");
+            """, "MA0232", "An event method must not be an explicit interface implementation");
     }
 
     [Fact]
@@ -408,7 +408,7 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                     WriteEventCore(1, {|#0:1|}, data);
                 }
             }
-            """, "'WriteEventCore' is called with an event data count of '1' but the method declares 2 payload parameter(s)");
+            """, "MA0235", "'WriteEventCore' writes 1 payload item(s) but the event method declares 2 payload parameter(s)");
     }
 
     [Fact]
@@ -423,6 +423,6 @@ public sealed class InvalidEventSourceImplementationAnalyzerTests
                 [Event(1)]
                 public void Start(Guid activityId, string name) => {|#0:WriteEventWithRelatedActivityId(1, activityId, name)|};
             }
-            """, "The first parameter of an event method calling 'WriteEventWithRelatedActivityId' must be a 'Guid' named 'relatedActivityId'");
+            """, "MA0237", "The first parameter of an event method calling 'WriteEventWithRelatedActivityId' must be a 'Guid' named 'relatedActivityId'");
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/InvalidEventSourceImplementationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/InvalidEventSourceImplementationAnalyzerTests.cs
@@ -1,0 +1,428 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
+    Meziantou.Analyzer.Rules.InvalidEventSourceImplementationAnalyzer>;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class InvalidEventSourceImplementationAnalyzerTests
+{
+    private static Task RunAsync(string testCode, string expectedMessage)
+    {
+        var test = new AnalyzerTest { TestCode = testCode };
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0228", DiagnosticSeverity.Warning).WithLocation(0).WithMessage(expectedMessage));
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ValidEventSource_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                    [Event(1)]
+                    public void Start() => WriteEvent(1);
+
+                    [Event(2)]
+                    public void Stop(string name, int count) => WriteEvent(2, name, count);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task NotAnEventSource_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                sealed class Sample
+                {
+                    public void Start() => WriteEvent(2);
+
+                    private void WriteEvent(int eventId) { }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task NonEventMethod_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                    [NonEvent]
+                    public void Start(string name, int count) => WriteEvent(1, name);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task NonPublicMethodWithoutEventAttribute_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                    private void Start(string name, int count) => WriteEvent(1, name);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task ArgumentIsNotAParameter_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                    [Event(1)]
+                    public void Start(string name) => WriteEvent(1, name.Trim());
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task ArgumentIsAnEnumConvertedToItsUnderlyingType_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                enum Level { None }
+
+                sealed class Sample : EventSource
+                {
+                    [Event(1)]
+                    public void Start(Level level) => WriteEvent(1, (int)level);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task ArgumentsProvidedAsAnArray_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                    [Event(1)]
+                    public void Start(string name, int count)
+                    {
+                        object[] args = [name, count];
+                        WriteEvent(1, args);
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task UtilityEventSource_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                abstract class UtilitySample : EventSource
+                {
+                    protected unsafe void WriteEvent(int eventId, int arg1, long arg2)
+                    {
+                        EventData* data = stackalloc EventData[2];
+                        WriteEventCore(eventId, 2, data);
+                    }
+                }
+
+                sealed class Sample : UtilitySample
+                {
+                    [Event(1)]
+                    public void Start(int arg1, long arg2) => WriteEvent(1, arg1, arg2);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task WriteEventCore_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                    [Event(1)]
+                    public unsafe void Start(int arg1, long arg2)
+                    {
+                        EventData* data = stackalloc EventData[2];
+                        WriteEventCore(1, 2, data);
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task WriteEventWithRelatedActivityId_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System;
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                    [Event(1)]
+                    public void Start(Guid relatedActivityId, string name) => WriteEventWithRelatedActivityId(1, relatedActivityId, name);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task SelfDescribingEvents_UnsupportedParameterType_NoDiagnostic()
+    {
+        return new AnalyzerTest
+        {
+            TestCode = """
+                using System.Diagnostics.Tracing;
+
+                sealed class Sample : EventSource
+                {
+                    public Sample()
+                        : base("Sample", EventSourceSettings.EtwSelfDescribingEventFormat)
+                    {
+                    }
+
+                    [Event(1)]
+                    public void Start(object value) => WriteEvent(1, value);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task MismatchedEventId_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public void Start() => WriteEvent({|#0:2|});
+            }
+            """, "'WriteEvent' is called with the event id '2' but the method declares the event id '1'");
+    }
+
+    [Fact]
+    public Task DuplicatedEventId_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public void Start() => WriteEvent(1);
+
+                [{|#0:Event(1)|}]
+                public void Stop() => WriteEvent(1);
+            }
+            """, "The event id '1' is already used by the event 'Start'");
+    }
+
+    [Fact]
+    public Task NonPositiveEventId_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [{|#0:Event(0)|}]
+                public void Start() => WriteEvent(0);
+            }
+            """, "The event id must be greater than 0");
+    }
+
+    [Fact]
+    public Task DuplicatedEventName_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public void Start() => WriteEvent(1);
+
+                [Event(2)]
+                public void {|#0:Start|}(string name) => WriteEvent(2, name);
+            }
+            """, "The event name 'Start' is already used by another event");
+    }
+
+    [Fact]
+    public Task TooFewArguments_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public void Start(string name, int count) => {|#0:WriteEvent(1, name)|};
+            }
+            """, "'WriteEvent' is called with 1 payload argument(s) but the method declares 2 payload parameter(s)");
+    }
+
+    [Fact]
+    public Task TooManyArguments_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public void Start(string name) => {|#0:WriteEvent(1, name, name)|};
+            }
+            """, "'WriteEvent' is called with 2 payload argument(s) but the method declares 1 payload parameter(s)");
+    }
+
+    [Fact]
+    public Task InvalidArgumentOrder_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public void Start(string name, string category) => {|#0:WriteEvent(1, category, name)|};
+            }
+            """, "'WriteEvent' must be called with the payload parameters of the method in the order they are declared");
+    }
+
+    [Fact]
+    public Task UnsupportedParameterType_Diagnostic()
+    {
+        return RunAsync("""
+            using System;
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public void Start(Uri {|#0:uri|}) => WriteEvent(1, uri);
+            }
+            """, "The type 'System.Uri' is not supported by EventSource");
+    }
+
+    [Fact]
+    public Task StaticEventMethod_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public static void {|#0:Start|}() { }
+            }
+            """, "An event method must not be static");
+    }
+
+    [Fact]
+    public Task AbstractEventSourceDeclaringAnEventMethod_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            abstract class Sample : EventSource
+            {
+                [{|#0:Event(1)|}]
+                public void Start() => WriteEvent(1);
+            }
+            """, "An abstract EventSource must not declare event methods");
+    }
+
+    [Fact]
+    public Task ExplicitInterfaceImplementation_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            interface ISample
+            {
+                void Start();
+            }
+
+            sealed class Sample : EventSource, ISample
+            {
+                [Event(1)]
+                void ISample.{|#0:Start|}() => WriteEvent(1);
+            }
+            """, "An event method must not be an explicit interface implementation");
+    }
+
+    [Fact]
+    public Task InvalidEventDataCount_Diagnostic()
+    {
+        return RunAsync("""
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public unsafe void Start(int arg1, long arg2)
+                {
+                    EventData* data = stackalloc EventData[2];
+                    WriteEventCore(1, {|#0:1|}, data);
+                }
+            }
+            """, "'WriteEventCore' is called with an event data count of '1' but the method declares 2 payload parameter(s)");
+    }
+
+    [Fact]
+    public Task MissingRelatedActivityIdParameter_Diagnostic()
+    {
+        return RunAsync("""
+            using System;
+            using System.Diagnostics.Tracing;
+
+            sealed class Sample : EventSource
+            {
+                [Event(1)]
+                public void Start(Guid activityId, string name) => {|#0:WriteEventWithRelatedActivityId(1, activityId, name)|};
+            }
+            """, "The first parameter of an event method calling 'WriteEventWithRelatedActivityId' must be a 'Guid' named 'relatedActivityId'");
+    }
+}


### PR DESCRIPTION
`EventSource` builds the metadata of the events from the methods of the type at runtime, using reflection. The compiler cannot validate that the declaration of an event matches what the method writes, so a mistake is only reported at runtime, as an `EventSourceException`, an error in the `EventSource` event source, or a payload that does not match the manifest.

These rules report the errors the runtime detects when it creates the manifest and the descriptors of an event source. There is one rule per kind of error, so each can be configured or suppressed on its own. They are all **disabled by default**:

| Rule | Description |
|------|-------------|
| MA0228 | The event id of an EventSource must be greater than zero |
| MA0229 | The event id of an EventSource is already used by another event |
| MA0230 | The event name of an EventSource is already used by another event |
| MA0231 | An EventSource event method must not be static |
| MA0232 | An EventSource event method must not be an explicit interface implementation |
| MA0233 | An abstract EventSource must not declare event methods |
| MA0234 | The event id written by an EventSource event method must match its `[Event]` attribute |
| MA0235 | The payload written by an EventSource event method must match its parameters |
| MA0236 | The payload written by an EventSource event method must use the order of its parameters |
| MA0237 | An EventSource event method writing a related activity id must declare it as its first parameter |
| MA0238 | The parameter type of an EventSource event method is not supported |

```c#
sealed class SampleEventSource : EventSource
{
    [Event(1)]
    public void Start() => WriteEvent(1);

    // ❌ MA0234: the event id of the attribute is 2, but the event 1 is written
    [Event(2)]
    public void Stop() => WriteEvent(1);

    // ❌ MA0235: the method declares 2 parameters, but only 1 is written
    [Event(3)]
    public void Resume(string name, int count) => WriteEvent(3, name);
}
```

The rules used to decide what is an event method, what the payload is, and which types the manifest supports are the ones of `EventSource.CreateManifestAndDescriptors`, `DebugCheckEvent` and `ManifestBuilder.GetTypeName`.

Notes on the cases that are deliberately not reported, to avoid false positives:

- MA0236 only reports when every argument is a parameter of the method, so `WriteEvent(1, (int)level)` and `WriteEvent(1, name.Trim())` are left alone.
- Passing an `object[]` instead of the expanded arguments stops the payload analysis, as the values cannot be matched to the parameters.
- MA0238 is skipped when the event source may use the self-describing format, which does not use a manifest: when `EventSourceSettings` is reachable from the type, or when it derives from another event source declared in the same compilation.
- The methods marked with `[NonEvent]`, and the non-public methods without an `[Event]` attribute, are not events for these rules.

All the tests pass on every supported Roslyn version, and the documentation is regenerated.