### PR TITLE
MA0113: Only report DateTime constructors with the Utc kind

### DIFF
--- a/docs/Rules/MA0113.md
+++ b/docs/Rules/MA0113.md
@@ -6,7 +6,10 @@ Sources: [UseDateTimeUnixEpochAnalyzer.cs](https://github.com/meziantou/Mezianto
 Use `System.DateTime.UnixEpoch` instead of re-implementing the logic.
 
 ````c#
-_ = new DateTime(1970, 1, 1); // report diagnostic
+_ = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc); // report diagnostic
+_ = new DateTime(621355968000000000, DateTimeKind.Utc); // report diagnostic
 
 _ = DateTime.UnixEpoch; // ok
 ````
+
+`DateTime.UnixEpoch` has the `DateTimeKind.Utc` kind. The rule does not report the constructors that create a value with another kind, such as `new DateTime(1970, 1, 1)` which creates a value with the `DateTimeKind.Unspecified` kind, as replacing them would change the `Kind` of the value.

--- a/src/Meziantou.Analyzer/Rules/UseDateTimeUnixEpochAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseDateTimeUnixEpochAnalyzer.cs
@@ -125,38 +125,23 @@ public sealed class UseDateTimeUnixEpochAnalyzer : DiagnosticAnalyzer
             }
         }
 
+        /// <summary>
+        /// Determines whether the operation creates a <see cref="DateTime"/> equal to <c>DateTime.UnixEpoch</c>, including its <see cref="DateTimeKind.Utc"/> kind.
+        /// The constructors that do not take a <see cref="DateTimeKind"/> create a <see cref="DateTimeKind.Unspecified"/> value, so replacing them would change the behavior.
+        /// </summary>
         private bool IsDateTimeUnixEpoch(IObjectCreationOperation operation, CancellationToken cancellationToken)
         {
             if (!operation.Type.IsEqualTo(_dateTimeSymbol))
                 return false;
 
-            if (operation.Arguments.Length == 1)
+            return operation.Arguments.Length switch
             {
-                if (ArgumentsEquals(operation, [621355968000000000L], cancellationToken))
-                    return true;
-            }
-            else if (operation.Arguments.Length == 2)
-            {
-                if (ArgumentsEquals(operation, [621355968000000000L], cancellationToken) && IsDateTimeKindUtc(GetArgument(operation, 1), cancellationToken))
-                    return true;
-            }
-            else if (operation.Arguments.Length == 3)
-            {
-                if (ArgumentsEquals(operation, [1970, 1, 1], cancellationToken))
-                    return true;
-            }
-            else if (operation.Arguments.Length == 6)
-            {
-                if (ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0], cancellationToken))
-                    return true;
-            }
-            else if (operation.Arguments.Length == 7)
-            {
-                if (ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0], cancellationToken) && IsDateTimeKindUtc(GetArgument(operation, 6), cancellationToken))
-                    return true;
-            }
-
-            return false;
+                2 => ArgumentsEquals(operation, [621355968000000000L], cancellationToken) && IsDateTimeKindUtc(GetArgument(operation, 1), cancellationToken),
+                7 => ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0], cancellationToken) && IsDateTimeKindUtc(GetArgument(operation, 6), cancellationToken),
+                8 => ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0, 0], cancellationToken) && IsDateTimeKindUtc(GetArgument(operation, 7), cancellationToken),
+                9 => ArgumentsEquals(operation, [1970, 1, 1, 0, 0, 0, 0, 0], cancellationToken) && IsDateTimeKindUtc(GetArgument(operation, 8), cancellationToken),
+                _ => false,
+            };
         }
 
         private bool IsDateTimeKindUtc(IArgumentOperation? argument, CancellationToken cancellationToken)

--- a/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseDateTimeUnixEpochAnalyzerTests.cs
@@ -10,12 +10,10 @@ public class UseDateTimeUnixEpochAnalyzerTests
     private static CodeFixTest CreateTest() => new();
 
     [Theory]
-    [InlineData("new DateTime(1970, 1, 1)")]
-    [InlineData("new DateTime(1970, 1, 1, 0,0,0)")]
     [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)")]
-    [InlineData("new DateTime(621355968000000000)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, 0, 0, DateTimeKind.Utc)")]
     [InlineData("new DateTime(621355968000000000, DateTimeKind.Utc)")]
-    [InlineData("new DateTime(day: 1, month: 1, year: 1970)")]
     [InlineData("new DateTime(kind: DateTimeKind.Utc, year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0)")]
     public Task UnixEpoch_DateTime(string code)
     {
@@ -84,13 +82,24 @@ public class UseDateTimeUnixEpochAnalyzerTests
 
     [Theory]
     [InlineData("new DateTime(1971, 1, 1)")]
-    [InlineData("new DateTime(1970, 1, 1, 0, 0, 1)")]
+    [InlineData("new DateTime(1970, 1, 1)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, 0)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 1, DateTimeKind.Utc)")]
     [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Local)")]
-    [InlineData("new DateTime(621355968000000001)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, 1, DateTimeKind.Utc)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Local)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, 0, 1, DateTimeKind.Utc)")]
+    [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, 0, new System.Globalization.GregorianCalendar(), DateTimeKind.Utc)")]
+    [InlineData("new DateTime(621355968000000000)")]
+    [InlineData("new DateTime(621355968000000001, DateTimeKind.Utc)")]
     [InlineData("new DateTime(621355968000000000, DateTimeKind.Local)")]
     [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, null)")]
     [InlineData("new DateTime(1970, 1, 1, 0, 0, 0, new System.Globalization.GregorianCalendar())")]
+    [InlineData("new DateTime(day: 1, month: 1, year: 1970)")]
     [InlineData("new DateTime(day: 1, month: 1, year: 1971)")]
+    [InlineData("new DateTime(1970, 1, 1).Kind")]
     public Task NonUnixEpoch_DateTime(string code)
     {
         var test = CreateTest();
@@ -147,7 +156,7 @@ public class UseDateTimeUnixEpochAnalyzerTests
             {
                void Test()
                {
-                   _ = new DateTime(1970, 1, 1);
+                   _ = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
                }
             }
             """;


### PR DESCRIPTION
## Problem

MA0113 reported `DateTime` constructors that don't take a `DateTimeKind`, and its fix replaced them with `DateTime.UnixEpoch`:

```csharp
public static object Run() => new System.DateTime(1970, 1, 1).Kind;
// fixed to
public static object Run() => System.DateTime.UnixEpoch.Kind;
```

Both compile, but the first returns `DateTimeKind.Unspecified` and the second returns `DateTimeKind.Utc`. The ticks are equal, but the values aren't interchangeable. The kind matters to code that inspects `Kind`, converts between time zones, or serializes the kind.

## Changes

- **Analyzer:** removed the branches for `new DateTime(ticks)`, `new DateTime(1970, 1, 1)` and `new DateTime(1970, 1, 1, 0, 0, 0)`. The rule now only reports constructors that explicitly pass `DateTimeKind.Utc`. It also recognizes the millisecond and microsecond overloads with `DateTimeKind.Utc`, which MA0114 already handles for `DateTimeOffset`.
- **Tests:** the constructors that don't set a kind are now "no diagnostic" cases, including the repro above. New cases cover the `Local` and `Unspecified` kinds, non-zero milliseconds and microseconds, and the `Calendar` overload. The old-framework test now uses a UTC constructor, so it still checks that nothing is reported when `DateTime.UnixEpoch` doesn't exist.
- **Docs:** `MA0113.md` no longer recommends replacing `new DateTime(1970, 1, 1)`. It explains why constructors without an explicit `DateTimeKind.Utc` aren't reported.

## Notes for reviewers

- MA0113 now reports fewer cases: code that relied on it for `new DateTime(1970, 1, 1)` won't get a diagnostic anymore. That's intended, because the fix would have changed behavior.
- MA0114 (`DateTimeOffset`) is unchanged. `DateTimeOffset` has no kind, and every case it reports requires a zero offset.

## Testing

- `UseDateTimeUnixEpochAnalyzerTests` passes on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9 (45 tests each).
- `dotnet run --project src/DocumentationGenerator` exits 0 and generates no further changes.
