### PR TITLE
Do not offer the MA0044 code fix when removing ToString would drop argument side effects

### DIFF
--- a/docs/Rules/MA0044.md
+++ b/docs/Rules/MA0044.md
@@ -14,3 +14,5 @@ Console.Write(str.ToString()); // non compliant
 var str = "abc";
 Console.Write(str); // compliant
 ````
+
+The code fix is not offered when the call has an argument whose evaluation may have side effects, such as `str.ToString(GetFormatProvider())`, as removing the call would also remove the evaluation of the argument.

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUselessToStringFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUselessToStringFixer.cs
@@ -14,26 +14,51 @@ public sealed class RemoveUselessToStringFixer : CodeFixProvider
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        if (nodeToFix is not InvocationExpressionSyntax syntax)
+        if (nodeToFix is not InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax memberAccess } syntax)
             return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel?.GetOperation(syntax, context.CancellationToken) is not IInvocationOperation operation)
+            return;
+
+        // The arguments are evaluated even though string.ToString ignores them, so they can only be removed
+        // along with the call when evaluating them has no observable effect
+        var cultureInfoType = semanticModel.Compilation.GetBestTypeByMetadataName("System.Globalization.CultureInfo");
+        foreach (var argument in operation.Arguments)
+        {
+            if (!CanBeDiscarded(argument.Value, cultureInfoType))
+                return;
+        }
 
         context.RegisterCodeFix(
             CodeAction.Create(
                 "Remove ToString",
-                ct => Remove(context.Document, syntax, ct),
+                ct => Remove(context.Document, syntax, memberAccess, ct),
                 equivalenceKey: "Remove ToString"),
             context.Diagnostics);
     }
 
-    private static async Task<Document> Remove(Document document, InvocationExpressionSyntax expression, CancellationToken cancellationToken)
+    /// <summary>
+    /// Indicates whether removing the expression from the code is safe, i.e. evaluating it has no observable side effect.
+    /// </summary>
+    private static bool CanBeDiscarded(IOperation operation, INamedTypeSymbol? cultureInfoType)
+    {
+        return operation switch
+        {
+            IConversionOperation { IsImplicit: true, OperatorMethod: null } conversion => CanBeDiscarded(conversion.Operand, cultureInfoType),
+            IParenthesizedOperation parenthesized => CanBeDiscarded(parenthesized.Operand, cultureInfoType),
+            ILiteralOperation or IInstanceReferenceOperation or ILocalReferenceOperation or IParameterReferenceOperation => true,
+            IFieldReferenceOperation fieldReference => fieldReference.Field.IsStatic || fieldReference.Instance is IInstanceReferenceOperation,
+            // The static properties of CultureInfo, such as InvariantCulture, have no observable side effect
+            IPropertyReferenceOperation { Instance: null } propertyReference => propertyReference.Property.ContainingType.IsEqualTo(cultureInfoType),
+            _ => operation.ConstantValue.HasValue,
+        };
+    }
+
+    private static async Task<Document> Remove(Document document, InvocationExpressionSyntax expression, MemberAccessExpressionSyntax memberAccess, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-
-        if (expression.Expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax)
-        {
-            editor.ReplaceNode(expression, memberAccessExpressionSyntax.Expression);
-        }
-
+        editor.ReplaceNode(expression, memberAccess.Expression);
         return editor.GetChangedDocument();
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUselessToStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUselessToStringAnalyzerTests.cs
@@ -41,4 +41,117 @@ public sealed class RemoveUselessToStringAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task StringToStringWithSideEffectingProvider_ShouldNotOfferFix()
+    {
+        const string SourceCode = """
+            class Test
+            {
+                static int calls;
+                static System.IFormatProvider Provider() { calls++; return null; }
+
+                public string A() => {|MA0044:"".ToString(Provider())|};
+            }
+            """;
+        var test = CreateTest();
+        test.TestCode = SourceCode;
+        test.FixedCode = SourceCode;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringToStringWithPropertyProvider_ShouldNotOfferFix()
+    {
+        const string SourceCode = """
+            class Test
+            {
+                static System.IFormatProvider Provider => null;
+
+                public string A() => {|MA0044:"".ToString(Provider)|};
+            }
+            """;
+        var test = CreateTest();
+        test.TestCode = SourceCode;
+        test.FixedCode = SourceCode;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringToStringWithInvariantCulture_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                public string A() => {|MA0044:"".ToString(System.Globalization.CultureInfo.InvariantCulture)|};
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                public string A() => "";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringToStringWithNullProvider_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                public string A() => {|MA0044:"".ToString(null)|};
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                public string A() => "";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringToStringWithParameterProvider_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                public string A(System.IFormatProvider provider) => {|MA0044:"".ToString(provider)|};
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                public string A(System.IFormatProvider provider) => "";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringToStringConditionalAccess_ShouldNotOfferFix()
+    {
+        const string SourceCode = """
+            class Test
+            {
+                public string A(string value) => value?{|MA0044:.ToString()|};
+            }
+            """;
+        var test = CreateTest();
+        test.TestCode = SourceCode;
+        test.FixedCode = SourceCode;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## Problem

MA0044 reports any `ToString` call on `System.String`, including `ToString(IFormatProvider)`. The provider is ignored by that overload, but C# still evaluates the argument. The fixer replaced the whole invocation with its receiver, so side effects of the argument were silently removed:

```csharp
_ = "text".ToString(Provider()); // Provider() is called
// after the fix
_ = "text";                      // Provider() is no longer called
```

## Changes

- `RemoveUselessToStringFixer` now only registers the fix when every argument can be discarded without observable effect: constants and literals, locals, parameters, `this`, static fields or fields of `this`, and static `CultureInfo` properties (so `str.ToString(CultureInfo.InvariantCulture)` is still fixed). Implicit conversions are looked through unless they call a user-defined operator.
- The member-access check is moved from the fix action to the registration, per the repository guidance. As a result the fix is no longer offered for `value?.ToString()`, where it previously returned the document unchanged.
- The analyzer is unchanged: the call is still useless, so the diagnostic is still reported.
- `docs/Rules/MA0044.md` documents when the fix is not offered.

## Tests

Added to `RemoveUselessToStringAnalyzerTests`:
- no fix for a side-effecting provider call, a property provider, and `?.ToString()` (these three fail against the previous fixer)
- fix applied for `CultureInfo.InvariantCulture`, `null`, and a parameter

The test class passes (8/8) on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9. The full suite was not run locally.

## Known gaps (not addressed here)

- The fix still removes the call when the receiver may be null (`s.ToString()` throws a `NullReferenceException`, `s` does not).
- Reading a static field may run a static constructor.
