### PR TITLE
Remove every dollar of raw strings in MA0184 code fix

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseInterpolatedStringWithoutParametersFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseInterpolatedStringWithoutParametersFixer.cs
@@ -17,58 +17,62 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersFixer : CodeFixPr
         if (nodeToFix is not InterpolatedStringExpressionSyntax interpolatedString)
             return;
 
+        var regularString = CreateRegularString(interpolatedString);
+        if (regularString is null)
+            return;
+
         context.RegisterCodeFix(
             CodeAction.Create(
                 "Convert to regular string",
-                ct => ConvertToRegularString(context.Document, interpolatedString, ct),
+                ct => ConvertToRegularString(context.Document, interpolatedString, regularString, ct),
                 equivalenceKey: "Convert to regular string"),
             context.Diagnostics);
     }
 
-    private static async Task<Document> ConvertToRegularString(Document document, InterpolatedStringExpressionSyntax interpolatedString, CancellationToken cancellationToken)
+    private static ExpressionSyntax? CreateRegularString(InterpolatedStringExpressionSyntax interpolatedString)
     {
-        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-
         // Check if this is a raw string literal (C# 11+)
         var isRawString = interpolatedString.StringStartToken.IsKind(SyntaxKind.InterpolatedMultiLineRawStringStartToken) ||
                           interpolatedString.StringStartToken.IsKind(SyntaxKind.InterpolatedSingleLineRawStringStartToken);
         if (isRawString)
         {
-            // For raw strings, simply remove the $ prefix from the start token
-            // $""" text """ -> """ text """
-            var originalText = interpolatedString.ToFullString();
+            // For raw strings, remove the whole $ prefix from the start token, as the number of $ determines
+            // the number of braces that start an interpolation: $$"""{text}""" -> """{text}"""
+            var startTokenText = interpolatedString.StringStartToken.Text;
+            var dollarCount = startTokenText.Length - startTokenText.TrimStart('$').Length;
+            if (dollarCount is 0)
+                return null;
 
-            // Find the position of $ in the start token and remove it
-            var dollarIndex = originalText.IndexOf('$', StringComparison.Ordinal);
-            if (dollarIndex >= 0)
-            {
-                var newText = originalText.Remove(dollarIndex, 1);
-                var newNode = SyntaxFactory.ParseExpression(newText);
+            // The text of the node starts with the start token and does not include the trivia
+            var newText = interpolatedString.ToString().Substring(dollarCount);
+            var newNode = SyntaxFactory.ParseExpression(newText, options: interpolatedString.SyntaxTree.Options);
+            if (!newNode.IsKind(SyntaxKind.StringLiteralExpression) || newNode.ContainsDiagnostics)
+                return null;
 
-                editor.ReplaceNode(interpolatedString, newNode.WithTriviaFrom(interpolatedString));
-            }
+            return newNode;
         }
-        else
+
+        // Extract the string content from the interpolated string
+        var stringContent = string.Empty;
+        foreach (var content in interpolatedString.Contents)
         {
-            // Extract the string content from the interpolated string
-            var stringContent = string.Empty;
-            foreach (var content in interpolatedString.Contents)
+            if (content is InterpolatedStringTextSyntax textSyntax)
             {
-                if (content is InterpolatedStringTextSyntax textSyntax)
-                {
-                    // Use the ValueText which contains the actual string value (not escaped)
-                    stringContent += textSyntax.TextToken.ValueText;
-                }
+                // Use the ValueText which contains the actual string value (not escaped)
+                stringContent += textSyntax.TextToken.ValueText;
             }
-
-            // Create a regular string literal with the same content
-            var regularString = SyntaxFactory.LiteralExpression(
-                SyntaxKind.StringLiteralExpression,
-                SyntaxFactory.Literal(stringContent));
-
-            editor.ReplaceNode(interpolatedString, regularString.WithTriviaFrom(interpolatedString));
         }
 
+        // Create a regular string literal with the same content
+        return SyntaxFactory.LiteralExpression(
+            SyntaxKind.StringLiteralExpression,
+            SyntaxFactory.Literal(stringContent));
+    }
+
+    private static async Task<Document> ConvertToRegularString(Document document, InterpolatedStringExpressionSyntax interpolatedString, ExpressionSyntax regularString, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        editor.ReplaceNode(interpolatedString, regularString.WithTriviaFrom(interpolatedString));
         return editor.GetChangedDocument();
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.DoNotUseInterpolatedStringWithoutParametersAnalyzer,
     Meziantou.Analyzer.Rules.DoNotUseInterpolatedStringWithoutParametersFixer>;
@@ -300,6 +301,91 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersAnalyzerTests
                     _ = """
                         Sample
                         """;
+                }
+            }
+            """";
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RawInterpolatedStringWithMultipleDollarsAndBraces_ShouldRemoveAllDollars()
+    {
+        var test = CreateTest();
+        test.MarkupOptions = MarkupOptions.TreatPositionIndicatorsAsCode;
+        test.TestCode = """"
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = {|MA0184:$$"""{unknown}"""|};
+                }
+            }
+            """";
+        test.FixedCode = """"
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = """{unknown}""";
+                }
+            }
+            """";
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MultiLineRawInterpolatedStringWithThreeDollarsAndBraces_ShouldRemoveAllDollars()
+    {
+        var test = CreateTest();
+        test.MarkupOptions = MarkupOptions.TreatPositionIndicatorsAsCode;
+        test.TestCode = """"
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = {|MA0184:$$$"""
+                        {{unknown}}
+                        """|};
+                }
+            }
+            """";
+        test.FixedCode = """"
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = """
+                        {{unknown}}
+                        """;
+                }
+            }
+            """";
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RawInterpolatedStringWithDollarInLeadingTrivia_ShouldPreserveTrivia()
+    {
+        var test = CreateTest();
+        test.MarkupOptions = MarkupOptions.TreatPositionIndicatorsAsCode;
+        test.TestCode = """"
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = /* $ */ {|MA0184:$$"""{unknown}"""|};
+                }
+            }
+            """";
+        test.FixedCode = """"
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = /* $ */ """{unknown}""";
                 }
             }
             """";


### PR DESCRIPTION
The MA0184 code fix removed a single `$` from raw interpolated strings. The number of `$` determines how many braces start an interpolation, so removing only one can turn literal braces into an interpolation:

```csharp
// Before the fix
public static object Run() => $$"""{unknown}""";
// Result of the code fix: error CS0103, `unknown` is now an interpolation
public static object Run() => $"""{unknown}""";
```

## Changes

- Remove the whole `$` prefix of the start token, so `$$"""{unknown}"""` becomes `"""{unknown}"""`.
- Use the node text without trivia (`ToString()` instead of `ToFullString()`), so a `$` in a leading comment is no longer the one removed (`/* $ */ $$"""..."""`).
- Build the replacement before registering the code fix, and only register it when the result parses as a string literal without diagnostics, using the parse options of the document. Previously the fix could be offered and leave the document unchanged.
- The regular (non-raw) interpolated string path is unchanged.

## Tests

New tests cover a single-line `$$` string with `{...}`, a multi-line `$$$` string with `{{...}}`, and a `$` in leading trivia. They use `MarkupOptions.TreatPositionIndicatorsAsCode`, as the testing library otherwise reads `$$` as a position marker.

- `DoNotUseInterpolatedStringWithoutParametersAnalyzerTests`: 16/16 pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- The 3 new tests fail against the previous fixer.
- `dotnet run --project src/DocumentationGenerator` produces no changes.
