### PR TITLE
Import System.Threading.Tasks in MA0152 code fix

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseTaskUnwrapFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseTaskUnwrapFixer.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Meziantou.Analyzer.Rules;
@@ -28,13 +29,18 @@ public sealed class UseTaskUnwrapFixer : CodeFixProvider
         if (awaitOp.Syntax is not AwaitExpressionSyntax)
             return;
 
+        // Unwrap is an extension method, so its namespace must be imported for the new invocation to compile
+        var taskExtensionsSymbol = semanticModel.Compilation.GetBestTypeByMetadataName("System.Threading.Tasks.TaskExtensions");
+        if (taskExtensionsSymbol is null)
+            return;
+
         const string Title = "Use Unwrap";
         context.RegisterCodeFix(
-            CodeAction.Create(Title, ct => UseUnwrap(context.Document, nodeToFix, ct), equivalenceKey: Title),
+            CodeAction.Create(Title, ct => UseUnwrap(context.Document, nodeToFix, taskExtensionsSymbol, ct), equivalenceKey: Title),
             context.Diagnostics);
     }
 
-    private static async Task<Document> UseUnwrap(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static async Task<Document> UseUnwrap(Document document, SyntaxNode nodeToFix, INamedTypeSymbol taskExtensionsSymbol, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         if (FindAwait(editor.SemanticModel, nodeToFix, cancellationToken) is not { } awaitOperation)
@@ -45,11 +51,7 @@ public sealed class UseTaskUnwrapFixer : CodeFixProvider
 
         if (awaitOperation.Operation is IAwaitOperation innerAwait)
         {
-            var unwrappedExpression = InvocationExpression(
-                MemberAccessExpression(
-                    Microsoft.CodeAnalysis.CSharp.SyntaxKind.SimpleMemberAccessExpression,
-                    (ExpressionSyntax)innerAwait.Operation.Syntax.WithoutTrivia().Parenthesize(),
-                    IdentifierName("Unwrap")));
+            var unwrappedExpression = CreateUnwrapInvocation(editor.Generator, innerAwait.Operation.Syntax, taskExtensionsSymbol);
 
             var newNode = awaitExpression.WithExpression(unwrappedExpression.WithTriviaFrom(awaitExpression.Expression));
             editor.ReplaceNode(awaitExpression, newNode.WithAdditionalAnnotations(Formatter.Annotation));
@@ -60,11 +62,7 @@ public sealed class UseTaskUnwrapFixer : CodeFixProvider
             awaitExpression.Expression is InvocationExpressionSyntax invocation &&
             invocation.Expression is MemberAccessExpressionSyntax memberAccess)
         {
-            var unwrappedExpression = InvocationExpression(
-                MemberAccessExpression(
-                    Microsoft.CodeAnalysis.CSharp.SyntaxKind.SimpleMemberAccessExpression,
-                    (ExpressionSyntax)innerAwaitOperation.Operation.Syntax.WithoutTrivia().Parenthesize(),
-                    IdentifierName("Unwrap")));
+            var unwrappedExpression = CreateUnwrapInvocation(editor.Generator, innerAwaitOperation.Operation.Syntax, taskExtensionsSymbol);
 
             var newExpression = invocation.WithExpression(memberAccess.WithExpression(unwrappedExpression.WithTriviaFrom(memberAccess.Expression)));
             editor.ReplaceNode(awaitExpression, awaitExpression.WithExpression(newExpression).WithAdditionalAnnotations(Formatter.Annotation));
@@ -72,6 +70,21 @@ public sealed class UseTaskUnwrapFixer : CodeFixProvider
         }
 
         return document;
+    }
+
+    private static InvocationExpressionSyntax CreateUnwrapInvocation(SyntaxGenerator generator, SyntaxNode task, INamedTypeSymbol taskExtensionsSymbol)
+    {
+        // The type expression is annotated with the symbol of TaskExtensions. Copying its annotations lets the code action
+        // add the using directive of the extension method when it is not in scope.
+        var unwrapName = generator.TypeExpression(taskExtensionsSymbol, addImport: true)
+            .WithAdditionalAnnotations(Simplifier.AddImportsAnnotation)
+            .CopyAnnotationsTo(IdentifierName("Unwrap"));
+
+        return InvocationExpression(
+            MemberAccessExpression(
+                Microsoft.CodeAnalysis.CSharp.SyntaxKind.SimpleMemberAccessExpression,
+                (ExpressionSyntax)task.WithoutTrivia().Parenthesize(),
+                unwrapName));
     }
 
     private static IAwaitOperation? FindAwait(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTaskUnwrapAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTaskUnwrapAnalyzerTests.cs
@@ -36,6 +36,77 @@ public sealed class UseTaskUnwrapAnalyzerTests
     }
 
     [Fact]
+    public Task TaskOfTask_WithoutUsingDirective()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            System.Threading.Tasks.Task<System.Threading.Tasks.Task> a = null;
+            {|MA0152:await await a|};
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+
+            System.Threading.Tasks.Task<System.Threading.Tasks.Task> a = null;
+            await a.Unwrap();
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TaskOfTask_WithoutUsingDirective_InNamespace()
+    {
+        var test = new CodeFixTest
+        {
+            TestCode = """
+                namespace Sample;
+
+                public class Test
+                {
+                    public static async System.Threading.Tasks.Task Run(System.Threading.Tasks.Task<System.Threading.Tasks.Task> a)
+                    {
+                        {|MA0152:await await a|};
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Threading.Tasks;
+
+                namespace Sample;
+
+                public class Test
+                {
+                    public static async System.Threading.Tasks.Task Run(System.Threading.Tasks.Task<System.Threading.Tasks.Task> a)
+                    {
+                        await a.Unwrap();
+                    }
+                }
+                """,
+        };
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TaskOfTask_GlobalUsingDirective()
+    {
+        const string GlobalUsings = "global using System.Threading.Tasks;";
+        var test = CreateTest();
+        test.TestState.Sources.Add(("/0/Test0.cs", """
+            Task<Task> a = null;
+            {|MA0152:await await a|};
+            """));
+        test.TestState.Sources.Add(("/0/GlobalUsings.cs", GlobalUsings));
+        test.FixedState.Sources.Add(("/0/Test0.cs", """
+            Task<Task> a = null;
+            await a.Unwrap();
+            """));
+        test.FixedState.Sources.Add(("/0/GlobalUsings.cs", GlobalUsings));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task TaskOfTask_ConfigureAwait()
     {
         var test = CreateTest();
@@ -63,6 +134,24 @@ public sealed class UseTaskUnwrapAnalyzerTests
             using System.Threading.Tasks;
 
             Task<Task> a = null;
+            await a.Unwrap().ConfigureAwait(false);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TaskOfTask_ConfigureAwait_Root_WithoutUsingDirective()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            System.Threading.Tasks.Task<System.Threading.Tasks.Task> a = null;
+            {|MA0152:await (await a).ConfigureAwait(false)|};
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+
+            System.Threading.Tasks.Task<System.Threading.Tasks.Task> a = null;
             await a.Unwrap().ConfigureAwait(false);
             """;
 


### PR DESCRIPTION
## Summary

The MA0152 code fix replaces `await await task` with `await task.Unwrap()`. `Unwrap` is an extension method of `System.Threading.Tasks.TaskExtensions`, and the fixer did not import its namespace. When `System.Threading.Tasks` was not in scope (for example, code using fully qualified task types), the fixed code failed with CS1061.

```csharp
// Before the fix: compiles without any using directive
System.Threading.Tasks.Task<System.Threading.Tasks.Task> a = null;
await await a;

// After the code fix: CS1061, Unwrap is not in scope
await a.Unwrap();
```

## Changes

- Both branches of the fixer (`await await task` and `await (await task).ConfigureAwait(...)`) now build the invocation with a shared `CreateUnwrapInvocation` helper.
- The `Unwrap` name gets the annotations of `SyntaxGenerator.TypeExpression(TaskExtensions, addImport: true)`, so the code action adds `using System.Threading.Tasks;` when the namespace is not already imported (local or global using). `SymbolAnnotation` is internal to Roslyn, so the annotations are copied from the generated type expression.
- The fix is only registered when `System.Threading.Tasks.TaskExtensions` exists in the compilation.

The generated code stays `task.Unwrap()` rather than `TaskExtensions.Unwrap(task)`.

## Tests

New cases in `UseTaskUnwrapAnalyzerTests`:
- `TaskOfTask_WithoutUsingDirective`
- `TaskOfTask_WithoutUsingDirective_InNamespace` (file-scoped namespace)
- `TaskOfTask_ConfigureAwait_Root_WithoutUsingDirective`
- `TaskOfTask_GlobalUsingDirective` (no redundant using when a global using is declared in another file)

The three `WithoutUsingDirective` tests fail on the previous fixer. `UseTaskUnwrapAnalyzerTests` passes 11/11 on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9. The full suite was not run locally. The documentation generator produced no changes.
