### PR TITLE
MA0052: Suggest the first declared member when the enum value has aliases

### DIFF
--- a/docs/Rules/MA0052.md
+++ b/docs/Rules/MA0052.md
@@ -19,3 +19,18 @@ void Sample()
     _ = nameof(Color.Blue); // compliant
 }
 ````
+
+The rule does not report a member whose value is shared by another member of the enumeration. `ToString` formats the value, so it may return the name of another member than the one used in the source code, while `nameof` always returns the name used in the source code.
+
+````csharp
+public enum Color
+{
+    Red = 0,
+    Other = 0,
+}
+
+void Sample()
+{
+    _ = Color.Other.ToString(); // compliant, may return "Red"
+}
+````

--- a/docs/Rules/MA0052.md
+++ b/docs/Rules/MA0052.md
@@ -20,7 +20,7 @@ void Sample()
 }
 ````
 
-The rule does not report a member whose value is shared by another member of the enumeration. `ToString` formats the value, so it may return the name of another member than the one used in the source code, while `nameof` always returns the name used in the source code.
+When several members of the enumeration share the same value, `ToString` formats the value, so it may return the name of another member than the one used in the source code, while `nameof` always returns the name used in the source code. In this case, the code fix uses the first declared member, which is the name returned by the .NET runtime, and provides one alternative code fix per other member sharing the value.
 
 ````csharp
 public enum Color
@@ -31,6 +31,7 @@ public enum Color
 
 void Sample()
 {
-    _ = Color.Other.ToString(); // compliant, may return "Red"
+    _ = Color.Other.ToString(); // non compliant, returns "Red"
+    _ = nameof(Color.Red); // compliant (default code fix)
 }
 ````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ReplaceEnumToStringWithNameofFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ReplaceEnumToStringWithNameofFixer.cs
@@ -3,6 +3,8 @@ namespace Meziantou.Analyzer.Rules;
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public sealed class ReplaceEnumToStringWithNameofFixer : CodeFixProvider
 {
+    private const string Title = "Use nameof";
+
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RuleIdentifiers.ReplaceEnumToStringWithNameof);
 
     public override FixAllProvider GetFixAllProvider()
@@ -21,26 +23,71 @@ public sealed class ReplaceEnumToStringWithNameofFixer : CodeFixProvider
         if (semanticModel is null)
             return;
 
-        if (semanticModel.GetOperation(nodeToFix, context.CancellationToken) is null)
+        var operation = semanticModel.GetOperation(nodeToFix, context.CancellationToken);
+        var enumMember = operation switch
+        {
+            IInvocationOperation invocation => invocation.Instance,
+            IInterpolationOperation interpolation => interpolation.Expression,
+            _ => null,
+        };
+
+        if (enumMember is not IFieldReferenceOperation { Field: var field, Syntax: ExpressionSyntax enumMemberSyntax })
             return;
 
-        var title = "Use nameof";
-        context.RegisterCodeFix(CodeAction.Create(title, ct => UseNameof(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
+        var aliases = GetMembersWithSameValue(field);
+        if (aliases.Length <= 1)
+        {
+            context.RegisterCodeFix(CodeAction.Create(Title, ct => UseNameof(context.Document, nodeToFix, enumMemberSyntax, ct), equivalenceKey: Title), context.Diagnostics);
+            return;
+        }
+
+        if (enumMemberSyntax is not (MemberAccessExpressionSyntax or IdentifierNameSyntax))
+            return;
+
+        // Enum.ToString formats the value, so when several members share the same value, it may return the name of another member
+        // than the one used in the source code. The runtime returns the first declared member, but this is not documented.
+        // So, the first declared member is the default fix, and the other members are provided as alternative fixes.
+        var generator = SyntaxGenerator.GetGenerator(context.Document);
+        for (var i = 0; i < aliases.Length; i++)
+        {
+            var alias = aliases[i];
+            var title = $"Use nameof({field.ContainingType.Name}.{alias.Name})";
+            var aliasSyntax = ReplaceMemberName(generator, enumMemberSyntax, alias.Name);
+            context.RegisterCodeFix(CodeAction.Create(title, ct => UseNameof(context.Document, nodeToFix, aliasSyntax, ct), equivalenceKey: i == 0 ? Title : title), context.Diagnostics);
+        }
     }
 
-    private static async Task<Document> UseNameof(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static ImmutableArray<IFieldSymbol> GetMembersWithSameValue(IFieldSymbol field)
+    {
+        if (!field.HasConstantValue)
+            return ImmutableArray.Create(field);
+
+        return field.ContainingType.GetMembers()
+            .OfType<IFieldSymbol>()
+            .Where(member => member.HasConstantValue && Equals(member.ConstantValue, field.ConstantValue))
+            .ToImmutableArray();
+    }
+
+    private static ExpressionSyntax ReplaceMemberName(SyntaxGenerator generator, ExpressionSyntax enumMemberSyntax, string name)
+    {
+        var newName = (IdentifierNameSyntax)generator.IdentifierName(name);
+        return enumMemberSyntax switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.WithName(newName.WithTriviaFrom(memberAccess.Name)),
+            _ => newName.WithTriviaFrom(enumMemberSyntax),
+        };
+    }
+
+    private static async Task<Document> UseNameof(Document document, SyntaxNode nodeToFix, ExpressionSyntax enumMemberSyntax, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var generator = editor.Generator;
-        var operation = editor.SemanticModel.GetOperation(nodeToFix, cancellationToken);
-        if (operation is IInvocationOperation invocation && invocation.Instance is not null)
+        var newExpression = (ExpressionSyntax)editor.Generator.NameOfExpression(enumMemberSyntax);
+        if (nodeToFix is InterpolationSyntax)
         {
-            var newExpression = generator.NameOfExpression(invocation.Instance.Syntax);
-            editor.ReplaceNode(nodeToFix, newExpression);
+            editor.ReplaceNode(nodeToFix, SyntaxFactory.Interpolation(newExpression));
         }
-        else if (operation is IInterpolationOperation interpolation)
+        else
         {
-            var newExpression = SyntaxFactory.Interpolation((ExpressionSyntax)generator.NameOfExpression(interpolation.Expression.Syntax));
             editor.ReplaceNode(nodeToFix, newExpression);
         }
 

--- a/src/Meziantou.Analyzer/Rules/ReplaceEnumToStringWithNameofAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ReplaceEnumToStringWithNameofAnalyzer.cs
@@ -33,7 +33,10 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzer : DiagnosticAnalyzer
         if (!operation.TargetMethod.ContainingType.IsEqualTo(context.Compilation.GetSpecialType(SpecialType.System_Enum)))
             return;
 
-        if (!IsUniquelyNamedEnumMember(operation.Instance))
+        if (operation.Instance is not IMemberReferenceOperation expression)
+            return;
+
+        if (expression.Member.ContainingType.EnumUnderlyingType is null)
             return;
 
         if (operation.Arguments.Length > 0)
@@ -56,7 +59,10 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeInterpolation(OperationAnalysisContext context)
     {
         var operation = (IInterpolationOperation)context.Operation;
-        if (!IsUniquelyNamedEnumMember(operation.Expression))
+        if (operation.Expression is not IMemberReferenceOperation expression)
+            return;
+
+        if (expression.Member.ContainingType.EnumUnderlyingType is null)
             return;
 
         if (operation.FormatString is ILiteralOperation { ConstantValue: { HasValue: true, Value: var format } })
@@ -66,26 +72,6 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzer : DiagnosticAnalyzer
         }
 
         context.ReportDiagnostic(Rule, operation);
-    }
-
-    // Enum.ToString formats the value, so when several members share the same value,
-    // it may return the name of another member than the one referenced in the source code.
-    private static bool IsUniquelyNamedEnumMember(IOperation? operation)
-    {
-        if (operation is not IFieldReferenceOperation { Field: { HasConstantValue: true } field })
-            return false;
-
-        var enumType = field.ContainingType;
-        if (enumType.EnumUnderlyingType is null)
-            return false;
-
-        foreach (var member in enumType.GetMembers())
-        {
-            if (member is IFieldSymbol { HasConstantValue: true } otherField && !otherField.IsEqualTo(field) && Equals(otherField.ConstantValue, field.ConstantValue))
-                return false;
-        }
-
-        return true;
     }
 
     private static bool IsNameFormat(object? format)

--- a/src/Meziantou.Analyzer/Rules/ReplaceEnumToStringWithNameofAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ReplaceEnumToStringWithNameofAnalyzer.cs
@@ -33,10 +33,7 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzer : DiagnosticAnalyzer
         if (!operation.TargetMethod.ContainingType.IsEqualTo(context.Compilation.GetSpecialType(SpecialType.System_Enum)))
             return;
 
-        if (operation.Instance is not IMemberReferenceOperation expression)
-            return;
-
-        if (expression.Member.ContainingType.EnumUnderlyingType is null)
+        if (!IsUniquelyNamedEnumMember(operation.Instance))
             return;
 
         if (operation.Arguments.Length > 0)
@@ -59,10 +56,7 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeInterpolation(OperationAnalysisContext context)
     {
         var operation = (IInterpolationOperation)context.Operation;
-        if (operation.Expression is not IMemberReferenceOperation expression)
-            return;
-
-        if (expression.Member.ContainingType.EnumUnderlyingType is null)
+        if (!IsUniquelyNamedEnumMember(operation.Expression))
             return;
 
         if (operation.FormatString is ILiteralOperation { ConstantValue: { HasValue: true, Value: var format } })
@@ -72,6 +66,26 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzer : DiagnosticAnalyzer
         }
 
         context.ReportDiagnostic(Rule, operation);
+    }
+
+    // Enum.ToString formats the value, so when several members share the same value,
+    // it may return the name of another member than the one referenced in the source code.
+    private static bool IsUniquelyNamedEnumMember(IOperation? operation)
+    {
+        if (operation is not IFieldReferenceOperation { Field: { HasConstantValue: true } field })
+            return false;
+
+        var enumType = field.ContainingType;
+        if (enumType.EnumUnderlyingType is null)
+            return false;
+
+        foreach (var member in enumType.GetMembers())
+        {
+            if (member is IFieldSymbol { HasConstantValue: true } otherField && !otherField.IsEqualTo(field) && Equals(otherField.ConstantValue, field.ConstantValue))
+                return false;
+        }
+
+        return true;
     }
 
     private static bool IsNameFormat(object? format)

--- a/tests/Meziantou.Analyzer.Test/Rules/ReplaceEnumToStringWithNameofAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ReplaceEnumToStringWithNameofAnalyzerTests.cs
@@ -48,7 +48,7 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzerTests
     }
 
     [Fact]
-    public Task EnumMemberWithAliasToString()
+    public Task EnumMemberWithAlias_UseFirstDeclaredMember()
     {
         var test = CreateTest();
         test.TestCode = """
@@ -56,11 +56,28 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzerTests
             {
                 void A()
                 {
-                    _ = MyEnum.A.ToString();
-                    _ = MyEnum.B.ToString();
-                    _ = MyEnum.C.ToString("G");
-                    _ = $"{MyEnum.A}";
-                    _ = $"{MyEnum.B:G}";
+                    _ = {|MA0052:MyEnum.B.ToString()|};
+                    _ = {|MA0052:MyEnum.D.ToString("G")|};
+                    _ = $"{|MA0052:{MyEnum.B}|}";
+                }
+            }
+
+            enum MyEnum
+            {
+                A = 0,
+                B = 0,
+                C = 1,
+                D = C,
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = nameof(MyEnum.A);
+                    _ = nameof(MyEnum.C);
+                    _ = $"{nameof(MyEnum.A)}";
                 }
             }
 
@@ -77,16 +94,17 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzerTests
     }
 
     [Fact]
-    public Task EnumMemberWithoutAliasToString()
+    public Task EnumMemberWithAlias_UseOtherMember()
     {
         var test = CreateTest();
+        test.CodeActionIndex = 1;
+        test.CodeActionEquivalenceKey = "Use nameof(MyEnum.B)";
         test.TestCode = """
             class Test
             {
                 void A()
                 {
-                    _ = {|MA0052:MyEnum.C.ToString()|};
-                    _ = $"{|MA0052:{MyEnum.C}|}";
+                    _ = {|MA0052:MyEnum.A.ToString()|};
                 }
             }
 
@@ -94,7 +112,6 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzerTests
             {
                 A = 0,
                 B = 0,
-                C = 1,
             }
             """;
         test.FixedCode = """
@@ -102,8 +119,7 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzerTests
             {
                 void A()
                 {
-                    _ = nameof(MyEnum.C);
-                    _ = $"{nameof(MyEnum.C)}";
+                    _ = nameof(MyEnum.B);
                 }
             }
 
@@ -111,7 +127,86 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzerTests
             {
                 A = 0,
                 B = 0,
-                C = 1,
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task EnumMemberWithAlias_UsingStatic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using static MyEnum;
+
+            class Test
+            {
+                void M()
+                {
+                    _ = {|MA0052:B.ToString()|};
+                }
+            }
+
+            enum MyEnum
+            {
+                A = 0,
+                B = 0,
+            }
+            """;
+        test.FixedCode = """
+            using static MyEnum;
+
+            class Test
+            {
+                void M()
+                {
+                    _ = nameof(A);
+                }
+            }
+
+            enum MyEnum
+            {
+                A = 0,
+                B = 0,
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task EnumMemberWithAlias_KeywordName()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = {|MA0052:MyEnum.B.ToString()|};
+                }
+            }
+
+            enum MyEnum
+            {
+                @class = 0,
+                B = 0,
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = nameof(MyEnum.@class);
+                }
+            }
+
+            enum MyEnum
+            {
+                @class = 0,
+                B = 0,
             }
             """;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/ReplaceEnumToStringWithNameofAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ReplaceEnumToStringWithNameofAnalyzerTests.cs
@@ -48,6 +48,77 @@ public sealed class ReplaceEnumToStringWithNameofAnalyzerTests
     }
 
     [Fact]
+    public Task EnumMemberWithAliasToString()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = MyEnum.A.ToString();
+                    _ = MyEnum.B.ToString();
+                    _ = MyEnum.C.ToString("G");
+                    _ = $"{MyEnum.A}";
+                    _ = $"{MyEnum.B:G}";
+                }
+            }
+
+            enum MyEnum
+            {
+                A = 0,
+                B = 0,
+                C = 1,
+                D = C,
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task EnumMemberWithoutAliasToString()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = {|MA0052:MyEnum.C.ToString()|};
+                    _ = $"{|MA0052:{MyEnum.C}|}";
+                }
+            }
+
+            enum MyEnum
+            {
+                A = 0,
+                B = 0,
+                C = 1,
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                void A()
+                {
+                    _ = nameof(MyEnum.C);
+                    _ = $"{nameof(MyEnum.C)}";
+                }
+            }
+
+            enum MyEnum
+            {
+                A = 0,
+                B = 0,
+                C = 1,
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task EnumVariableToString()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

When the referenced enum member shares its value with other members, the MA0052 code fix no longer blindly uses the member written in source. The diagnostic is still reported, but:

- The **default fix** (and Fix All) uses the **first declared member** sharing the value.
- **One alternative fix per other member** sharing the value is also offered (for example, `Use nameof(Color.Other)`).

```csharp
enum Color { Red = 0, Other = 0 }

_ = Color.Other.ToString(); // returns "Red"
// Before: fixed to nameof(Color.Other) -> "Other" (behavior change)
// After:  fixed to nameof(Color.Red)   -> "Red"   (alternative fix: nameof(Color.Other))
```

The analyzer is unchanged. Enums whose values are all distinct keep the single `Use nameof` fix.

## Why

`Enum.ToString` formats the *value*, so with aliases it may return a name different from the one in source, while `nameof` always returns the source identifier. The old fix could change strings used for logging, persisted values, or comparisons.

I checked the runtime's choice on .NET 11 with 2, 3 and 4 aliases, non-zero values, and aliases mixed with other members. It always returned the first declared member. The [docs](https://learn.microsoft.com/dotnet/api/system.enum.tostring) say not to rely on which alias is returned, so the other aliases remain available as explicit alternative fixes.

## Notes for reviewers

- Aliases are the enum's constant fields with the same value, in declaration order. Members defined in terms of another (`D = C`) count as aliases.
- To use an alias, the fix replaces only the member name in the existing syntax (`MemberAccessExpression` or, with `using static`, `IdentifierName`). This keeps the written qualification, such as `global::` or an alias, and escapes keywords (`@class`).
- Equivalence keys: the first-declared option shares the `Use nameof` key, so Fix All is consistent. Each alternative uses its own title as the key.
- Interpolation alignment and format clauses are still dropped by the fixer, as before. That's a separate finding and is out of scope here.

## Tests

- `EnumMemberWithAlias_UseFirstDeclaredMember`: covers `ToString()`, `ToString("G")`, a member defined as another, and interpolation. All are fixed to the first declared member.
- `EnumMemberWithAlias_UseOtherMember`: the alternative code action.
- `EnumMemberWithAlias_UsingStatic`, `EnumMemberWithAlias_KeywordName`.
- `ReplaceEnumToStringWithNameofAnalyzerTests`: 18/18 pass on Roslyn 5.9 and 4.8. The full solution builds for all Roslyn versions with no warnings, and `DocumentationGenerator` reports no pending changes.
