### PR TITLE
Add MA0239: Use 'typeof' instead of 'GetType()' when the type is sealed

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ If you are already using other analyzers, you can check [which rules are duplica
 |[MA0236](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0236.md)|Usage|The payload written by an EventSource event method must use the order of its parameters|⚠️|❌|❌|❌|
 |[MA0237](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0237.md)|Usage|An EventSource event method writing a related activity id must declare it as its first parameter|⚠️|❌|❌|❌|
 |[MA0238](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0238.md)|Usage|The parameter type of an EventSource event method is not supported|⚠️|❌|❌|❌|
+|[MA0239](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0239.md)|Performance|Use 'typeof' instead of 'GetType()' when the type is sealed|ℹ️|❌|✔️|❌|
 
 <!-- rules -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -237,6 +237,7 @@
 |[MA0236](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0236.md)|Usage|The payload written by an EventSource event method must use the order of its parameters|<span title='Warning'>⚠️</span>|❌|❌|❌|
 |[MA0237](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0237.md)|Usage|An EventSource event method writing a related activity id must declare it as its first parameter|<span title='Warning'>⚠️</span>|❌|❌|❌|
 |[MA0238](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0238.md)|Usage|The parameter type of an EventSource event method is not supported|<span title='Warning'>⚠️</span>|❌|❌|❌|
+|[MA0239](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0239.md)|Performance|Use 'typeof' instead of 'GetType()' when the type is sealed|<span title='Info'>ℹ️</span>|❌|✔️|❌|
 
 |Id|Suppressed rule|Justification|
 |--|---------------|-------------|

--- a/docs/Rules/MA0239.md
+++ b/docs/Rules/MA0239.md
@@ -1,0 +1,54 @@
+# MA0239 - Use 'typeof' instead of 'GetType()' when the type is sealed
+<!-- sources -->
+Sources: [UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzer.cs), [UseTypeofInsteadOfGetTypeOnSealedTypeFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeFixer.cs)
+<!-- sources -->
+
+## Description
+
+`instance.GetType()` returns the runtime type of the instance. When the type of the instance is sealed, that type is known at compile time, so `typeof(TheType)` returns the same value without reading the instance. This also avoids boxing the instance when it is a value type, as `object.GetType()` is not overridden.
+
+The rule reports the calls to `object.GetType()` on an instance whose type cannot have derived types: a sealed class, a sealed record, a struct, an enum, or a delegate.
+
+The rule does not report the calls whose instance must be evaluated, such as `GetValue().GetType()` or `list[0].GetType()`, as removing the evaluation of the instance would change the behavior of the code. `instance?.GetType()` is not reported either, as it evaluates to `null` instead of the type when the instance is `null`.
+
+## Motivation
+
+````c#
+class Sample
+{
+    void Test(string str, System.DateTime date)
+    {
+        // ❌ Reads the instance to get a type known at compile time
+        _ = str.GetType();
+
+        // ❌ Boxes the value to get a type known at compile time
+        _ = date.GetType();
+    }
+}
+````
+
+## How to fix violations
+
+Use `typeof` with the type of the instance:
+
+````c#
+class Sample
+{
+    void Test(string str, System.DateTime date)
+    {
+        // ✅ The type is resolved at compile time
+        _ = typeof(string);
+        _ = typeof(System.DateTime);
+    }
+}
+````
+
+Note that `typeof` does not throw when the instance is `null`, whereas `instance.GetType()` throws a `NullReferenceException`. If the code relies on that exception, suppress the diagnostic.
+
+## Configuration
+
+This rule is disabled by default. To enable it, add the following to your `.editorconfig` file:
+
+````editorconfig
+dotnet_diagnostic.MA0239.severity = suggestion
+````

--- a/docs/Rules/MA0239.md
+++ b/docs/Rules/MA0239.md
@@ -9,6 +9,8 @@ Sources: [UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzer.cs](https://github.com/m
 
 The rule reports the calls to `object.GetType()` on an instance whose type cannot have derived types: a sealed class, a sealed record, a struct, an enum, or a delegate.
 
+The rule does not report the calls whose type cannot be used with `typeof`, such as an anonymous type, or a type that contains one like `Container<anonymous type>`.
+
 The rule does not report the calls whose instance must be evaluated, such as `GetValue().GetType()` or `list[0].GetType()`, as removing the evaluation of the instance would change the behavior of the code. `instance?.GetType()` is not reported either, as it evaluates to `null` instead of the type when the instance is `null`.
 
 ## Motivation

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeFixer.cs
@@ -1,0 +1,52 @@
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+
+namespace Meziantou.Analyzer.Rules;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class UseTypeofInsteadOfGetTypeOnSealedTypeFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.UseTypeofInsteadOfGetTypeOnSealedType);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
+        if (nodeToFix is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        if (semanticModel.GetOperation(nodeToFix, context.CancellationToken) is not IInvocationOperation operation)
+            return;
+
+        if (UseTypeofInsteadOfGetTypeOnSealedTypeCommon.GetKnownType(operation) is not { } type)
+            return;
+
+        var title = $"Use 'typeof({type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)})'";
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title,
+                ct => UseTypeofAsync(context.Document, nodeToFix, type, ct),
+                equivalenceKey: title),
+            context.Diagnostics);
+    }
+
+    private static async Task<Document> UseTypeofAsync(Document document, SyntaxNode nodeToFix, INamedTypeSymbol type, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var generator = editor.Generator;
+
+        var typeExpression = generator.TypeExpression(type, addImport: true).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
+        var newNode = generator.TypeOfExpression(typeExpression)
+            .WithTriviaFrom(nodeToFix)
+            .WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation);
+
+        editor.ReplaceNode(nodeToFix, newNode);
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeFixer.cs
@@ -27,12 +27,12 @@ public sealed class UseTypeofInsteadOfGetTypeOnSealedTypeFixer : CodeFixProvider
         if (UseTypeofInsteadOfGetTypeOnSealedTypeCommon.GetKnownType(operation) is not { } type)
             return;
 
-        var title = $"Use 'typeof({type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)})'";
+        // The equivalence key does not contain the type, so "Fix all" fixes the invocations of all the types at once
         context.RegisterCodeFix(
             CodeAction.Create(
-                title,
+                $"Use 'typeof({type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)})'",
                 ct => UseTypeofAsync(context.Document, nodeToFix, type, ct),
-                equivalenceKey: title),
+                equivalenceKey: "Use typeof"),
             context.Diagnostics);
     }
 

--- a/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-errors.editorconfig
@@ -709,3 +709,6 @@ dotnet_diagnostic.MA0237.severity = error
 
 # MA0238: The parameter type of an EventSource event method is not supported
 dotnet_diagnostic.MA0238.severity = error
+
+# MA0239: Use 'typeof' instead of 'GetType()' when the type is sealed
+dotnet_diagnostic.MA0239.severity = error

--- a/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-suggestions.editorconfig
@@ -709,3 +709,6 @@ dotnet_diagnostic.MA0237.severity = suggestion
 
 # MA0238: The parameter type of an EventSource event method is not supported
 dotnet_diagnostic.MA0238.severity = suggestion
+
+# MA0239: Use 'typeof' instead of 'GetType()' when the type is sealed
+dotnet_diagnostic.MA0239.severity = suggestion

--- a/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/all-warnings.editorconfig
@@ -709,3 +709,6 @@ dotnet_diagnostic.MA0237.severity = warning
 
 # MA0238: The parameter type of an EventSource event method is not supported
 dotnet_diagnostic.MA0238.severity = warning
+
+# MA0239: Use 'typeof' instead of 'GetType()' when the type is sealed
+dotnet_diagnostic.MA0239.severity = warning

--- a/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/default.editorconfig
@@ -709,3 +709,6 @@ dotnet_diagnostic.MA0237.severity = none
 
 # MA0238: The parameter type of an EventSource event method is not supported
 dotnet_diagnostic.MA0238.severity = none
+
+# MA0239: Use 'typeof' instead of 'GetType()' when the type is sealed
+dotnet_diagnostic.MA0239.severity = none

--- a/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
+++ b/src/Meziantou.Analyzer.Pack/configuration/none.editorconfig
@@ -709,3 +709,6 @@ dotnet_diagnostic.MA0237.severity = none
 
 # MA0238: The parameter type of an EventSource event method is not supported
 dotnet_diagnostic.MA0238.severity = none
+
+# MA0239: Use 'typeof' instead of 'GetType()' when the type is sealed
+dotnet_diagnostic.MA0239.severity = none

--- a/src/Meziantou.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Analyzer/RuleIdentifiers.cs
@@ -238,6 +238,7 @@ internal static class RuleIdentifiers
     public const string EventSourceMismatchedPayloadOrder = "MA0236";
     public const string EventSourceMissingRelatedActivityIdParameter = "MA0237";
     public const string EventSourceUnsupportedParameterType = "MA0238";
+    public const string UseTypeofInsteadOfGetTypeOnSealedType = "MA0239";
 
     public static string GetHelpUri(string identifier)
     {

--- a/src/Meziantou.Analyzer/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzer.cs
@@ -1,0 +1,32 @@
+namespace Meziantou.Analyzer.Rules;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        RuleIdentifiers.UseTypeofInsteadOfGetTypeOnSealedType,
+        title: "Use 'typeof' instead of 'GetType()' when the type is sealed",
+        messageFormat: "Use 'typeof({0})' instead of 'GetType()' as '{0}' cannot have derived types",
+        RuleCategories.Performance,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: false,
+        description: "",
+        helpLinkUri: RuleIdentifiers.GetHelpUri(RuleIdentifiers.UseTypeofInsteadOfGetTypeOnSealedType));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterOperationAction(context =>
+        {
+            var operation = (IInvocationOperation)context.Operation;
+            if (UseTypeofInsteadOfGetTypeOnSealedTypeCommon.GetKnownType(operation) is not { } type)
+                return;
+
+            context.ReportDiagnostic(Rule, operation, type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+        }, OperationKind.Invocation);
+    }
+}

--- a/src/Meziantou.Analyzer/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeCommon.cs
@@ -26,7 +26,7 @@ internal static class UseTypeofInsteadOfGetTypeOnSealedTypeCommon
         if (instance is null || !IsSideEffectFree(instance))
             return null;
 
-        if (instance.Type is not INamedTypeSymbol { IsSealed: true, IsAnonymousType: false, TypeKind: not TypeKind.Error } type)
+        if (instance.Type is not INamedTypeSymbol { IsSealed: true } type)
             return null;
 
         // 'nullable.GetType()' returns the type of the underlying value, or throws when there is no value
@@ -34,10 +34,42 @@ internal static class UseTypeofInsteadOfGetTypeOnSealedTypeCommon
             return null;
 
         // 'typeof' does not support tuple element names, so use the underlying type of the named tuples
-        if (type.IsTupleType)
-            return type.TupleUnderlyingType ?? type;
+        if (type.IsTupleType && type.TupleUnderlyingType is { } tupleUnderlyingType)
+        {
+            type = tupleUnderlyingType;
+        }
+
+        if (!CanBeNamed(type))
+            return null;
 
         return type;
+    }
+
+    /// <summary>
+    /// Gets whether the type can be used with <c>typeof</c>, which the anonymous types and the types that contain
+    /// one cannot, such as <c>Container&lt;anonymous type&gt;</c>.
+    /// </summary>
+    private static bool CanBeNamed(ITypeSymbol type)
+    {
+        if (type.IsAnonymousType || type.TypeKind is TypeKind.Error)
+            return false;
+
+        if (type is IArrayTypeSymbol array)
+            return CanBeNamed(array.ElementType);
+
+        if (type is INamedTypeSymbol namedType)
+        {
+            if (namedType.ContainingType is not null && !CanBeNamed(namedType.ContainingType))
+                return false;
+
+            foreach (var typeArgument in namedType.TypeArguments)
+            {
+                if (!CanBeNamed(typeArgument))
+                    return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool IsSideEffectFree(IOperation operation) => operation switch

--- a/src/Meziantou.Analyzer/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeCommon.cs
@@ -1,0 +1,54 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class UseTypeofInsteadOfGetTypeOnSealedTypeCommon
+{
+    /// <summary>
+    /// Gets the type <c>typeof</c> must be used with when the invocation is a call to <c>object.GetType()</c> whose
+    /// result is known at compile time, or <see langword="null"/> when the invocation must not be replaced.
+    /// </summary>
+    public static INamedTypeSymbol? GetKnownType(IInvocationOperation operation)
+    {
+        // System.Type hides Object.GetType() with "public new Type GetType()", so the containing type of the invoked
+        // method also excludes the calls reported by MA0130
+        if (operation.TargetMethod is not { Name: "GetType", IsStatic: false, Parameters.IsEmpty: true, ContainingType.SpecialType: SpecialType.System_Object })
+            return null;
+
+        var instance = operation.Instance;
+
+        // A value type instance is implicitly boxed to call 'object.GetType()'
+        while (instance is IConversionOperation { IsImplicit: true } conversion)
+        {
+            instance = conversion.Operand;
+        }
+
+        // Replacing the invocation removes the evaluation of the instance, so its side effects must be preserved.
+        // This also excludes 'instance?.GetType()', which evaluates to null instead of the type when the instance is null.
+        if (instance is null || !IsSideEffectFree(instance))
+            return null;
+
+        if (instance.Type is not INamedTypeSymbol { IsSealed: true, IsAnonymousType: false, TypeKind: not TypeKind.Error } type)
+            return null;
+
+        // 'nullable.GetType()' returns the type of the underlying value, or throws when there is no value
+        if (type.OriginalDefinition.SpecialType is SpecialType.System_Nullable_T)
+            return null;
+
+        // 'typeof' does not support tuple element names, so use the underlying type of the named tuples
+        if (type.IsTupleType)
+            return type.TupleUnderlyingType ?? type;
+
+        return type;
+    }
+
+    private static bool IsSideEffectFree(IOperation operation) => operation switch
+    {
+        ILocalReferenceOperation => true,
+        IParameterReferenceOperation => true,
+        ILiteralOperation => true,
+        IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance } => true,
+        IFieldReferenceOperation { Instance: var fieldInstance } => fieldInstance is null || IsSideEffectFree(fieldInstance),
+        // Indexers are excluded as they can throw, unlike the properties without arguments
+        IPropertyReferenceOperation { Arguments.IsEmpty: true, Instance: var propertyInstance } => propertyInstance is null || IsSideEffectFree(propertyInstance),
+        _ => false,
+    };
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests.cs
@@ -152,6 +152,20 @@ public sealed class UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests
     }
 
     [Fact]
+    public Task UnknownType_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test({|CS0246:Unknown|} value) => value.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
     public Task Dynamic_NoDiagnostic()
     {
         return new CodeFixTest

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests.cs
@@ -1,0 +1,418 @@
+using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
+    Meziantou.Analyzer.Rules.UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzer,
+    Meziantou.Analyzer.Rules.UseTypeofInsteadOfGetTypeOnSealedTypeFixer>;
+
+namespace Meziantou.Analyzer.Test.Rules;
+
+public sealed class UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests
+{
+    [Theory]
+    [InlineData("object value")]
+    [InlineData("System.Exception value")]
+    [InlineData("System.IDisposable value")]
+    [InlineData("System.Collections.Generic.List<int> value")]
+    // Arrays are covariant, so the runtime type of an 'object[]' can be a 'string[]'
+    [InlineData("string[] value")]
+    // Boxing a 'Nullable<T>' creates a 'T', or a null reference when there is no value
+    [InlineData("int? value")]
+    public Task NonSealedType_NoDiagnostic(string parameter)
+    {
+        return new CodeFixTest
+        {
+            TestCode = $$"""
+                class Sample
+                {
+                    System.Type Test({{parameter}}) => value.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task TypeParameter_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test<T>(T value) => value.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task AnonymousType_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test()
+                    {
+                        var value = new { Name = "" };
+                        return value.GetType();
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task ConditionalAccess_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test(string value) => value?.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Theory]
+    // The invocation must be evaluated, as it can have side effects
+    [InlineData("Get().GetType()")]
+    // The indexer can throw
+    [InlineData("values[0].GetType()")]
+    // The cast can throw
+    [InlineData("((string)value).GetType()")]
+    public Task InstanceWithSideEffects_NoDiagnostic(string expression)
+    {
+        return new CodeFixTest
+        {
+            TestCode = $$"""
+                class Sample
+                {
+                    System.Type Test(object value, System.Collections.Generic.List<string> values) => {{expression}};
+
+                    static string Get() => "";
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task GetTypeOnTypeInstance_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test(System.Type value) => value.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task HiddenGetType_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                sealed class Sample
+                {
+                    public new System.Type GetType() => null;
+
+                    System.Type Test(Sample value) => value.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task BaseAccess_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Base { }
+
+                sealed class Sample : Base
+                {
+                    System.Type Test() => base.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task Parameter()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test(string value) => [|value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                class Sample
+                {
+                    System.Type Test(string value) => typeof(string);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task Local()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test()
+                    {
+                        var value = 0;
+                        return [|value.GetType()|];
+                    }
+                }
+                """,
+            FixedCode = """
+                class Sample
+                {
+                    System.Type Test()
+                    {
+                        var value = 0;
+                        return typeof(int);
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task This()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                sealed class Sample
+                {
+                    System.Type Test() => [|GetType()|];
+                }
+                """,
+            FixedCode = """
+                sealed class Sample
+                {
+                    System.Type Test() => typeof(Sample);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task Field()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                sealed class Sample
+                {
+                    private readonly Sample _value;
+
+                    System.Type Test() => [|_value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                sealed class Sample
+                {
+                    private readonly Sample _value;
+
+                    System.Type Test() => typeof(Sample);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task Property()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                sealed class Sample
+                {
+                    private string Value => "";
+
+                    System.Type Test() => [|Value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                sealed class Sample
+                {
+                    private string Value => "";
+
+                    System.Type Test() => typeof(string);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task Enum()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                enum Color { Red }
+
+                class Sample
+                {
+                    System.Type Test(Color value) => [|value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                enum Color { Red }
+
+                class Sample
+                {
+                    System.Type Test(Color value) => typeof(Color);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task Struct()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                struct Point { }
+
+                class Sample
+                {
+                    System.Type Test(Point value) => [|value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                struct Point { }
+
+                class Sample
+                {
+                    System.Type Test(Point value) => typeof(Point);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task GenericSealedType()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                sealed class Container<T> { }
+
+                class Sample
+                {
+                    System.Type Test<T>(Container<T> value) => [|value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                sealed class Container<T> { }
+
+                class Sample
+                {
+                    System.Type Test<T>(Container<T> value) => typeof(Container<T>);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task ThisInStruct()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                struct Point
+                {
+                    System.Type Test() => [|GetType()|];
+                }
+                """,
+            FixedCode = """
+                struct Point
+                {
+                    System.Type Test() => typeof(Point);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task Record()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                sealed record Person(string Name);
+
+                class Sample
+                {
+                    System.Type Test(Person value) => [|value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                sealed record Person(string Name);
+
+                class Sample
+                {
+                    System.Type Test(Person value) => typeof(Person);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task NamedTuple()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test((int Id, string Name) value) => [|value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                class Sample
+                {
+                    System.Type Test((int Id, string Name) value) => typeof((int, string));
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task TypeInNamespace()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test(System.Text.StringBuilder value) => [|value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                using System.Text;
+
+                class Sample
+                {
+                    System.Type Test(System.Text.StringBuilder value) => typeof(StringBuilder);
+                }
+                """,
+        }.RunAsync();
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests.cs
@@ -61,6 +61,111 @@ public sealed class UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests
     }
 
     [Fact]
+    public Task SealedGenericTypeOfAnonymousType_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                sealed class Container<T> { }
+
+                static class Container
+                {
+                    public static Container<T> Create<T>(T value) => new Container<T>();
+                }
+
+                class Sample
+                {
+                    System.Type Test()
+                    {
+                        var value = Container.Create(new { Name = "" });
+                        return value.GetType();
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task SealedTypeNestedInAGenericTypeOfAnonymousType_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Container<T>
+                {
+                    public sealed class Item { }
+
+                    public Item GetItem() => new Item();
+                }
+
+                static class Container
+                {
+                    public static Container<T> Create<T>(T value) => new Container<T>();
+                }
+
+                class Sample
+                {
+                    System.Type Test()
+                    {
+                        var value = Container.Create(new { Name = "" }).GetItem();
+                        return value.GetType();
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task TupleOfAnonymousType_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test()
+                    {
+                        var value = (new { Name = "" }, 0);
+                        return value.GetType();
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task ArrayOfAnonymousType_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test()
+                    {
+                        var value = new[] { new { Name = "" } };
+                        return value.GetType();
+                    }
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task Dynamic_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    System.Type Test(dynamic value) => value.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
     public Task ConditionalAccess_NoDiagnostic()
     {
         return new CodeFixTest
@@ -389,6 +494,68 @@ public sealed class UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests
                 class Sample
                 {
                     System.Type Test((int Id, string Name) value) => typeof((int, string));
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task GenericSealedTypeOfDynamic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                sealed class Container<T> { }
+
+                class Sample
+                {
+                    System.Type Test(Container<dynamic> value) => [|value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                sealed class Container<T> { }
+
+                class Sample
+                {
+                    System.Type Test(Container<dynamic> value) => typeof(Container<dynamic>);
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task NullableReferenceType()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                #nullable enable
+                sealed class Container<T> { }
+
+                class Sample
+                {
+                    System.Type Test()
+                    {
+                        string? value = "";
+                        return [|value.GetType()|];
+                    }
+
+                    System.Type Test(Container<string?> value) => [|value.GetType()|];
+                }
+                """,
+            FixedCode = """
+                #nullable enable
+                sealed class Container<T> { }
+
+                class Sample
+                {
+                    System.Type Test()
+                    {
+                        string? value = "";
+                        return typeof(string);
+                    }
+
+                    System.Type Test(Container<string?> value) => typeof(Container<string?>);
                 }
                 """,
         }.RunAsync();


### PR DESCRIPTION
Adds MA0239, which reports the calls to `object.GetType()` whose result is known at compile time, so they can be replaced with `typeof(...)`.

`instance.GetType()` returns the runtime type of the instance. When the type of the instance cannot have derived types (a sealed class, a sealed record, a struct, an enum, or a delegate), that type is known at compile time, so `typeof(TheType)` returns the same value without reading the instance. It also avoids boxing the instance when it is a value type, as `object.GetType()` is not overridden.

The rule is in the `Performance` category, is a suggestion, and is disabled by default. A code fix replaces the invocation with `typeof(...)`.

## What is not reported

- The calls whose instance must be evaluated, as replacing them would remove side effects or exceptions: `Get().GetType()`, `list[0].GetType()` (the indexer can throw), `((string)value).GetType()` (the cast can throw).
- `instance?.GetType()`, which evaluates to `null` instead of the type when the instance is `null`.
- `Nullable<T>`, as boxing it creates a `T`, or a null reference when there is no value.
- The arrays, as they are covariant: the runtime type of an `object[]` can be a `string[]`.
- The anonymous types, as they cannot be named.
- The `System.Type` instances, which MA0130 already reports. `System.Type` hides `Object.GetType()` with `public new Type GetType()`, so the containing type of the invoked method is enough to tell them apart.

The named tuples are reported with their underlying type, as `typeof` does not support tuple element names: `typeof((int, string))`.

`base.GetType()` in a sealed type is not reported, as the static type of `base` is the base type. This is a missed case, not a false positive.

## Notes for the reviewer

- `typeof` does not throw when the instance is `null`, whereas `instance.GetType()` throws a `NullReferenceException`. This is documented in [`docs/Rules/MA0239.md`](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0239.md), and is one of the reasons the rule is disabled by default.
- The properties without arguments are considered side effect free, like the fields, so `Value.GetType()` is reported. The indexers are not, as they can throw.
- The logic shared by the analyzer and the code fix is in `UseTypeofInsteadOfGetTypeOnSealedTypeCommon.cs`, which the `*Common.cs` wildcard of the code fixers project shares.

## Validation

- The whole solution builds without any warning.
- The 27 new tests pass with every supported Roslyn version (4.8, 4.14, 5.0, 5.6, and 5.9).
- The whole test suite of the default Roslyn version passes (4307 tests).
- `dotnet run --project src/DocumentationGenerator` leaves the markdown files unchanged.
