### PR TITLE
Fix MA0127 code fix producing uncompilable code for object and span operands

### DIFF
--- a/docs/Rules/MA0127.md
+++ b/docs/Rules/MA0127.md
@@ -8,10 +8,23 @@ This rule is enabled by default as a silent suggestion.
 You should use `string.Equals` instead of `is`, to make string comparisons explicit. _Similar to [MA0006](./MA0006.md) but for patterns._
 
 ````csharp
-_ str = is "foo";
+_ = str is "foo";
 
 // Should be
-string.Equals(str, foo, StringComparison.Ordinal);
+_ = string.Equals(str, "foo", StringComparison.Ordinal);
+````
+
+The code fix adapts the comparison to the type of the operand:
+
+````csharp
+// string
+_ = string.Equals(str, "foo", StringComparison.Ordinal);
+
+// object, dynamic, interfaces, type parameters
+_ = string.Equals(obj as string, "foo", StringComparison.Ordinal);
+
+// Span<char>, ReadOnlySpan<char>
+_ = MemoryExtensions.Equals(span, "foo", StringComparison.Ordinal);
 ````
 
 ## Additional resources

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringEqualsInsteadOfIsPatternFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringEqualsInsteadOfIsPatternFixer.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Analyzer.Rules;
 
@@ -23,6 +24,21 @@ public sealed class UseStringEqualsInsteadOfIsPatternFixer : CodeFixProvider
         if (isPatternExpression.Pattern is not ConstantPatternSyntax { Expression: ExpressionSyntax constantExpression })
             return;
 
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var compilation = semanticModel.Compilation;
+        if (compilation.GetBestTypeByMetadataName("System.StringComparison") is not { } stringComparisonType)
+            return;
+
+        if (semanticModel.GetOperation(isPatternExpression, context.CancellationToken) is not IIsPatternOperation { Value.Type: { } operandType })
+            return;
+
+        var operandKind = GetOperandKind(compilation, operandType, stringComparisonType);
+        if (operandKind is OperandKind.None)
+            return;
+
         RegisterCodeFix(nameof(StringComparison.Ordinal));
         RegisterCodeFix(nameof(StringComparison.OrdinalIgnoreCase));
 
@@ -32,28 +48,88 @@ public sealed class UseStringEqualsInsteadOfIsPatternFixer : CodeFixProvider
             context.RegisterCodeFix(
                 CodeAction.Create(
                     title,
-                    ct => ReplaceWithStringEquals(context.Document, isPatternExpression, constantExpression, comparisonMode, ct),
+                    ct => ReplaceWithStringEquals(context.Document, isPatternExpression, constantExpression, operandKind, comparisonMode, ct),
                     equivalenceKey: title),
                 context.Diagnostics);
         }
     }
 
-    private static async Task<Document> ReplaceWithStringEquals(Document document, IsPatternExpressionSyntax isPatternExpression, ExpressionSyntax constantExpression, string comparisonMode, CancellationToken cancellationToken)
+    private static OperandKind GetOperandKind(Compilation compilation, ITypeSymbol operandType, INamedTypeSymbol stringComparisonType)
+    {
+        if (operandType.SpecialType is SpecialType.System_String)
+            return OperandKind.String;
+
+        // The constant pattern also matches Span<char> and ReadOnlySpan<char> (C# 11). string.Equals does not accept
+        // them, so the comparison is done by MemoryExtensions.Equals(ReadOnlySpan<char>, ReadOnlySpan<char>, StringComparison).
+        if (operandType is INamedTypeSymbol { TypeArguments: [{ SpecialType: SpecialType.System_Char }] } namedType &&
+            namedType.OriginalDefinition.IsEqualToAny(compilation.GetBestTypeByMetadataName("System.Span`1"), compilation.GetBestTypeByMetadataName("System.ReadOnlySpan`1")))
+        {
+            return HasMemoryExtensionsEquals(compilation, stringComparisonType) ? OperandKind.Span : OperandKind.None;
+        }
+
+        // Other operands (object, dynamic, interfaces implemented by string, type parameters) only match when their
+        // value is a string, so they are converted using 'as string', which is null when the value is not a string.
+        if (operandType.IsReferenceType || operandType is ITypeParameterSymbol { IsValueType: false })
+            return OperandKind.Object;
+
+        return OperandKind.None;
+    }
+
+    private static bool HasMemoryExtensionsEquals(Compilation compilation, INamedTypeSymbol stringComparisonType)
+    {
+        var memoryExtensionsType = compilation.GetBestTypeByMetadataName("System.MemoryExtensions");
+        var readOnlySpanType = compilation.GetBestTypeByMetadataName("System.ReadOnlySpan`1");
+        if (memoryExtensionsType is null || readOnlySpanType is null)
+            return false;
+
+        var readOnlySpanOfCharType = readOnlySpanType.Construct(compilation.GetSpecialType(SpecialType.System_Char));
+        return memoryExtensionsType.GetMembers(nameof(MemoryExtensions.Equals))
+            .OfType<IMethodSymbol>()
+            .Any(method => method is { IsStatic: true, DeclaredAccessibility: Accessibility.Public, Parameters.Length: 3 } &&
+                           method.Parameters[0].Type.IsEqualTo(readOnlySpanOfCharType) &&
+                           method.Parameters[1].Type.IsEqualTo(readOnlySpanOfCharType) &&
+                           method.Parameters[2].Type.IsEqualTo(stringComparisonType));
+    }
+
+    private static async Task<Document> ReplaceWithStringEquals(Document document, IsPatternExpressionSyntax isPatternExpression, ExpressionSyntax constantExpression, OperandKind operandKind, string comparisonMode, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         var generator = editor.Generator;
+        var compilation = editor.SemanticModel.Compilation;
 
-        var stringComparisonType = editor.SemanticModel.Compilation.GetBestTypeByMetadataName("System.StringComparison");
-        if (stringComparisonType is null)
-            return document;
+        var stringComparisonType = compilation.GetBestTypeByMetadataName("System.StringComparison")!;
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
 
-        var newExpression = generator.InvocationExpression(
-            generator.TypeMemberAccessExpression(editor.SemanticModel.Compilation.GetSpecialType(SpecialType.System_String), nameof(string.Equals)),
-            isPatternExpression.Expression,
-            constantExpression,
-            generator.TypeMemberAccessExpression(stringComparisonType, comparisonMode, addImport: true));
+        var newExpression = operandKind switch
+        {
+            OperandKind.Span => generator.InvocationExpression(
+                generator.TypeMemberAccessExpression(compilation.GetBestTypeByMetadataName("System.MemoryExtensions")!, nameof(MemoryExtensions.Equals), addImport: true),
+                isPatternExpression.Expression,
+                constantExpression,
+                generator.TypeMemberAccessExpression(stringComparisonType, comparisonMode, addImport: true)),
+
+            OperandKind.Object => generator.InvocationExpression(
+                generator.TypeMemberAccessExpression(stringType, nameof(string.Equals)),
+                generator.TryCastExpression(isPatternExpression.Expression, generator.TypeExpression(stringType)),
+                constantExpression,
+                generator.TypeMemberAccessExpression(stringComparisonType, comparisonMode, addImport: true)),
+
+            _ => generator.InvocationExpression(
+                generator.TypeMemberAccessExpression(stringType, nameof(string.Equals)),
+                isPatternExpression.Expression,
+                constantExpression,
+                generator.TypeMemberAccessExpression(stringComparisonType, comparisonMode, addImport: true)),
+        };
 
         editor.ReplaceNode(isPatternExpression, newExpression.WithAdditionalAnnotations(Formatter.Annotation));
         return editor.GetChangedDocument();
+    }
+
+    private enum OperandKind
+    {
+        None,
+        String,
+        Object,
+        Span,
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsInsteadOfIsPatternAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringEqualsInsteadOfIsPatternAnalyzerTests.cs
@@ -133,6 +133,188 @@ public sealed class UseStringEqualsInsteadOfIsPatternAnalyzerTests
     }
 
     [Fact]
+    public Task PatternMatching_Object_CodeFix_Ordinal()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public bool Test(object value) => value is {|MA0127:"hello"|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public bool Test(object value) => string.Equals(value as string, "hello", System.StringComparison.Ordinal);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PatternMatching_Object_CodeFix_OrdinalIgnoreCase()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public bool Test(object value) => value is {|MA0127:"hello"|};
+            }
+            """;
+        test.CodeActionIndex = 1;
+        test.FixedCode = """
+            class TypeName
+            {
+                public bool Test(object value) => string.Equals(value as string, "hello", System.StringComparison.OrdinalIgnoreCase);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PatternMatching_ObjectExpression_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public bool Test(object a, object b) => (a ?? b) is {|MA0127:"hello"|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public bool Test(object a, object b) => string.Equals((a ?? b) as string, "hello", System.StringComparison.Ordinal);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PatternMatching_Dynamic_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public bool Test(dynamic value) => value is {|MA0127:"hello"|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public bool Test(dynamic value) => string.Equals(value as string, "hello", System.StringComparison.Ordinal);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PatternMatching_Interface_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public bool Test(System.IComparable value) => value is {|MA0127:"hello"|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public bool Test(System.IComparable value) => string.Equals(value as string, "hello", System.StringComparison.Ordinal);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PatternMatching_TypeParameter_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public bool Test<T>(T value) => value is {|MA0127:"hello"|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public bool Test<T>(T value) => string.Equals(value as string, "hello", System.StringComparison.Ordinal);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PatternMatching_ReadOnlySpan_CodeFix_Ordinal()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public bool Test(System.ReadOnlySpan<char> value) => value is {|MA0127:"hello"|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public bool Test(System.ReadOnlySpan<char> value) => System.MemoryExtensions.Equals(value, "hello", System.StringComparison.Ordinal);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PatternMatching_ReadOnlySpan_CodeFix_OrdinalIgnoreCase()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public bool Test(System.ReadOnlySpan<char> value) => value is {|MA0127:"hello"|};
+            }
+            """;
+        test.CodeActionIndex = 1;
+        test.FixedCode = """
+            class TypeName
+            {
+                public bool Test(System.ReadOnlySpan<char> value) => System.MemoryExtensions.Equals(value, "hello", System.StringComparison.OrdinalIgnoreCase);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PatternMatching_Span_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public bool Test(System.Span<char> value) => value is {|MA0127:"hello"|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public bool Test(System.Span<char> value) => System.MemoryExtensions.Equals(value, "hello", System.StringComparison.Ordinal);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task PatternMatching_Complex1()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

MA0127 reports constant string patterns without checking the type of the operand, but its fixer always rewrote them as `string.Equals(operand, "x", comparison)`. For operands that aren't strings, applying the fix broke code that compiled before:

```csharp
public static bool MatchObject(object value) => value is "hello";
public static bool MatchSpan(System.ReadOnlySpan<char> value) => value is "hello"; // C# 11+

// Fixed (before this PR): CS1503, cannot convert from 'object' / 'ReadOnlySpan<char>' to 'string?'
string.Equals(value, "hello", System.StringComparison.Ordinal);
```

## Change

The fixer now checks the operand type in `RegisterCodeFixesAsync`, before registering the fix, and uses a rewrite with the same behavior:

| Operand type | Fix result |
|---|---|
| `string` | `string.Equals(value, "hello", StringComparison.Ordinal)` (unchanged) |
| `object`, `dynamic`, interfaces, type parameters | `string.Equals(value as string, "hello", StringComparison.Ordinal)` |
| `Span<char>`, `ReadOnlySpan<char>` | `MemoryExtensions.Equals(value, "hello", StringComparison.Ordinal)` |

No fix is registered for any other operand type, or for spans when the `MemoryExtensions.Equals(ReadOnlySpan<char>, ReadOnlySpan<char>, StringComparison)` overload isn't available.

**Why the rewrites keep the same behavior:**
- **Object-like operands:** the pattern only matches a string. `value as string` is `null` for anything else, and `string.Equals(null, "hello", …)` returns `false`.
- **Span operands:** the pattern compares characters ordinally, which is what `MemoryExtensions.Equals(…, Ordinal)` does.

`docs/Rules/MA0127.md` now explains what the fix produces for each operand type, and its broken example (`_ str = is "foo"`) is fixed.

## Tests

- Added 9 code fix tests: `object` (Ordinal and OrdinalIgnoreCase), an `object` expression that needs parentheses (`(a ?? b) as string`), `dynamic`, an interface, a type parameter, `ReadOnlySpan<char>` (both comparisons) and `Span<char>`. The test harness compiles the fixed code, so these tests would fail with the old CS1503 error.
- All 19 MA0127 tests pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- `dotnet run --project src/DocumentationGenerator` reports no further changes.
- The full test suite was not run locally.
