### PR TITLE
Do not report MA0005 for arrays of pointers

### DIFF
--- a/docs/Rules/MA0005.md
+++ b/docs/Rules/MA0005.md
@@ -11,3 +11,5 @@ new int[0];
 // Should be
 Array.Empty<int>();
 ````
+
+The rule does not report arrays of pointers or function pointers (e.g. `new int*[0]`), as pointer types cannot be used as generic type arguments.

--- a/src/Meziantou.Analyzer/Rules/UseArrayEmptyAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseArrayEmptyAnalyzer.cs
@@ -42,6 +42,10 @@ public sealed class UseArrayEmptyAnalyzer : DiagnosticAnalyzer
         var operation = (IArrayCreationOperation)context.Operation;
         if (IsZeroLengthArrayCreation(operation, context.CancellationToken))
         {
+            // Pointer types cannot be used as generic type arguments (CS0306)
+            if (operation.Type is IArrayTypeSymbol { ElementType.TypeKind: TypeKind.Pointer or TypeKind.FunctionPointer })
+                return;
+
             // Cannot use Array.Empty<T>() as an attribute parameter
             if (IsInAttribute(operation))
                 return;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseArrayEmptyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseArrayEmptyAnalyzerTests.cs
@@ -55,6 +55,52 @@ public sealed class UseArrayEmptyAnalyzerTests
         return test.RunAsync();
     }
 
+    [Theory]
+    [InlineData("new int*[0]")]
+    [InlineData("new int*[] { }")]
+    [InlineData("new delegate*<void>[0]")]
+    public Task EmptyPointerArray_ShouldNotReportError(string code)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            unsafe class TestClass
+            {
+                void Test()
+                {
+                    var a = {{code}};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task EmptyArrayOfPointerArrays_ShouldReportError()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            unsafe class TestClass
+            {
+                void Test()
+                {
+                    var a = {|MA0005:new int*[0][]|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            unsafe class TestClass
+            {
+                void Test()
+                {
+                    var a = System.Array.Empty<int*[]>();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Fact]
     public Task Length_FlowedFromLocal_ShouldReportError()
     {


### PR DESCRIPTION
## Problem

MA0005 reported zero-length arrays of pointers, and its code fix produced code that does not compile:

```csharp
public unsafe class Sample
{
    public static int*[] Run() => new int*[0];
}
```

became

```csharp
public static int*[] Run() => System.Array.Empty<int*>(); // CS0306
```

Pointer and function pointer types cannot be used as generic type arguments.

## Change

- `UseArrayEmptyAnalyzer` no longer reports when the array's element type is a pointer or a function pointer. The code fix only runs on this diagnostic, so it is no longer offered either.
- Arrays whose element type is itself an array of pointers (`new int*[0][]`) are still reported, since `Array.Empty<int*[]>()` is valid.
- `docs/Rules/MA0005.md` documents the exclusion.

## Tests

- `EmptyPointerArray_ShouldNotReportError`: `new int*[0]`, `new int*[] { }`, `new delegate*<void>[0]`
- `EmptyArrayOfPointerArrays_ShouldReportError`: `new int*[0][]` is still fixed to `System.Array.Empty<int*[]>()`

All 12 `UseArrayEmptyAnalyzerTests` pass on Roslyn 5.9 and 4.8. With the analyzer change reverted, the three pointer cases fail. I ran only these tests locally; CI runs the other Roslyn versions.
