### PR TITLE
Do not report MA0160 when ContainsKey is explicitly implemented

### DIFF
--- a/docs/Rules/MA0160.md
+++ b/docs/Rules/MA0160.md
@@ -11,4 +11,4 @@ dict.TryGetValue("dummy", out var a); // ok
 dict.ContainsKey("dummy"); // ok
 ````
 
-The code fix replaces the call with `ContainsKey`. When `ContainsKey` is not accessible from the type of the instance, for instance because it is implemented explicitly, the code fix casts the instance to the dictionary interface. No code fix is offered when the instance is a value type, as the cast would box it.
+The rule does not report when `ContainsKey` is implemented explicitly by the type of the instance, as it is not meant to be called on this type.

--- a/docs/Rules/MA0160.md
+++ b/docs/Rules/MA0160.md
@@ -10,3 +10,5 @@ dict.TryGetValue("dummy", out _); // non-compliant
 dict.TryGetValue("dummy", out var a); // ok
 dict.ContainsKey("dummy"); // ok
 ````
+
+The code fix replaces the call with `ContainsKey`. When `ContainsKey` is not accessible from the type of the instance, for instance because it is implemented explicitly, the code fix casts the instance to the dictionary interface. No code fix is offered when the instance is a value type, as the cast would box it.

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseContainsKeyInsteadOfTryGetValueFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseContainsKeyInsteadOfTryGetValueFixer.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;
@@ -31,39 +32,100 @@ public sealed class UseContainsKeyInsteadOfTryGetValueFixer : CodeFixProvider
             return;
 
         if (operation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
-            invocationSyntax.Expression is not MemberAccessExpressionSyntax)
+            invocationSyntax.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return;
+        }
+
+        var generator = SyntaxGenerator.GetGenerator(context.Document);
+        if (CreateContainsKeyInvocation(generator, semanticModel, operation, invocationSyntax, memberAccess) is not { } newInvocation)
             return;
 
         const string Title = "Use ContainsKey";
         context.RegisterCodeFix(
-            CodeAction.Create(Title, ct => UseContainsKey(context.Document, nodeToFix, ct), equivalenceKey: Title),
+            CodeAction.Create(Title, ct => UseContainsKey(context.Document, invocationSyntax, newInvocation, ct), equivalenceKey: Title),
             context.Diagnostics);
     }
 
-    private static async Task<Document> UseContainsKey(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static async Task<Document> UseContainsKey(Document document, InvocationExpressionSyntax invocationSyntax, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        if (FindInvocation(editor.SemanticModel, nodeToFix, cancellationToken) is not { Arguments.Length: 2 } operation)
-            return document;
-
-        if (operation.TargetMethod.Name != "TryGetValue")
-            return document;
-
-        if (operation.Arguments[1].Value is not IDiscardOperation)
-            return document;
-
-        if (operation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
-            invocationSyntax.Expression is not MemberAccessExpressionSyntax memberAccess)
-        {
-            return document;
-        }
-
-        var newInvocation = invocationSyntax
-            .WithExpression(memberAccess.WithName(IdentifierName("ContainsKey")))
-            .WithArgumentList(ArgumentList(SeparatedList(new[] { invocationSyntax.ArgumentList.Arguments[0] })));
-
         editor.ReplaceNode(invocationSyntax, newInvocation.WithTriviaFrom(invocationSyntax).WithAdditionalAnnotations(Formatter.Annotation));
         return editor.GetChangedDocument();
+    }
+
+    private static InvocationExpressionSyntax? CreateContainsKeyInvocation(SyntaxGenerator generator, SemanticModel semanticModel, IInvocationOperation operation, InvocationExpressionSyntax invocationSyntax, MemberAccessExpressionSyntax memberAccess)
+    {
+        if (operation.Instance?.Type is not { } receiverType)
+            return null;
+
+        var containsKeyMethods = GetContainsKeyMethods(semanticModel.Compilation, operation.TargetMethod);
+        if (containsKeyMethods.Count == 0)
+            return null;
+
+        var argumentList = ArgumentList(SingletonSeparatedList(invocationSyntax.ArgumentList.Arguments[0]));
+        var newInvocation = invocationSyntax
+            .WithExpression(memberAccess.WithName(IdentifierName("ContainsKey")))
+            .WithArgumentList(argumentList);
+        if (IsContainsKeyInvocation(newInvocation))
+            return newInvocation;
+
+        // ContainsKey is not accessible from the receiver type, e.g. when it is implemented explicitly, so call it through the interface.
+        // Casting a value type would box it, and "base" cannot be cast.
+        if (!receiverType.IsReferenceType || memberAccess.Expression is BaseExpressionSyntax)
+            return null;
+
+        var interfaceType = generator.TypeExpression(containsKeyMethods[0].ContainingType, addImport: true).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
+        var castInvocation = InvocationExpression(
+            (ExpressionSyntax)generator.MemberAccessExpression(generator.CastExpression(interfaceType, memberAccess.Expression.WithoutLeadingTrivia()), "ContainsKey"),
+            argumentList);
+        if (IsContainsKeyInvocation(castInvocation))
+            return castInvocation;
+
+        return null;
+
+        bool IsContainsKeyInvocation(ExpressionSyntax expression)
+        {
+            if (semanticModel.GetSpeculativeSymbolInfo(invocationSyntax.SpanStart, expression, SpeculativeBindingOption.BindAsExpression).Symbol is not IMethodSymbol method)
+                return false;
+
+            foreach (var containsKey in containsKeyMethods)
+            {
+                if (method.IsEqualTo(containsKey) || method.IsEqualTo(receiverType.FindImplementationForInterfaceMember(containsKey)))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    private static List<IMethodSymbol> GetContainsKeyMethods(Compilation compilation, IMethodSymbol tryGetValueMethod)
+    {
+        var result = new List<IMethodSymbol>();
+        foreach (var metadataName in (ReadOnlySpan<string>)["System.Collections.Generic.IReadOnlyDictionary`2", "System.Collections.Generic.IDictionary`2"])
+        {
+            var symbol = compilation.GetBestTypeByMetadataName(metadataName);
+            if (symbol is null)
+                continue;
+
+            var containingType = tryGetValueMethod.ContainingType;
+            var iface = containingType.OriginalDefinition.IsEqualTo(symbol) ? containingType : containingType.AllInterfaces.FirstOrDefault(i => i.OriginalDefinition.IsEqualTo(symbol));
+            if (iface is null)
+                continue;
+
+            if (iface.GetMembers("TryGetValue").FirstOrDefault() is not IMethodSymbol tryGetValue)
+                continue;
+
+            if (!tryGetValueMethod.IsEqualTo(tryGetValue) && !tryGetValueMethod.IsEqualTo(containingType.FindImplementationForInterfaceMember(tryGetValue)))
+                continue;
+
+            if (iface.GetMembers("ContainsKey").OfType<IMethodSymbol>().FirstOrDefault(m => m.Parameters.Length == 1) is { } containsKey)
+            {
+                result.Add(containsKey);
+            }
+        }
+
+        return result;
     }
 
     private static IInvocationOperation? FindInvocation(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseContainsKeyInsteadOfTryGetValueFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseContainsKeyInsteadOfTryGetValueFixer.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;
@@ -32,100 +31,39 @@ public sealed class UseContainsKeyInsteadOfTryGetValueFixer : CodeFixProvider
             return;
 
         if (operation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
-            invocationSyntax.Expression is not MemberAccessExpressionSyntax memberAccess)
-        {
-            return;
-        }
-
-        var generator = SyntaxGenerator.GetGenerator(context.Document);
-        if (CreateContainsKeyInvocation(generator, semanticModel, operation, invocationSyntax, memberAccess) is not { } newInvocation)
+            invocationSyntax.Expression is not MemberAccessExpressionSyntax)
             return;
 
         const string Title = "Use ContainsKey";
         context.RegisterCodeFix(
-            CodeAction.Create(Title, ct => UseContainsKey(context.Document, invocationSyntax, newInvocation, ct), equivalenceKey: Title),
+            CodeAction.Create(Title, ct => UseContainsKey(context.Document, nodeToFix, ct), equivalenceKey: Title),
             context.Diagnostics);
     }
 
-    private static async Task<Document> UseContainsKey(Document document, InvocationExpressionSyntax invocationSyntax, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)
+    private static async Task<Document> UseContainsKey(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        editor.ReplaceNode(invocationSyntax, newInvocation.WithTriviaFrom(invocationSyntax).WithAdditionalAnnotations(Formatter.Annotation));
-        return editor.GetChangedDocument();
-    }
+        if (FindInvocation(editor.SemanticModel, nodeToFix, cancellationToken) is not { Arguments.Length: 2 } operation)
+            return document;
 
-    private static InvocationExpressionSyntax? CreateContainsKeyInvocation(SyntaxGenerator generator, SemanticModel semanticModel, IInvocationOperation operation, InvocationExpressionSyntax invocationSyntax, MemberAccessExpressionSyntax memberAccess)
-    {
-        if (operation.Instance?.Type is not { } receiverType)
-            return null;
+        if (operation.TargetMethod.Name != "TryGetValue")
+            return document;
 
-        var containsKeyMethods = GetContainsKeyMethods(semanticModel.Compilation, operation.TargetMethod);
-        if (containsKeyMethods.Count == 0)
-            return null;
+        if (operation.Arguments[1].Value is not IDiscardOperation)
+            return document;
 
-        var argumentList = ArgumentList(SingletonSeparatedList(invocationSyntax.ArgumentList.Arguments[0]));
+        if (operation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
+            invocationSyntax.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return document;
+        }
+
         var newInvocation = invocationSyntax
             .WithExpression(memberAccess.WithName(IdentifierName("ContainsKey")))
-            .WithArgumentList(argumentList);
-        if (IsContainsKeyInvocation(newInvocation))
-            return newInvocation;
+            .WithArgumentList(ArgumentList(SeparatedList(new[] { invocationSyntax.ArgumentList.Arguments[0] })));
 
-        // ContainsKey is not accessible from the receiver type, e.g. when it is implemented explicitly, so call it through the interface.
-        // Casting a value type would box it, and "base" cannot be cast.
-        if (!receiverType.IsReferenceType || memberAccess.Expression is BaseExpressionSyntax)
-            return null;
-
-        var interfaceType = generator.TypeExpression(containsKeyMethods[0].ContainingType, addImport: true).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
-        var castInvocation = InvocationExpression(
-            (ExpressionSyntax)generator.MemberAccessExpression(generator.CastExpression(interfaceType, memberAccess.Expression.WithoutLeadingTrivia()), "ContainsKey"),
-            argumentList);
-        if (IsContainsKeyInvocation(castInvocation))
-            return castInvocation;
-
-        return null;
-
-        bool IsContainsKeyInvocation(ExpressionSyntax expression)
-        {
-            if (semanticModel.GetSpeculativeSymbolInfo(invocationSyntax.SpanStart, expression, SpeculativeBindingOption.BindAsExpression).Symbol is not IMethodSymbol method)
-                return false;
-
-            foreach (var containsKey in containsKeyMethods)
-            {
-                if (method.IsEqualTo(containsKey) || method.IsEqualTo(receiverType.FindImplementationForInterfaceMember(containsKey)))
-                    return true;
-            }
-
-            return false;
-        }
-    }
-
-    private static List<IMethodSymbol> GetContainsKeyMethods(Compilation compilation, IMethodSymbol tryGetValueMethod)
-    {
-        var result = new List<IMethodSymbol>();
-        foreach (var metadataName in (ReadOnlySpan<string>)["System.Collections.Generic.IReadOnlyDictionary`2", "System.Collections.Generic.IDictionary`2"])
-        {
-            var symbol = compilation.GetBestTypeByMetadataName(metadataName);
-            if (symbol is null)
-                continue;
-
-            var containingType = tryGetValueMethod.ContainingType;
-            var iface = containingType.OriginalDefinition.IsEqualTo(symbol) ? containingType : containingType.AllInterfaces.FirstOrDefault(i => i.OriginalDefinition.IsEqualTo(symbol));
-            if (iface is null)
-                continue;
-
-            if (iface.GetMembers("TryGetValue").FirstOrDefault() is not IMethodSymbol tryGetValue)
-                continue;
-
-            if (!tryGetValueMethod.IsEqualTo(tryGetValue) && !tryGetValueMethod.IsEqualTo(containingType.FindImplementationForInterfaceMember(tryGetValue)))
-                continue;
-
-            if (iface.GetMembers("ContainsKey").OfType<IMethodSymbol>().FirstOrDefault(m => m.Parameters.Length == 1) is { } containsKey)
-            {
-                result.Add(containsKey);
-            }
-        }
-
-        return result;
+        editor.ReplaceNode(invocationSyntax, newInvocation.WithTriviaFrom(invocationSyntax).WithAdditionalAnnotations(Formatter.Annotation));
+        return editor.GetChangedDocument();
     }
 
     private static IInvocationOperation? FindInvocation(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)

--- a/src/Meziantou.Analyzer/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzer.cs
@@ -48,7 +48,7 @@ public sealed class UseContainsKeyInsteadOfTryGetValueAnalyzer : DiagnosticAnaly
                             if (iface.GetMembers("TryGetValue").FirstOrDefault() is IMethodSymbol member)
                             {
                                 var implementation = operation.TargetMethod.IsEqualTo(member) ? member : operation.TargetMethod.ContainingType.FindImplementationForInterfaceMember(member);
-                                if (SymbolEqualityComparer.Default.Equals(operation.TargetMethod, implementation))
+                                if (SymbolEqualityComparer.Default.Equals(operation.TargetMethod, implementation) && !IsContainsKeyExplicitlyImplemented(operation.Instance?.Type, iface))
                                 {
                                     context.ReportDiagnostic(Rule, operation);
                                     return;
@@ -58,6 +58,15 @@ public sealed class UseContainsKeyInsteadOfTryGetValueAnalyzer : DiagnosticAnaly
                     }
                 }
             }
+        }
+
+        // A member implemented explicitly is not meant to be called on the type
+        private static bool IsContainsKeyExplicitlyImplemented(ITypeSymbol? instanceType, INamedTypeSymbol iface)
+        {
+            if (instanceType is null || iface.GetMembers("ContainsKey").FirstOrDefault() is not IMethodSymbol containsKey)
+                return false;
+
+            return instanceType.FindImplementationForInterfaceMember(containsKey) is IMethodSymbol { MethodKind: MethodKind.ExplicitInterfaceImplementation };
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzerTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseContainsKeyInsteadOfTryGetValueAnalyzer,
     Meziantou.Analyzer.Rules.UseContainsKeyInsteadOfTryGetValueFixer>;
@@ -107,20 +106,31 @@ public sealed class UseContainsKeyInsteadOfTryGetValueAnalyzerTests
         return test.RunAsync();
     }
 
-    [Fact]
-    public Task Dictionary_TryGetValue_Discard_Fix()
+    [Theory]
+    [InlineData("class")]
+    [InlineData("struct")]
+    public Task ExplicitContainsKey_TryGetValue_Discard(string kind)
     {
         var test = CreateTest();
-        test.TestCode = """
-            class ClassTest
+        test.TestCode = $$"""
+            using System.Collections;
+            using System.Collections.Generic;
+
+            {{kind}} Map : IReadOnlyDictionary<int, int>
             {
-                bool Test(System.Collections.Generic.Dictionary<string, string> dict) => {|MA0160:dict.TryGetValue("", out _)|};
+                public int this[int key] => 0;
+                public IEnumerable<int> Keys => [];
+                public IEnumerable<int> Values => [];
+                public int Count => 0;
+                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out int value) { value = 0; return false; }
+                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
             }
-            """;
-        test.FixedCode = """
-            class ClassTest
+
+            class Sample
             {
-                bool Test(System.Collections.Generic.Dictionary<string, string> dict) => dict.ContainsKey("");
+                bool Run(Map map) => map.TryGetValue(0, out _);
             }
             """;
 
@@ -128,141 +138,7 @@ public sealed class UseContainsKeyInsteadOfTryGetValueAnalyzerTests
     }
 
     [Fact]
-    public Task ExplicitContainsKey_Class_CastToInterface()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections;
-            using System.Collections.Generic;
-
-            class Map : IReadOnlyDictionary<int, int>
-            {
-                public int this[int key] => 0;
-                public IEnumerable<int> Keys => [];
-                public IEnumerable<int> Values => [];
-                public int Count => 0;
-                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
-                public bool TryGetValue(int key, out int value) { value = 0; return false; }
-                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
-                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-            }
-
-            class Sample
-            {
-                bool Run(Map map) => {|MA0160:map.TryGetValue(0, out _)|};
-            }
-            """;
-        test.FixedCode = """
-            using System.Collections;
-            using System.Collections.Generic;
-
-            class Map : IReadOnlyDictionary<int, int>
-            {
-                public int this[int key] => 0;
-                public IEnumerable<int> Keys => [];
-                public IEnumerable<int> Values => [];
-                public int Count => 0;
-                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
-                public bool TryGetValue(int key, out int value) { value = 0; return false; }
-                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
-                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-            }
-
-            class Sample
-            {
-                bool Run(Map map) => ((IReadOnlyDictionary<int, int>)map).ContainsKey(0);
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task ExplicitContainsKey_NewExpression_CastToInterface()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            using System.Collections;
-            using System.Collections.Generic;
-
-            class Map : IReadOnlyDictionary<int, int>
-            {
-                public int this[int key] => 0;
-                public IEnumerable<int> Keys => [];
-                public IEnumerable<int> Values => [];
-                public int Count => 0;
-                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
-                public bool TryGetValue(int key, out int value) { value = 0; return false; }
-                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
-                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-            }
-
-            class Sample
-            {
-                object Run() => {|MA0160:new Map().TryGetValue(0, out _)|};
-            }
-            """;
-        test.FixedCode = """
-            using System.Collections;
-            using System.Collections.Generic;
-
-            class Map : IReadOnlyDictionary<int, int>
-            {
-                public int this[int key] => 0;
-                public IEnumerable<int> Keys => [];
-                public IEnumerable<int> Values => [];
-                public int Count => 0;
-                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
-                public bool TryGetValue(int key, out int value) { value = 0; return false; }
-                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
-                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-            }
-
-            class Sample
-            {
-                object Run() => ((IReadOnlyDictionary<int, int>)new Map()).ContainsKey(0);
-            }
-            """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task ExplicitContainsKey_Struct_NoFix()
-    {
-        // Casting the struct to the interface would box it
-        const string Code = """
-            using System.Collections;
-            using System.Collections.Generic;
-
-            struct Map : IReadOnlyDictionary<int, int>
-            {
-                public int this[int key] => 0;
-                public IEnumerable<int> Keys => [];
-                public IEnumerable<int> Values => [];
-                public int Count => 0;
-                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
-                public bool TryGetValue(int key, out int value) { value = 0; return false; }
-                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
-                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-            }
-
-            class Sample
-            {
-                bool Run(Map map) => {|MA0160:map.TryGetValue(0, out _)|};
-            }
-            """;
-
-        var test = CreateTest();
-        test.FixedState.MarkupHandling = MarkupMode.Allow;
-        test.TestCode = Code;
-        test.FixedCode = Code;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task ExplicitContainsKey_UnrelatedPublicContainsKey_CastToInterface()
+    public Task ExplicitContainsKey_UnrelatedPublicContainsKey_TryGetValue_Discard()
     {
         var test = CreateTest();
         test.TestCode = """
@@ -284,7 +160,36 @@ public sealed class UseContainsKeyInsteadOfTryGetValueAnalyzerTests
 
             class Sample
             {
-                bool Run(Map map) => {|MA0160:map.TryGetValue(0, out _)|};
+                bool Run(Map map) => map.TryGetValue(0, out _);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExplicitContainsKey_InterfaceReceiver_TryGetValue_Discard()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            class Map : IReadOnlyDictionary<int, int>
+            {
+                public int this[int key] => 0;
+                public IEnumerable<int> Keys => [];
+                public IEnumerable<int> Values => [];
+                public int Count => 0;
+                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out int value) { value = 0; return false; }
+                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            class Sample
+            {
+                bool Run(IReadOnlyDictionary<int, int> map) => {|MA0160:map.TryGetValue(0, out _)|};
             }
             """;
         test.FixedCode = """
@@ -297,7 +202,6 @@ public sealed class UseContainsKeyInsteadOfTryGetValueAnalyzerTests
                 public IEnumerable<int> Keys => [];
                 public IEnumerable<int> Values => [];
                 public int Count => 0;
-                public bool ContainsKey(int key) => true;
                 bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
                 public bool TryGetValue(int key, out int value) { value = 0; return false; }
                 public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
@@ -306,7 +210,7 @@ public sealed class UseContainsKeyInsteadOfTryGetValueAnalyzerTests
 
             class Sample
             {
-                bool Run(Map map) => ((IReadOnlyDictionary<int, int>)map).ContainsKey(0);
+                bool Run(IReadOnlyDictionary<int, int> map) => map.ContainsKey(0);
             }
             """;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseContainsKeyInsteadOfTryGetValueAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseContainsKeyInsteadOfTryGetValueAnalyzer,
     Meziantou.Analyzer.Rules.UseContainsKeyInsteadOfTryGetValueFixer>;
@@ -100,6 +101,212 @@ public sealed class UseContainsKeyInsteadOfTryGetValueAnalyzerTests
 
             class SampleDictionary : System.Collections.Generic.Dictionary<string, string>
             {
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Dictionary_TryGetValue_Discard_Fix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class ClassTest
+            {
+                bool Test(System.Collections.Generic.Dictionary<string, string> dict) => {|MA0160:dict.TryGetValue("", out _)|};
+            }
+            """;
+        test.FixedCode = """
+            class ClassTest
+            {
+                bool Test(System.Collections.Generic.Dictionary<string, string> dict) => dict.ContainsKey("");
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExplicitContainsKey_Class_CastToInterface()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            class Map : IReadOnlyDictionary<int, int>
+            {
+                public int this[int key] => 0;
+                public IEnumerable<int> Keys => [];
+                public IEnumerable<int> Values => [];
+                public int Count => 0;
+                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out int value) { value = 0; return false; }
+                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            class Sample
+            {
+                bool Run(Map map) => {|MA0160:map.TryGetValue(0, out _)|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            class Map : IReadOnlyDictionary<int, int>
+            {
+                public int this[int key] => 0;
+                public IEnumerable<int> Keys => [];
+                public IEnumerable<int> Values => [];
+                public int Count => 0;
+                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out int value) { value = 0; return false; }
+                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            class Sample
+            {
+                bool Run(Map map) => ((IReadOnlyDictionary<int, int>)map).ContainsKey(0);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExplicitContainsKey_NewExpression_CastToInterface()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            class Map : IReadOnlyDictionary<int, int>
+            {
+                public int this[int key] => 0;
+                public IEnumerable<int> Keys => [];
+                public IEnumerable<int> Values => [];
+                public int Count => 0;
+                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out int value) { value = 0; return false; }
+                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            class Sample
+            {
+                object Run() => {|MA0160:new Map().TryGetValue(0, out _)|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            class Map : IReadOnlyDictionary<int, int>
+            {
+                public int this[int key] => 0;
+                public IEnumerable<int> Keys => [];
+                public IEnumerable<int> Values => [];
+                public int Count => 0;
+                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out int value) { value = 0; return false; }
+                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            class Sample
+            {
+                object Run() => ((IReadOnlyDictionary<int, int>)new Map()).ContainsKey(0);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExplicitContainsKey_Struct_NoFix()
+    {
+        // Casting the struct to the interface would box it
+        const string Code = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            struct Map : IReadOnlyDictionary<int, int>
+            {
+                public int this[int key] => 0;
+                public IEnumerable<int> Keys => [];
+                public IEnumerable<int> Values => [];
+                public int Count => 0;
+                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out int value) { value = 0; return false; }
+                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            class Sample
+            {
+                bool Run(Map map) => {|MA0160:map.TryGetValue(0, out _)|};
+            }
+            """;
+
+        var test = CreateTest();
+        test.FixedState.MarkupHandling = MarkupMode.Allow;
+        test.TestCode = Code;
+        test.FixedCode = Code;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExplicitContainsKey_UnrelatedPublicContainsKey_CastToInterface()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            class Map : IReadOnlyDictionary<int, int>
+            {
+                public int this[int key] => 0;
+                public IEnumerable<int> Keys => [];
+                public IEnumerable<int> Values => [];
+                public int Count => 0;
+                public bool ContainsKey(int key) => true;
+                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out int value) { value = 0; return false; }
+                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            class Sample
+            {
+                bool Run(Map map) => {|MA0160:map.TryGetValue(0, out _)|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            class Map : IReadOnlyDictionary<int, int>
+            {
+                public int this[int key] => 0;
+                public IEnumerable<int> Keys => [];
+                public IEnumerable<int> Values => [];
+                public int Count => 0;
+                public bool ContainsKey(int key) => true;
+                bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
+                public bool TryGetValue(int key, out int value) { value = 0; return false; }
+                public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => throw null;
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+
+            class Sample
+            {
+                bool Run(Map map) => ((IReadOnlyDictionary<int, int>)map).ContainsKey(0);
             }
             """;
 


### PR DESCRIPTION
## What changed

MA0160 reported `TryGetValue(key, out _)` even when the type of the instance implements `ContainsKey` explicitly. The suggestion was wrong, because an explicitly implemented member is not meant to be called on that type, and the code fix produced code that does not compile (CS1061):

```csharp
class Map : IReadOnlyDictionary<int, int>
{
    bool IReadOnlyDictionary<int, int>.ContainsKey(int key) => false;
    public bool TryGetValue(int key, out int value) { ... }
    // ...
}

object Run() => new Map().TryGetValue(0, out _); // fix produced new Map().ContainsKey(0) → CS1061
```

The analyzer now skips the diagnostic when the implementation of `ContainsKey` on the instance type is an explicit interface implementation. The code fix is unchanged.

## Notes for reviewers

- The check uses the instance type (`operation.Instance.Type`), so calls through the interface (`IReadOnlyDictionary<int, int> map`) are still reported and fixed as before.
- A public `ContainsKey` that exists alongside the explicit implementation is unrelated to the interface, so it is not suggested either.
- If a type implements both `IReadOnlyDictionary` and `IDictionary`, the other interface is still checked when one has an explicit `ContainsKey`.
- `docs/Rules/MA0160.md` documents the exception.

## Tests

Added tests for a class and a struct with an explicit `ContainsKey` (no diagnostic), a type with an unrelated public `ContainsKey` (no diagnostic), and an interface-typed receiver (still reported and fixed). `UseContainsKeyInsteadOfTryGetValueAnalyzerTests` passes on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9 (9/9 each). `dotnet run --project src/DocumentationGenerator` reports no further changes.
