### PR TITLE
Do not merge MA0148/MA0149 comparisons when the operand can change between evaluations

### DIFF
--- a/docs/Rules/MA0148.md
+++ b/docs/Rules/MA0148.md
@@ -13,6 +13,12 @@ value == 0 || value == 1; // not compliant
 value is 0 or 1; // ok
 ````
 
+The code fix only merges the comparisons into a single pattern when the value is a local, a parameter, or a non-volatile field, as merging them evaluates the value only once. Other values, such as method calls or properties, are converted to separate patterns:
+
+````c#
+Next() == 0 || Next() == 1; // fixed as "Next() is 0 || Next() is 1"
+````
+
 Cases that rely on implicit user-defined conversions are ignored because replacing `==` with `is` would be invalid:
 
 ````c#

--- a/docs/Rules/MA0149.md
+++ b/docs/Rules/MA0149.md
@@ -13,6 +13,12 @@ value != 0 && value != 1; // not compliant
 value is not (0 or 1); // ok
 ````
 
+The code fix only merges the comparisons into a single pattern when the value is a local, a parameter, or a non-volatile field, as merging them evaluates the value only once. Other values, such as method calls or properties, are converted to separate patterns:
+
+````c#
+Next() != 0 && Next() != 1; // fixed as "Next() is not 0 && Next() is not 1"
+````
+
 Cases that rely on implicit user-defined conversions are ignored because replacing `!=` with `is not` would be invalid:
 
 ````c#

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
@@ -121,7 +121,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
         {
             if (TryCreateDiscreteComparisonCandidate(term, expectedComparisonOperatorKind, semanticModel, cancellationToken, out var candidate))
             {
-                if (mergeCandidates.Count > 0 && !SyntaxFactory.AreEquivalent(mergeCandidates[0].Expression, candidate.Expression))
+                if (mergeCandidates.Count > 0 && !CanMerge(mergeCandidates[0], candidate))
                 {
                     updatedTerms.Add(CreatePatternExpressionFromCandidates(mergeCandidates, expectedComparisonOperatorKind));
                     mergeCandidates.Clear();
@@ -216,8 +216,38 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
         if (expressionOperation.Syntax is not ExpressionSyntax valueExpression || constantOperation.Syntax is not ExpressionSyntax constantExpression)
             return false;
 
-        candidate = new(valueExpression, ConstantPattern(constantExpression));
+        candidate = new(valueExpression, ConstantPattern(constantExpression), IsStableValue(expressionOperation));
         return true;
+    }
+
+    /// <summary>
+    /// Merging the comparisons into a single pattern evaluates the operand once instead of once per comparison,
+    /// so it is only valid when the operands are the same and evaluating them again cannot have a side effect or return another value.
+    /// </summary>
+    private static bool CanMerge(DiscreteComparisonCandidate first, DiscreteComparisonCandidate candidate)
+    {
+        return first.HasStableValue && candidate.HasStableValue && SyntaxFactory.AreEquivalent(first.Expression, candidate.Expression);
+    }
+
+    /// <summary>
+    /// Determines if evaluating the operation has no side effect and returns the same value as the previous evaluation.
+    /// The properties, the indexers and the methods are excluded as they can execute any code.
+    /// </summary>
+    private static bool IsStableValue(IOperation? operation)
+    {
+        if (operation is null)
+            return false;
+
+        if (operation.ConstantValue.HasValue)
+            return true;
+
+        return operation switch
+        {
+            ILocalReferenceOperation or IParameterReferenceOperation or IInstanceReferenceOperation => true,
+            IFieldReferenceOperation fieldReference => !fieldReference.Field.IsVolatile && (fieldReference.Field.IsStatic || IsStableValue(fieldReference.Instance)),
+            IConversionOperation conversion => conversion.OperatorMethod is null && IsStableValue(conversion.Operand),
+            _ => false,
+        };
     }
 
     private static bool TryCreatePatternExpression(BinaryExpressionSyntax binaryExpression, SemanticModel semanticModel, CancellationToken cancellationToken, out IsPatternExpressionSyntax updatedExpression)
@@ -280,5 +310,5 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
 
     private static bool IsLogicalBinary(SyntaxKind kind) => kind is SyntaxKind.LogicalAndExpression or SyntaxKind.LogicalOrExpression;
 
-    private readonly record struct DiscreteComparisonCandidate(ExpressionSyntax Expression, PatternSyntax Pattern);
+    private readonly record struct DiscreteComparisonCandidate(ExpressionSyntax Expression, PatternSyntax Pattern, bool HasStableValue);
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
@@ -274,6 +274,104 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
     }
 
     [Fact]
+    public Task EqualityComparison_MethodCall_DoNotMerge()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            _ = {|MA0148:Next() == 0|} || {|MA0148:Next() == 2|};
+
+            static int Next() => 0;
+            """;
+        test.FixedCode = """
+            _ = Next() is 0 || Next() is 2;
+
+            static int Next() => 0;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InequalityComparison_MethodCall_DoNotMerge()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            _ = {|MA0149:Next() != 0|} && {|MA0149:Next() != 2|};
+
+            static int Next() => 0;
+            """;
+        test.FixedCode = """
+            _ = Next() is not 0 && Next() is not 2;
+
+            static int Next() => 0;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task EqualityComparison_Property_DoNotMerge()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            _ = {|MA0148:args.Length == 0|} || {|MA0148:args.Length == 1|};
+            """;
+        test.FixedCode = """
+            _ = args.Length is 0 || args.Length is 1;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task EqualityComparison_Field_MergeConditions()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            _ = {|MA0148:Sample.Value == 0|} || {|MA0148:Sample.Value == 1|};
+
+            static class Sample
+            {
+                public static int Value;
+            }
+            """;
+        test.FixedCode = """
+            _ = Sample.Value is 0 or 1;
+
+            static class Sample
+            {
+                public static int Value;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task EqualityComparison_VolatileField_DoNotMerge()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            _ = {|MA0148:Sample.Value == 0|} || {|MA0148:Sample.Value == 1|};
+
+            static class Sample
+            {
+                public static volatile int Value;
+            }
+            """;
+        test.FixedCode = """
+            _ = Sample.Value is 0 || Sample.Value is 1;
+
+            static class Sample
+            {
+                public static volatile int Value;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task BatchFix_MergeConditions()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

The MA0148/MA0149 code fix merges adjacent comparisons into a single pattern when their operands are syntactically equivalent. Syntax equivalence does not guarantee the operand returns the same value or has no side effect:

```csharp
static int count;
static int Next() => ++count;
public static object Run() => Next() == 0 || Next() == 2;
```

was fixed as `Next() is 0 or 2`. The original calls `Next()` twice (returns `true`), the fixed code calls it once (returns `false`). The same issue applied to `!=` / `&&` merged into `is not (… or …)`.

## Fix

The comparisons are merged only when the operand is stable, i.e. evaluating it again has no side effect and returns the same value:

- constants, locals, parameters, `this`
- non-volatile fields, static or on a stable instance
- built-in conversions (no user-defined operator) of a stable operand

Other operands (method calls, properties, indexers, …) are still converted to patterns, but kept as separate comparisons: `Next() is 0 || Next() is 2`, `Next() is not 0 && Next() is not 2`.

## Notes for reviewers

- Behavior change: `x.Length == 0 || x.Length == 1` is no longer merged into `x.Length is 0 or 1`, as a property getter can execute any code.
- Non-volatile fields are still merged, consistent with `UseHasFlagMethodCommon.AreEquivalentOperands`.
- `docs/Rules/MA0148.md` and `MA0149.md` document when the fix merges comparisons.

## Tests

Added tests for method calls (`==`/`||` and `!=`/`&&`), a property, and a volatile field (not merged), and a static field (merged). The 4 "do not merge" tests fail without the fix. The `UsePatternMatchingForEqualityComparisonsAnalyzer*` tests (37) pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
