### PR TITLE
Fix MA0184 code fix keeping doubled braces as literal text

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseInterpolatedStringWithoutParametersFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotUseInterpolatedStringWithoutParametersFixer.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
@@ -17,22 +19,22 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersFixer : CodeFixPr
         if (nodeToFix is not InterpolatedStringExpressionSyntax interpolatedString)
             return;
 
+        var regularString = await CreateRegularStringAsync(context.Document, interpolatedString, context.CancellationToken).ConfigureAwait(false);
+        if (regularString is null)
+            return;
+
         context.RegisterCodeFix(
             CodeAction.Create(
                 "Convert to regular string",
-                ct => ConvertToRegularString(context.Document, interpolatedString, ct),
+                ct => ConvertToRegularString(context.Document, interpolatedString, regularString, ct),
                 equivalenceKey: "Convert to regular string"),
             context.Diagnostics);
     }
 
-    private static async Task<Document> ConvertToRegularString(Document document, InterpolatedStringExpressionSyntax interpolatedString, CancellationToken cancellationToken)
+    private static async Task<ExpressionSyntax?> CreateRegularStringAsync(Document document, InterpolatedStringExpressionSyntax interpolatedString, CancellationToken cancellationToken)
     {
-        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-
         // Check if this is a raw string literal (C# 11+)
-        var isRawString = interpolatedString.StringStartToken.IsKind(SyntaxKind.InterpolatedMultiLineRawStringStartToken) ||
-                          interpolatedString.StringStartToken.IsKind(SyntaxKind.InterpolatedSingleLineRawStringStartToken);
-        if (isRawString)
+        if (interpolatedString.StringStartToken.Kind() is SyntaxKind.InterpolatedMultiLineRawStringStartToken or SyntaxKind.InterpolatedSingleLineRawStringStartToken)
         {
             // For raw strings, simply remove the $ prefix from the start token
             // $""" text """ -> """ text """
@@ -40,35 +42,36 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersFixer : CodeFixPr
 
             // Find the position of $ in the start token and remove it
             var dollarIndex = originalText.IndexOf('$', StringComparison.Ordinal);
-            if (dollarIndex >= 0)
-            {
-                var newText = originalText.Remove(dollarIndex, 1);
-                var newNode = SyntaxFactory.ParseExpression(newText);
+            if (dollarIndex < 0)
+                return null;
 
-                editor.ReplaceNode(interpolatedString, newNode.WithTriviaFrom(interpolatedString));
-            }
+            return SyntaxFactory.ParseExpression(originalText.Remove(dollarIndex, 1));
         }
-        else
+
+        // The text of the tokens still contains the escaped braces ("{{" and "}}"),
+        // so use the value computed by the compiler
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel?.GetOperation(interpolatedString, cancellationToken) is not IInterpolatedStringOperation operation)
+            return null;
+
+        var stringContent = new StringBuilder();
+        foreach (var part in operation.Parts)
         {
-            // Extract the string content from the interpolated string
-            var stringContent = string.Empty;
-            foreach (var content in interpolatedString.Contents)
-            {
-                if (content is InterpolatedStringTextSyntax textSyntax)
-                {
-                    // Use the ValueText which contains the actual string value (not escaped)
-                    stringContent += textSyntax.TextToken.ValueText;
-                }
-            }
+            if (part is not IInterpolatedStringTextOperation { Text.ConstantValue: { HasValue: true, Value: string text } })
+                return null;
 
-            // Create a regular string literal with the same content
-            var regularString = SyntaxFactory.LiteralExpression(
-                SyntaxKind.StringLiteralExpression,
-                SyntaxFactory.Literal(stringContent));
-
-            editor.ReplaceNode(interpolatedString, regularString.WithTriviaFrom(interpolatedString));
+            stringContent.Append(text);
         }
 
+        return SyntaxFactory.LiteralExpression(
+            SyntaxKind.StringLiteralExpression,
+            SyntaxFactory.Literal(stringContent.ToString()));
+    }
+
+    private static async Task<Document> ConvertToRegularString(Document document, InterpolatedStringExpressionSyntax interpolatedString, ExpressionSyntax regularString, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        editor.ReplaceNode(interpolatedString, regularString.WithTriviaFrom(interpolatedString));
         return editor.GetChangedDocument();
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
@@ -278,6 +278,66 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersAnalyzerTests
     }
 
     [Fact]
+    public Task CodeFix_ShouldUnescapeBraces()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public string Test() => {|MA0184:$"{{text}}"|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public string Test() => "{text}";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task CodeFix_Verbatim_ShouldUnescapeBracesAndQuotes()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public string Test() => {|MA0184:$@"{{""text"": ""\""}}"|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public string Test() => "{\"text\": \"\\\"}";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task CodeFix_EmptyString()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public string Test() => {|MA0184:$""|};
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public string Test() => "";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task RawInterpolatedStringWithoutParameters_ShouldReportDiagnostic()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

The MA0184 code fix ("Convert to regular string") copied `InterpolatedStringTextSyntax.TextToken.ValueText` into a regular string literal. For non-raw interpolated strings, that text still contains the brace escapes (`{{` and `}}`), which a regular string literal does not interpret, so the fix changed the value of the string:

```csharp
public static object Run() => $"{{text}}"; // returns {text}
// after the fix
public static object Run() => "{{text}}";  // returns {{text}}
```

Both versions compile, so JSON fragments and other brace-containing text were silently corrupted.

## Fix

For non-raw interpolated strings, the fixer now builds the literal from the value computed by the compiler: the constant values of the `IInterpolatedStringTextOperation` parts, which have the braces unescaped. The replacement is computed in `RegisterCodeFixesAsync`, and the fix is not registered when the value cannot be obtained. The raw string path is unchanged.

## Tests

Added to `DoNotUseInterpolatedStringWithoutParametersAnalyzerTests`:
- `$"{{text}}"` → `"{text}"`
- `$@"{{""text"": ""\""}}"` → `"{\"text\": \"\\\"}"` (verbatim string with escaped braces, quotes, and a backslash)
- `$""` → `""`

The two brace tests fail with the previous fixer. The test class passes (16/16) on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9. `dotnet run --project src/DocumentationGenerator` produces no changes.

## Notes for reviewers

- Not addressed here: the raw string path removes only the first `$`, so `$$"""{text}"""` becomes `$"""{text}"""`, which turns `{text}` into an interpolation. Testing it is awkward because the testing library's markup parser treats `$$` as the caret position marker, so I left it for a separate change.
- Verbatim interpolated strings are still converted to regular (escaped) literals rather than verbatim ones, as before.
