### PR TITLE
Preserve interpolation alignment in MA0052 code fix

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ReplaceEnumToStringWithNameofFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ReplaceEnumToStringWithNameofFixer.cs
@@ -38,10 +38,13 @@ public sealed class ReplaceEnumToStringWithNameofFixer : CodeFixProvider
             var newExpression = generator.NameOfExpression(invocation.Instance.Syntax);
             editor.ReplaceNode(nodeToFix, newExpression);
         }
-        else if (operation is IInterpolationOperation interpolation)
+        else if (operation is IInterpolationOperation { Syntax: InterpolationSyntax interpolationSyntax } interpolation)
         {
-            var newExpression = SyntaxFactory.Interpolation((ExpressionSyntax)generator.NameOfExpression(interpolation.Expression.Syntax));
-            editor.ReplaceNode(nodeToFix, newExpression);
+            // Keep the alignment clause as it pads the value. The format clause is removed as the reported formats (G, F) already produce the name of the value.
+            var newExpression = interpolationSyntax
+                .WithExpression((ExpressionSyntax)generator.NameOfExpression(interpolation.Expression.Syntax))
+                .WithFormatClause(null);
+            editor.ReplaceNode(interpolationSyntax, newExpression);
         }
 
         return editor.GetChangedDocument();

--- a/tests/Meziantou.Analyzer.Test/Rules/ReplaceEnumToStringWithNameofAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ReplaceEnumToStringWithNameofAnalyzerTests.cs
@@ -205,4 +205,48 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task InterpolatedString_Alignment()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = $"[{|MA0052:{MyEnum.A,10}|}]";
+                    _ = $"[{|MA0052:{MyEnum.A,-10}|}]";
+                    _ = $"[{|MA0052:{MyEnum.A,10:G}|}]";
+                    _ = $"[{|MA0052:{MyEnum.A,-10:f}|}]";
+                    _ = $"[{MyEnum.A,10:D}]";
+                }
+            }
+
+            enum MyEnum
+            {
+                A,
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = $"[{nameof(MyEnum.A),10}]";
+                    _ = $"[{nameof(MyEnum.A),-10}]";
+                    _ = $"[{nameof(MyEnum.A),10}]";
+                    _ = $"[{nameof(MyEnum.A),-10}]";
+                    _ = $"[{MyEnum.A,10:D}]";
+                }
+            }
+
+            enum MyEnum
+            {
+                A,
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## Summary

The MA0052 code fix (replace constant `Enum.ToString` with `nameof`) dropped the alignment clause of interpolations, which changed the output of the code:

```csharp
enum Color { Red }

_ = $"[{Color.Red,10}]";          // "[       Red]"
_ = $"[{nameof(Color.Red)}]";     // "[Red]" — previous fix result
_ = $"[{nameof(Color.Red),10}]";  // "[       Red]" — new fix result
```

## Changes

- `ReplaceEnumToStringWithNameofFixer` now updates the existing `InterpolationSyntax` instead of creating a new one: the expression is replaced by `nameof(...)` and the alignment clause is kept.
- The format clause is still removed, as before. This is safe because the analyzer only reports interpolations whose format produces the name of the value (`G`, `g`, `F`, `f`, or none).
- Added `InterpolatedString_Alignment` test covering positive and negative widths, with and without a format clause, plus a non-reported `:D` case.

## Validation

- The new test fails without the fix and passes with it.
- `ReplaceEnumToStringWithNameofAnalyzerTests` pass on roslyn4.8, 4.14, 5.0, 5.6 and 5.9 (15/15 each).
- `dotnet run --project src/DocumentationGenerator` produces no changes.
