### PR TITLE
MA0239: Do not report GetType() on a property

### DIFF
--- a/docs/Rules/MA0239.md
+++ b/docs/Rules/MA0239.md
@@ -11,7 +11,7 @@ The rule reports the calls to `object.GetType()` on an instance whose type canno
 
 The rule does not report the calls whose type cannot be used with `typeof`, such as an anonymous type, or a type that contains one like `Container<anonymous type>`.
 
-The rule does not report the calls whose instance must be evaluated, such as `GetValue().GetType()` or `list[0].GetType()`, as removing the evaluation of the instance would change the behavior of the code. `instance?.GetType()` is not reported either, as it evaluates to `null` instead of the type when the instance is `null`.
+The rule does not report the calls whose instance must be evaluated, such as `GetValue().GetType()`, `instance.Property.GetType()`, or `list[0].GetType()`, as removing the evaluation of the instance would change the behavior of the code. `instance?.GetType()` is not reported either, as it evaluates to `null` instead of the type when the instance is `null`.
 
 ## Motivation
 

--- a/src/Meziantou.Analyzer/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeCommon.cs
@@ -79,8 +79,8 @@ internal static class UseTypeofInsteadOfGetTypeOnSealedTypeCommon
         ILiteralOperation => true,
         IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance } => true,
         IFieldReferenceOperation { Instance: var fieldInstance } => fieldInstance is null || IsSideEffectFree(fieldInstance),
-        // Indexers are excluded as they can throw, unlike the properties without arguments
-        IPropertyReferenceOperation { Arguments.IsEmpty: true, Instance: var propertyInstance } => propertyInstance is null || IsSideEffectFree(propertyInstance),
+        // The properties and the indexers are excluded as their getter can execute any code, such as modifying a
+        // state or throwing an exception
         _ => false,
     };
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests.cs
@@ -354,24 +354,70 @@ public sealed class UseTypeofInsteadOfGetTypeOnSealedTypeAnalyzerTests
     }
 
     [Fact]
-    public Task Property()
+    public Task PropertyGetterModifyingState_NoDiagnostic()
     {
         return new CodeFixTest
         {
             TestCode = """
-                sealed class Sample
+                class Sample
                 {
-                    private string Value => "";
+                    static int calls;
+                    static string Value { get { calls++; return ""; } }
 
-                    System.Type Test() => [|Value.GetType()|];
+                    System.Type Test() => Value.GetType();
                 }
                 """,
-            FixedCode = """
-                sealed class Sample
-                {
-                    private string Value => "";
+        }.RunAsync();
+    }
 
-                    System.Type Test() => typeof(string);
+    [Fact]
+    public Task PropertyGetterThrowing_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    string Value => throw new System.InvalidOperationException();
+
+                    System.Type Test() => Value.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task AutoProperty_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Sample
+                {
+                    string Value { get; set; }
+
+                    System.Type Test() => Value.GetType();
+                }
+                """,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public Task FieldOfProperty_NoDiagnostic()
+    {
+        return new CodeFixTest
+        {
+            TestCode = """
+                class Item
+                {
+                    public string Field;
+                }
+
+                class Sample
+                {
+                    Item Value => throw new System.InvalidOperationException();
+
+                    System.Type Test() => Value.Field.GetType();
                 }
                 """,
         }.RunAsync();


### PR DESCRIPTION
## What changed

MA0239 (Use `typeof` instead of `GetType()` when the type is sealed) no longer reports `GetType()` calls on a property reference, such as `Value.GetType()` or `Value.Field.GetType()`.

## Why

`IsSideEffectFree` accepted any property reference without arguments. A property getter can execute arbitrary code, so replacing `Value.GetType()` with `typeof(string)` removed the getter call and changed the behavior of the code:

```csharp
public class Sample
{
    static int calls;
    static string Value { get { calls++; return "hello"; } }

    public static object Run()
    {
        _ = Value.GetType(); // fixed to typeof(string): Run() returned 1 before the fix, 0 after
        return calls;
    }
}
```

A getter that throws had the same problem: the fix removed the exception.

## Changes

- `UseTypeofInsteadOfGetTypeOnSealedTypeCommon.IsSideEffectFree` no longer accepts property references. The analyzer and the fixer both use `GetKnownType`, so they share the same eligibility check.
- The `Property` test, which expected a diagnostic, is replaced with no-diagnostic tests for a getter that modifies state, a getter that throws, an auto-property, and a field read through a property. The four tests fail without the fix.
- `docs/Rules/MA0239.md` lists `instance.Property.GetType()` among the calls that are not reported.

## Notes for reviewers

- Auto-properties are excluded too. Allowing them safely would require proving that the getter only reads the backing field: non-virtual, not an override, not an interface member, not a C# 14 `field` getter with logic, and not a partial property with an implementation body (hard to check on Roslyn 4.8). Given that the rule is disabled by default, the simpler conservative behavior seemed preferable; it can be refined in a follow-up.
- Tests pass on Roslyn 5.9 and 4.8 (38/38 for this rule), the solution builds, and `dotnet run --project src/DocumentationGenerator` produces no further changes.
