### PR TITLE
Fix MA0171 code fix omitting parentheses around the generated pattern

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingInsteadOfHasvalueFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingInsteadOfHasvalueFixer.cs
@@ -83,7 +83,7 @@ public sealed class UsePatternMatchingInsteadOfHasvalueFixer : CodeFixProvider
         return (operation.Syntax, false);
     }
 
-    private static IsPatternExpressionSyntax MakeIsNotNull(ExpressionSyntax instance, bool negate)
+    private static ExpressionSyntax MakeIsNotNull(ExpressionSyntax instance, bool negate)
     {
         PatternSyntax constantExpression = ConstantPattern(LiteralExpression(SyntaxKind.NullLiteralExpression));
         if (!negate)
@@ -91,6 +91,6 @@ public sealed class UsePatternMatchingInsteadOfHasvalueFixer : CodeFixProvider
             constantExpression = UnaryPattern(constantExpression);
         }
 
-        return IsPatternExpression(instance.Parenthesize(), constantExpression);
+        return IsPatternExpression(instance.Parenthesize(), constantExpression).Parenthesize();
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerHasValueTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerHasValueTests.cs
@@ -125,4 +125,52 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerHasValueTest
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task HasValue_MemberAccessReceiver()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            var value = default(int?);
+            _ = {|MA0171:value.HasValue|}.ToString();
+            """;
+        test.FixedCode = """
+            var value = default(int?);
+            _ = (value is not null).ToString();
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task HasValueEqualsFalse_MemberAccessReceiver()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            var value = default(int?);
+            _ = ({|MA0171:value.HasValue|} == false).ToString();
+            """;
+        test.FixedCode = """
+            var value = default(int?);
+            _ = (value is null).ToString();
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task HasValue_Cast()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            var value = default(int?);
+            _ = (object){|MA0171:value.HasValue|};
+            """;
+        test.FixedCode = """
+            var value = default(int?);
+            _ = (object)(value is not null);
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## Problem

The MA0171 code fix parenthesized only the operand of the generated `is` pattern, not the pattern itself. When the replaced expression sits in a position that needs grouping, the emitted source is wrong:

| Original | Before this PR | After this PR |
|---|---|---|
| `value.HasValue.ToString()` | `value is not null.ToString()` (CS0023) | `(value is not null).ToString()` |
| `(object)value.HasValue` | `(object)value is not null` (compiles, different meaning) | `(object)(value is not null)` |

The in-memory syntax tree produced by the fix still has the intended nesting, so the broken result only shows up once the fixed text is reparsed (for example, on the next build).

## Fix

`MakeIsNotNull` now calls `Parenthesize()` on the whole `IsPatternExpression`. The parentheses carry the simplifier annotation, so they are removed wherever they are not needed, and the output of the existing cases (`_ = value is not null;`, `_ = value is null;`) is unchanged.

## Tests

New tests in `UsePatternMatchingForEqualityComparisonsAnalyzerHasValueTests`:

- `HasValue_MemberAccessReceiver`: `value.HasValue.ToString()`.
- `HasValue_Cast`: `(object)value.HasValue`.
- `HasValueEqualsFalse_MemberAccessReceiver`: parentheses already in the source are not doubled.

The first two fail against the previous fixer. The harness compares the fixed document text, so a missing parenthesis fails the test.

The test class passes (10/10) on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9. `dotnet run --project src/DocumentationGenerator` produced no changes. The full test suite was not run locally.
