### PR TITLE
Preserve attribute inheritance behavior in the MA0179 code fix

### DIFF
--- a/docs/Rules/MA0179.md
+++ b/docs/Rules/MA0179.md
@@ -45,3 +45,21 @@ if (attr != null)
     _ = attr.Message;
 }
 ````
+
+## Attribute inheritance on properties and events
+
+The instance methods `MemberInfo.GetCustomAttributes(bool)` and `MemberInfo.GetCustomAttributes(Type, bool)` ignore the `inherit` parameter for properties and events, whereas `Attribute.IsDefined(MemberInfo, Type, bool)` also searches the overridden properties and events when `inherit` is `true`. To keep the same behavior, the code fix uses the instance method `MemberInfo.IsDefined(Type, bool)` when the member can be a property or an event and `inherit` is not `false`:
+
+````csharp
+using System;
+using System.Reflection;
+
+void Sample(MemberInfo member)
+{
+    // non-compliant
+    _ = member.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: true).Length > 0;
+
+    // compliant (fixed code)
+    _ = member.IsDefined(typeof(ObsoleteAttribute), inherit: true);
+}
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAttributeIsDefinedFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAttributeIsDefinedFixer.cs
@@ -271,7 +271,7 @@ public sealed class UseAttributeIsDefinedFixer : CodeFixProvider
         arguments.Add(typeSyntax);
 
         // Find inherit argument
-        SyntaxNode? inheritSyntax = null;
+        IArgumentOperation? inheritArgument = null;
         foreach (var arg in invocation.Arguments)
         {
             // Skip instance argument for extension methods
@@ -284,19 +284,30 @@ public sealed class UseAttributeIsDefinedFixer : CodeFixProvider
 
             if (arg.Parameter?.Type.SpecialType == SpecialType.System_Boolean && arg.Parameter.Name == "inherit")
             {
-                inheritSyntax = arg.Syntax;
+                inheritArgument = arg;
                 break;
             }
         }
 
-        if (inheritSyntax is not null)
+        SyntaxNode isDefinedInvocation;
+        if (instanceSyntax is not null && inheritArgument is not null && MustUseInstanceIsDefined(semanticModel.Compilation, invocation, inheritArgument))
         {
-            arguments.Add(inheritSyntax);
+            isDefinedInvocation = generator.InvocationExpression(
+                generator.MemberAccessExpression(instanceSyntax, "IsDefined"),
+                typeSyntax,
+                inheritArgument.Syntax);
         }
+        else
+        {
+            if (inheritArgument is not null)
+            {
+                arguments.Add(inheritArgument.Syntax);
+            }
 
-        var isDefinedInvocation = generator.InvocationExpression(
-            generator.MemberAccessExpression(attributeTypeSyntax, "IsDefined"),
-            arguments);
+            isDefinedInvocation = generator.InvocationExpression(
+                generator.MemberAccessExpression(attributeTypeSyntax, "IsDefined"),
+                arguments);
+        }
 
         if (negate)
         {
@@ -304,5 +315,25 @@ public sealed class UseAttributeIsDefinedFixer : CodeFixProvider
         }
 
         return isDefinedInvocation;
+    }
+
+    // The instance methods, such as MemberInfo.GetCustomAttributes(Type, bool), ignore 'inherit' for properties and events,
+    // while Attribute.IsDefined(MemberInfo, Type, bool) walks the chain of the overridden properties and events.
+    // MemberInfo.IsDefined(Type, bool) behaves like the instance methods, so it is used when the results could differ.
+    private static bool MustUseInstanceIsDefined(Compilation compilation, IInvocationOperation invocation, IArgumentOperation inheritArgument)
+    {
+        if (invocation.Instance?.Type is not { } instanceType)
+            return false;
+
+        if (inheritArgument.Value.ConstantValue is { HasValue: true, Value: false })
+            return false;
+
+        return CanBeInstanceOf(instanceType, compilation.GetBestTypeByMetadataName("System.Reflection.PropertyInfo")) ||
+               CanBeInstanceOf(instanceType, compilation.GetBestTypeByMetadataName("System.Reflection.EventInfo"));
+
+        static bool CanBeInstanceOf(ITypeSymbol type, INamedTypeSymbol? expectedType)
+        {
+            return expectedType is not null && (type.IsOrInheritsFrom(expectedType) || expectedType.IsOrInheritsFrom(type));
+        }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
@@ -853,7 +853,7 @@ public sealed class UseAttributeIsDefinedAnalyzerTests
             {
                 void Test(MemberInfo member)
                 {
-                    _ = Attribute.IsDefined(member, typeof(ObsoleteAttribute), inherit: true);
+                    _ = member.IsDefined(typeof(ObsoleteAttribute), inherit: true);
                 }
             }
             """;
@@ -885,7 +885,7 @@ public sealed class UseAttributeIsDefinedAnalyzerTests
             {
                 void Test(MemberInfo member)
                 {
-                    _ = Attribute.IsDefined(member, typeof(Attribute), inherit: true);
+                    _ = member.IsDefined(typeof(Attribute), inherit: true);
                 }
             }
             """;
@@ -987,7 +987,174 @@ public sealed class UseAttributeIsDefinedAnalyzerTests
             {
                 void Test(MemberInfo member)
                 {
-                    _ = Attribute.IsDefined(member, typeof(ObsoleteAttribute), inherit: true);
+                    _ = member.IsDefined(typeof(ObsoleteAttribute), inherit: true);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("PropertyInfo")]
+    [InlineData("EventInfo")]
+    public Task InstanceGetCustomAttributes_WithInherit_PropertyOrEvent_UsesInstanceIsDefined(string memberType)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test({{memberType}} member)
+                {
+                    _ = {|MA0179:member.GetCustomAttributes(typeof(ObsoleteAttribute), true).Length > 0|};
+                }
+            }
+            """;
+        test.FixedCode = $$"""
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test({{memberType}} member)
+                {
+                    _ = member.IsDefined(typeof(ObsoleteAttribute), true);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InstanceGetCustomAttributes_WithNonConstantInherit_UsesInstanceIsDefined()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member, bool inherit)
+                {
+                    _ = {|MA0179:member.GetCustomAttributes(typeof(ObsoleteAttribute), inherit).Length == 0|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member, bool inherit)
+                {
+                    _ = !member.IsDefined(typeof(ObsoleteAttribute), inherit);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InstanceGetCustomAttributes_WithoutInherit_Property_UsesAttributeIsDefined()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(PropertyInfo member)
+                {
+                    _ = {|MA0179:member.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: false).Length > 0|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(PropertyInfo member)
+                {
+                    _ = Attribute.IsDefined(member, typeof(ObsoleteAttribute), inherit: false);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("Type")]
+    [InlineData("MethodInfo")]
+    [InlineData("FieldInfo")]
+    public Task InstanceGetCustomAttributes_WithInherit_NotPropertyOrEvent_UsesAttributeIsDefined(string memberType)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test({{memberType}} member)
+                {
+                    _ = {|MA0179:member.GetCustomAttributes(typeof(ObsoleteAttribute), true).Length > 0|};
+                }
+            }
+            """;
+        test.FixedCode = $$"""
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test({{memberType}} member)
+                {
+                    _ = Attribute.IsDefined(member, typeof(ObsoleteAttribute), true);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExtensionGetCustomAttributes_Property_UsesAttributeIsDefined()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(PropertyInfo member)
+                {
+                    _ = {|MA0179:member.GetCustomAttributes(typeof(ObsoleteAttribute)).Any()|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(PropertyInfo member)
+                {
+                    _ = Attribute.IsDefined(member, typeof(ObsoleteAttribute));
                 }
             }
             """;


### PR DESCRIPTION
## Problem

The MA0179 code fix replaced instance `GetCustomAttributes` calls with `Attribute.IsDefined` and copied the `inherit` argument unchanged. The two APIs don't handle `inherit` the same way on properties and events:

- the instance `MemberInfo.GetCustomAttributes(Type, bool)` and `MemberInfo.GetCustomAttributes(bool)` methods ignore `inherit` for properties and events
- `Attribute.IsDefined(MemberInfo, Type, bool)` also searches the overridden properties and events when `inherit` is `true`

```csharp
[AttributeUsage(AttributeTargets.Property, Inherited = true)]
public class MarkerAttribute : Attribute { }
public class Base { [Marker] public virtual int Value => 0; }
public class Derived : Base { public override int Value => 0; }

// false
typeof(Derived).GetProperty("Value").GetCustomAttributes(typeof(MarkerAttribute), true).Length > 0
// fix output before this PR: true
Attribute.IsDefined(typeof(Derived).GetProperty("Value"), typeof(MarkerAttribute), true)
```

I ran this on .NET 10 for each member kind:

| Member | instance `GetCustomAttributes(t, true)` | instance `IsDefined(t, true)` | `Attribute.IsDefined(m, t, true)` |
|---|---|---|---|
| Property | false | false | **true** |
| Event | false | false | **true** |
| Method | true | true | true |
| Type | true | true | true |

The extension (`CustomAttributeExtensions`) and static `Attribute.GetCustomAttribute(s)` calls were not affected: they already search inherited attributes the same way as `Attribute.IsDefined`.

## Fix

For instance `GetCustomAttributes` calls, the fix now produces the instance `MemberInfo.IsDefined(Type, bool)` when:
- the static type of the receiver can be a `PropertyInfo` or `EventInfo` at runtime (for example `MemberInfo`, `PropertyInfo` or `EventInfo`), and
- `inherit` is not the constant `false`.

`MemberInfo.IsDefined(Type, bool)` gives the same result as the original call. In all other cases (`inherit: false`, receivers such as `Type`, `MethodInfo`, `FieldInfo`, `Assembly`, `Module`, and the extension and static calls), the fix still produces `Attribute.IsDefined`.

```csharp
// before
_ = member.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: true).Length > 0;
// after the fix
_ = member.IsDefined(typeof(ObsoleteAttribute), inherit: true);
```

## Tests

- Three existing fix tests expected `Attribute.IsDefined(member, ..., inherit: true)` for a `MemberInfo` receiver, which is the buggy output. They now expect the instance `IsDefined`.
- New cases:
  - `PropertyInfo` and `EventInfo` with `inherit: true`
  - a non-constant `inherit` variable
  - `PropertyInfo` with `inherit: false`, which still gets `Attribute.IsDefined`
  - `Type`, `MethodInfo` and `FieldInfo` with `inherit: true`, which still get `Attribute.IsDefined`
  - the extension `GetCustomAttributes(Type)` on a `PropertyInfo`, which still gets `Attribute.IsDefined`
- Without the fixer change, 6 of these tests fail. With it, all 43 `UseAttributeIsDefinedAnalyzerTests` pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- `dotnet run --project src/DocumentationGenerator` makes no further changes.

## Notes for reviewers

- `docs/Rules/MA0179.md` has a new section describing this behavior.
- The code fix title ("Use Attribute.IsDefined") and the diagnostic message are unchanged, even when the fix produces `member.IsDefined(...)`. Showing a different title would mean building the replacement before the fix is registered, which is a larger refactor of the fixer. I left it out of this PR.
