### PR TITLE
Fix MA0089 treating an integer start index or count as StringComparison.Ordinal

### DIFF
--- a/docs/Rules/MA0089.md
+++ b/docs/Rules/MA0089.md
@@ -16,4 +16,6 @@ str.Replace('a', 'b'); // ok
 
 str.IndexOf("a", StringComparison.Ordinal); // non-compliant
 str.IndexOf('a'); // ok
+
+str.IndexOf("a", 4); // ok, 4 is the start index and the search is culture-sensitive
 ````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStartsWithFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStartsWithFixer.cs
@@ -54,13 +54,14 @@ public class OptimizeStartsWithFixer : CodeFixProvider
         {
             editor.ReplaceNode(literalOperation.Syntax, editor.Generator.LiteralExpression(literalValue[0]));
 
-            if (invocation?.TargetMethod.Name is "StartsWith" or "EndsWith" or "LastIndexOf")
+            if (invocation?.TargetMethod.Name is "StartsWith" or "EndsWith")
             {
                 RemoveStringComparisonArgument(editor, invocation);
             }
-            else if (invocation?.TargetMethod.Name is "IndexOf")
+            else if (invocation?.TargetMethod.Name is "IndexOf" or "LastIndexOf")
             {
-                if (invocation.TargetMethod.Parameters.Length > 1 && invocation.TargetMethod.Parameters[1].Type.IsInt32())
+                // Keep the StringComparison argument when there is a (char, StringComparison) overload, as the comparison may not be ordinal
+                if (invocation.TargetMethod.Parameters.Length != 2 || !HasCharStringComparisonOverload(invocation.TargetMethod, editor.SemanticModel.Compilation))
                 {
                     RemoveStringComparisonArgument(editor, invocation);
                 }
@@ -84,6 +85,18 @@ public class OptimizeStartsWithFixer : CodeFixProvider
         }
 
         return editor.GetChangedDocument();
+    }
+
+    private static bool HasCharStringComparisonOverload(IMethodSymbol method, Compilation compilation)
+    {
+        var stringComparisonSymbol = compilation.GetBestTypeByMetadataName("System.StringComparison");
+        foreach (var member in method.ContainingType.GetMembers(method.Name))
+        {
+            if (member is IMethodSymbol { IsStatic: false, Parameters: [var valueParameter, var comparisonParameter] } && valueParameter.Type.IsChar() && comparisonParameter.Type.IsEqualTo(stringComparisonSymbol))
+                return true;
+        }
+
+        return false;
     }
 
     private static void RemoveStringComparisonArgument(DocumentEditor editor, IInvocationOperation invocation)

--- a/src/Meziantou.Analyzer/Rules/OptimizeStartsWithAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStartsWithAnalyzer.cs
@@ -178,165 +178,53 @@ public sealed class OptimizeStartsWithAnalyzer : DiagnosticAnalyzer
             {
                 if (operation.TargetMethod.Name is "StartsWith")
                 {
-                    if (StartsWith_Char is null || operation.TargetMethod.IsEqualTo(StartsWith_Char))
+                    if (StartsWith_Char is null)
                         return;
 
-                    if (operation.Arguments is [
-                        { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } value },
-                        { Value: { ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } } },
-                        ])
+                    // string.StartsWith(string, StringComparison)
+                    if (IsStringSearchWithStringComparison(operation.TargetMethod, int32ParameterCount: 0) &&
+                        IsOrdinalArgument(operation, parameterOrdinal: 1) &&
+                        GetSingleCharStringArgument(operation, parameterOrdinal: 0) is { } value)
                     {
                         context.ReportDiagnostic(Rule, value);
                     }
                 }
                 else if (operation.TargetMethod.Name is "EndsWith")
                 {
-                    if (EndsWith_Char is null || operation.TargetMethod.IsEqualTo(EndsWith_Char))
+                    if (EndsWith_Char is null)
                         return;
 
-                    if (operation.Arguments is [
-                        { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } value },
-                        { Value: { ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } } },
-                        ])
+                    // string.EndsWith(string, StringComparison)
+                    if (IsStringSearchWithStringComparison(operation.TargetMethod, int32ParameterCount: 0) &&
+                        IsOrdinalArgument(operation, parameterOrdinal: 1) &&
+                        GetSingleCharStringArgument(operation, parameterOrdinal: 0) is { } value)
                     {
                         context.ReportDiagnostic(Rule, value);
                     }
                 }
                 else if (operation.TargetMethod.Name is "Replace")
                 {
-                    if (Replace_Char_Char is null || operation.TargetMethod.IsEqualTo(Replace_Char_Char))
+                    if (Replace_Char_Char is null)
                         return;
 
-                    if (operation.Arguments is [
-                        { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                        { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                        ])
+                    if (GetSingleCharStringArgument(operation, parameterOrdinal: 0) is null || GetSingleCharStringArgument(operation, parameterOrdinal: 1) is null)
+                        return;
+
+                    // string.Replace(string, string) or string.Replace(string, string, StringComparison)
+                    if (operation.TargetMethod.Parameters.Length == 2 ||
+                        (operation.TargetMethod.Parameters.Length == 3 && IsOrdinalArgument(operation, parameterOrdinal: 2)))
                     {
                         // Improve the error message as the rule is reported on the method
-                        context.ReportDiagnostic(Rule, ImmutableDictionary<string, string?>.Empty, operation, DiagnosticInvocationReportOptions.ReportOnMember);
-                    }
-                    else if (operation.Arguments is [
-                        { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                        { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                        { Value: { ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } } }
-                        ])
-                    {
                         context.ReportDiagnostic(Rule, ImmutableDictionary<string, string?>.Empty, operation, DiagnosticInvocationReportOptions.ReportOnMember);
                     }
                 }
                 else if (operation.TargetMethod.Name is "IndexOf")
                 {
-                    if (operation.Arguments.Length == 2)
-                    {
-                        if (IndexOf_Char is not null)
-                        {
-                            if (operation.Arguments is [
-                                { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                                { Value: { ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } } }
-                                ])
-                            {
-                                context.ReportDiagnostic(Rule, operation.Arguments[0].Value);
-                                return;
-                            }
-                        }
-
-                        if (IndexOf_Char_StringComparison is not null)
-                        {
-                            if (operation.Arguments[0].Value is { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } &&
-                                operation.Arguments[1].Value.Type.IsEqualTo(StringComparisonSymbol))
-                            {
-                                context.ReportDiagnostic(Rule, operation.Arguments[0].Value);
-                                return;
-                            }
-                        }
-                    }
-                    else if (operation.Arguments.Length == 3)
-                    {
-                        if (IndexOf_Char_Int32 is null)
-                            return;
-
-                        if (operation.Arguments is [
-                            { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                            { Value: { Type.SpecialType: SpecialType.System_Int32 } },
-                            { Value: { ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } } }
-                            ])
-                        {
-                            context.ReportDiagnostic(Rule, operation.Arguments[0].Value);
-                        }
-                    }
-                    else if (operation.Arguments.Length == 4)
-                    {
-                        if (IndexOf_Char_Int32_Int32 is null)
-                            return;
-
-                        if (operation.Arguments is [
-                            { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                            { Value: { Type.SpecialType: SpecialType.System_Int32 } },
-                            { Value: { Type.SpecialType: SpecialType.System_Int32 } },
-                            { Value: { ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } } }
-                            ])
-                        {
-                            context.ReportDiagnostic(Rule, operation.Arguments[0].Value);
-                        }
-                    }
+                    AnalyzeIndexOf(context, operation, IndexOf_Char, IndexOf_Char_Int32, IndexOf_Char_Int32_Int32, IndexOf_Char_StringComparison);
                 }
                 else if (operation.TargetMethod.Name is "LastIndexOf")
                 {
-                    if (operation.Arguments.Length == 2)
-                    {
-                        if (LastIndexOf_Char is not null)
-                        {
-                            if (operation.Arguments is [
-                                { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                                { Value: { ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } } }
-                                ])
-                            {
-                                context.ReportDiagnostic(Rule, operation.Arguments[0].Value);
-                                return;
-                            }
-                        }
-
-                        if (LastIndexOf_Char_StringComparison is not null)
-                        {
-                            if (operation.Arguments is [
-                                { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                                { Value: { Type.SpecialType: SpecialType.System_Int32 } }
-                                ])
-                            {
-                                context.ReportDiagnostic(Rule, operation.Arguments[0].Value);
-                                return;
-                            }
-                        }
-                    }
-                    else if (operation.Arguments.Length == 3)
-                    {
-                        if (LastIndexOf_Char_Int32 is null)
-                            return;
-
-                        if (operation.Arguments is [
-                            { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                            { Value: { Type.SpecialType: SpecialType.System_Int32 } },
-                            { Value: { ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } } }
-                            ])
-                        {
-                            context.ReportDiagnostic(Rule, operation.Arguments[0].Value);
-                        }
-                    }
-                    else if (operation.Arguments.Length == 4)
-                    {
-                        if (LastIndexOf_Char_Int32_Int32 is null)
-                            return;
-
-                        if (operation.Arguments is [
-                            { Value: { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } } },
-                            { Value: { Type.SpecialType: SpecialType.System_Int32 } },
-                            { Value: { Type.SpecialType: SpecialType.System_Int32 } },
-                            { Value: { ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } } }
-                            ])
-                        {
-                            context.ReportDiagnostic(Rule, operation.Arguments[0].Value);
-                        }
-                    }
+                    AnalyzeIndexOf(context, operation, LastIndexOf_Char, LastIndexOf_Char_Int32, LastIndexOf_Char_Int32_Int32, LastIndexOf_Char_StringComparison);
                 }
                 else if (operation.TargetMethod.Name is "Join" && operation.TargetMethod.IsStatic)
                 {
@@ -392,6 +280,78 @@ public sealed class OptimizeStartsWithAnalyzer : DiagnosticAnalyzer
                     }
                 }
             }
+        }
+
+        private void AnalyzeIndexOf(OperationAnalysisContext context, IInvocationOperation operation, IMethodSymbol? charOverload, IMethodSymbol? charInt32Overload, IMethodSymbol? charInt32Int32Overload, IMethodSymbol? charStringComparisonOverload)
+        {
+            if (GetSingleCharStringArgument(operation, parameterOrdinal: 0) is not { } value)
+                return;
+
+            // The overloads without a StringComparison parameter are culture-sensitive, so they cannot be replaced
+            // with the char overloads, which are ordinal. e.g. IndexOf(string, int) or IndexOf(string, int, int)
+            var method = operation.TargetMethod;
+            var shouldReport = method.Parameters.Length switch
+            {
+                // (string, StringComparison)
+                2 when IsStringSearchWithStringComparison(method, int32ParameterCount: 0) => charStringComparisonOverload is not null || (charOverload is not null && IsOrdinalArgument(operation, parameterOrdinal: 1)),
+
+                // (string, int, StringComparison)
+                3 when IsStringSearchWithStringComparison(method, int32ParameterCount: 1) => charInt32Overload is not null && IsOrdinalArgument(operation, parameterOrdinal: 2),
+
+                // (string, int, int, StringComparison)
+                4 when IsStringSearchWithStringComparison(method, int32ParameterCount: 2) => charInt32Int32Overload is not null && IsOrdinalArgument(operation, parameterOrdinal: 3),
+
+                _ => false,
+            };
+
+            if (shouldReport)
+            {
+                context.ReportDiagnostic(Rule, value);
+            }
+        }
+
+        // Match (string, int32 x int32ParameterCount, StringComparison)
+        private bool IsStringSearchWithStringComparison(IMethodSymbol method, int int32ParameterCount)
+        {
+            var parameters = method.Parameters;
+            if (parameters.Length != int32ParameterCount + 2)
+                return false;
+
+            if (!parameters[0].Type.IsString())
+                return false;
+
+            for (var i = 1; i <= int32ParameterCount; i++)
+            {
+                if (!parameters[i].Type.IsInt32())
+                    return false;
+            }
+
+            return parameters[parameters.Length - 1].Type.IsEqualTo(StringComparisonSymbol);
+        }
+
+        private bool IsOrdinalArgument(IInvocationOperation operation, int parameterOrdinal)
+        {
+            return GetArgument(operation, parameterOrdinal) is { Parameter: { } parameter, Value.ConstantValue: { HasValue: true, Value: (int)StringComparison.Ordinal } }
+                && parameter.Type.IsEqualTo(StringComparisonSymbol);
+        }
+
+        private static IOperation? GetSingleCharStringArgument(IInvocationOperation operation, int parameterOrdinal)
+        {
+            if (GetArgument(operation, parameterOrdinal) is { Parameter.Type.SpecialType: SpecialType.System_String, Value: { ConstantValue: { HasValue: true, Value: string { Length: 1 } } } value })
+                return value;
+
+            return null;
+        }
+
+        private static IArgumentOperation? GetArgument(IInvocationOperation operation, int parameterOrdinal)
+        {
+            foreach (var argument in operation.Arguments)
+            {
+                if (argument.Parameter?.Ordinal == parameterOrdinal)
+                    return argument;
+            }
+
+            return null;
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStartsWithAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStartsWithAnalyzerTests.cs
@@ -42,6 +42,7 @@ public sealed class OptimizeStartsWithAnalyzerTests
 
     [Theory]
     [InlineData("""{|MA0089:"a"|}, StringComparison.Ordinal""", """'a'""")]
+    [InlineData("""comparisonType: StringComparison.Ordinal, value: {|MA0089:"a"|}""", """value: 'a'""")]
     public Task StartsWith_Report(string method, string fix)
     {
         var test = CreateTest();
@@ -132,6 +133,9 @@ public sealed class OptimizeStartsWithAnalyzerTests
     [InlineData(@"{|MA0089:""a""|}, StringComparison.CurrentCulture", @"'a', StringComparison.CurrentCulture")]
     [InlineData(@"{|MA0089:""a""|}, 1, 2, StringComparison.Ordinal", @"'a', 1, 2")]
     [InlineData(@"{|MA0089:""a""|}, 1, StringComparison.Ordinal", @"'a', 1")]
+    [InlineData(@"{|MA0089:""a""|}, 4, StringComparison.Ordinal", @"'a', 4")]
+    [InlineData(@"{|MA0089:""a""|}, 4, 4, StringComparison.Ordinal", @"'a', 4, 4")]
+    [InlineData(@"comparisonType: StringComparison.Ordinal, value: {|MA0089:""a""|}", @"comparisonType: StringComparison.Ordinal, value: 'a'")]
     public Task IndexOf_Report(string method, string fix)
     {
         var test = CreateTest();
@@ -169,6 +173,12 @@ public sealed class OptimizeStartsWithAnalyzerTests
     [InlineData(@"""a"", 1, 2")]
     [InlineData(@"""a"", 1, 2, StringComparison.OrdinalIgnoreCase")]
     [InlineData(@"""a"", 1, StringComparison.OrdinalIgnoreCase")]
+    [InlineData(@"""\0"", 4")]
+    [InlineData(@"""a"", (int)StringComparison.Ordinal")]
+    [InlineData(@"""a"", 1, 4")]
+    [InlineData(@"""a"", 4, 4")]
+    [InlineData(@"""a"", 1, (int)StringComparison.Ordinal")]
+    [InlineData(@"""a"", startIndex: 1, count: 4")]
     public Task IndexOf_NoReport(string method)
     {
         var test = CreateTest();
@@ -188,6 +198,9 @@ public sealed class OptimizeStartsWithAnalyzerTests
 
     [Theory]
     [InlineData(@"""a"", StringComparison.OrdinalIgnoreCase")]
+    [InlineData(@"""a"", StringComparison.CurrentCulture")]
+    [InlineData(@"""\0"", 4")]
+    [InlineData(@"""a"", 1, 4")]
     public Task IndexOf_NoReport_Netstandard2_0(string method)
     {
         var test = CreateTest();
@@ -208,8 +221,42 @@ public sealed class OptimizeStartsWithAnalyzerTests
 
     [Theory]
     [InlineData(@"{|MA0089:""a""|}, StringComparison.Ordinal", @"'a'")]
+    [InlineData(@"{|MA0089:""a""|}, 1, StringComparison.Ordinal", @"'a', 1")]
+    public Task IndexOf_Report_Netstandard2_0(string method, string fix)
+    {
+        var test = CreateTest();
+        test.ReferenceAssemblies = ReferenceAssemblies.NetStandard.NetStandard20;
+        test.TestCode = $$"""
+            using System;
+            class Test
+            {
+                void A(string str)
+                {
+                    _ = str.IndexOf({{method}});
+                }
+            }
+            """;
+        test.FixedCode = $$"""
+            using System;
+            class Test
+            {
+                void A(string str)
+                {
+                    _ = str.IndexOf({{fix}});
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData(@"{|MA0089:""a""|}, StringComparison.Ordinal", @"'a'")]
     [InlineData(@"{|MA0089:""a""|}, 1, 2, StringComparison.Ordinal", @"'a', 1, 2")]
     [InlineData(@"{|MA0089:""a""|}, 1, StringComparison.Ordinal", @"'a', 1")]
+    [InlineData(@"{|MA0089:""a""|}, 4, StringComparison.Ordinal", @"'a', 4")]
+    [InlineData(@"{|MA0089:""a""|}, 4, 4, StringComparison.Ordinal", @"'a', 4, 4")]
+    [InlineData(@"{|MA0089:""a""|}, comparisonType: StringComparison.Ordinal, startIndex: 1", @"'a', startIndex: 1")]
     public Task LastIndexOf_Report(string method, string fix)
     {
         var test = CreateTest();
@@ -248,6 +295,11 @@ public sealed class OptimizeStartsWithAnalyzerTests
     [InlineData(@"""a"", StringComparison.CurrentCulture")]
     [InlineData(@"""a"", 1, 2, StringComparison.OrdinalIgnoreCase")]
     [InlineData(@"""a"", 1, StringComparison.OrdinalIgnoreCase")]
+    [InlineData(@"""\0"", 4")]
+    [InlineData(@"""a"", (int)StringComparison.Ordinal")]
+    [InlineData(@"""a"", 5, 4")]
+    [InlineData(@"""a"", 4, 4")]
+    [InlineData(@"""a"", 5, (int)StringComparison.Ordinal")]
     public Task LastIndexOf_NoReport(string method)
     {
         var test = CreateTest();
@@ -313,6 +365,7 @@ public sealed class OptimizeStartsWithAnalyzerTests
     [Theory]
     [InlineData(@"""a"", ""b""", @"'a', 'b'")]
     [InlineData(@"""a"", ""b"", StringComparison.Ordinal", @"'a', 'b'")]
+    [InlineData(@"""a"", ""b"", comparisonType: StringComparison.Ordinal", @"'a', 'b'")]
     public Task Replace_Report(string method, string fix)
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

MA0089 compared the constant value of the last argument of `IndexOf`/`LastIndexOf`/`StartsWith`/`EndsWith`/`Replace` against `(int)StringComparison.Ordinal` (`4`) without checking its type. An integer start index or count equal to `4` was therefore treated as an ordinal comparison:

```csharp
"abcdef".IndexOf("\0", 4);   // culture-sensitive, returns 4
// fixed to
"abcdef".IndexOf('\0', 4);   // ordinal, returns -1
```

The same happened with `IndexOf("a", 1, 4)` (count), and the equivalent `LastIndexOf` overloads.

## Changes

**Analyzer**
- The overload is identified from the method parameters: `(string, [int, [int]], StringComparison)`. The comparison argument must be bound to a `System.StringComparison` parameter before its constant value is checked. Overloads without a `StringComparison` parameter are culture-sensitive and are never reported.
- Arguments are looked up by parameter instead of by position, so reordered named arguments (e.g. `StartsWith(comparisonType: StringComparison.Ordinal, value: "a")`) are handled.
- `IndexOf` and `LastIndexOf` now share the same logic. This also fixes a `LastIndexOf` branch that would have reported any `(string, int)` call if a `LastIndexOf(char, StringComparison)` overload existed (it currently doesn't exist in any .NET version, so the branch was dead).

**Code fixer**
- For `IndexOf`/`LastIndexOf`, the `StringComparison` argument is kept only when a `(char, StringComparison)` overload exists. Previously, on netstandard2.0, `IndexOf("a", StringComparison.Ordinal)` was fixed to `IndexOf('a', StringComparison.Ordinal)`, which does not compile.

**Docs**
- Added an example to `docs/Rules/MA0089.md` showing that `str.IndexOf("a", 4)` is not reported.

## Tests

Added regression cases for start index/count values equal to `4`, `(int)StringComparison.Ordinal` passed to an `int` parameter, reordered named arguments, and the netstandard2.0 fix. 17 of the new cases fail against the previous implementation. All 106 `OptimizeStartsWithAnalyzerTests` pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9, and `dotnet run --project src/DocumentationGenerator` reports no pending changes.
