### PR TITLE
Fix MA0210 checking the wrong parameter for reordered named arguments

### DIFF
--- a/docs/Rules/MA0210.md
+++ b/docs/Rules/MA0210.md
@@ -17,4 +17,6 @@ void Process(LargeStruct value) { }
 void Process(in LargeStruct value) { }
 ````
 
+When the call uses named arguments, the `in` overload must use the same parameter names, so that adding `in` binds the arguments to the same parameters.
+
 This rule is disabled by default.

--- a/src/Meziantou.Analyzer/Rules/UseInKeywordForInParameterAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseInKeywordForInParameterAnalyzer.cs
@@ -64,10 +64,11 @@ public sealed class UseInKeywordForInParameterAnalyzer : DiagnosticAnalyzer
         if (operation.Parameter.RefKind is not RefKind.None)
             return;
 
-        if (!TryGetInvocationAndArgumentIndex(operation, out var invocationOperation, out var argumentIndex))
+        if (operation.Parent is not IInvocationOperation invocationOperation)
             return;
 
-        if (HasInOverloadWithEquivalentParameters(invocationOperation, argumentIndex, overloadFinder))
+        // The arguments are in source order, which differs from the parameter order when named arguments are reordered
+        if (HasInOverloadWithEquivalentParameters(invocationOperation, operation.Parameter.Ordinal, overloadFinder))
         {
             context.ReportDiagnostic(RuleUseInToSelectInOverload, argumentSyntax);
         }
@@ -112,36 +113,21 @@ public sealed class UseInKeywordForInParameterAnalyzer : DiagnosticAnalyzer
         };
     }
 
-    private static bool TryGetInvocationAndArgumentIndex(IArgumentOperation operation, out IInvocationOperation invocationOperation, out int argumentIndex)
-    {
-        invocationOperation = null!;
-        argumentIndex = -1;
-
-        if (operation.Parent is not IInvocationOperation invocation)
-            return false;
-
-        for (var i = 0; i < invocation.Arguments.Length; i++)
-        {
-            if (invocation.Arguments[i] == operation)
-            {
-                invocationOperation = invocation;
-                argumentIndex = i;
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool HasInOverloadWithEquivalentParameters(IInvocationOperation invocationOperation, int argumentIndex, OverloadFinder overloadFinder)
+    private static bool HasInOverloadWithEquivalentParameters(IInvocationOperation invocationOperation, int parameterIndex, OverloadFinder overloadFinder)
     {
         var targetMethod = invocationOperation.TargetMethod;
         if (targetMethod.ContainingType is null)
             return false;
 
-        var currentParameter = targetMethod.Parameters[argumentIndex];
+        if (parameterIndex >= targetMethod.Parameters.Length)
+            return false;
+
+        var currentParameter = targetMethod.Parameters[parameterIndex];
         if (currentParameter.RefKind is not RefKind.None)
             return false;
+
+        // Named arguments are bound by name, so the overload must use the same names to bind the arguments to the same parameters
+        var compareParameterNames = HasNamedArguments(invocationOperation);
 
         var options = new OverloadOptions(
             IncludeObsoleteMembers: false,
@@ -157,16 +143,27 @@ public sealed class UseInKeywordForInParameterAnalyzer : DiagnosticAnalyzer
                 if (method.Parameters.Length != targetMethod.Parameters.Length)
                     return false;
 
-                if (method.Parameters[argumentIndex].RefKind is not RefKind.In)
+                if (method.Parameters[parameterIndex].RefKind is not RefKind.In)
                     return false;
 
-                return HasEquivalentParameterList(targetMethod.Parameters, method.Parameters, argumentIndex);
+                return HasEquivalentParameterList(targetMethod.Parameters, method.Parameters, parameterIndex, compareParameterNames);
             });
 
         return overloadFinder.FindFirstSimilarMethod(targetMethod, options, targetMethod.Name, additionalParameterTypes: default) is not null;
     }
 
-    private static bool HasEquivalentParameterList(ImmutableArray<IParameterSymbol> currentParameters, ImmutableArray<IParameterSymbol> candidateParameters, int argumentIndex)
+    private static bool HasNamedArguments(IInvocationOperation invocationOperation)
+    {
+        foreach (var argument in invocationOperation.Arguments)
+        {
+            if (argument.Syntax is ArgumentSyntax { NameColon: not null })
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasEquivalentParameterList(ImmutableArray<IParameterSymbol> currentParameters, ImmutableArray<IParameterSymbol> candidateParameters, int parameterIndex, bool compareParameterNames)
     {
         if (currentParameters.Length != candidateParameters.Length)
             return false;
@@ -175,7 +172,10 @@ public sealed class UseInKeywordForInParameterAnalyzer : DiagnosticAnalyzer
         {
             var current = currentParameters[i];
             var candidate = candidateParameters[i];
-            if (i == argumentIndex)
+            if (compareParameterNames && !string.Equals(current.Name, candidate.Name, StringComparison.Ordinal))
+                return false;
+
+            if (i == parameterIndex)
             {
                 if (current.RefKind is not (RefKind.None or RefKind.In))
                     return false;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseInKeywordForInParameterAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseInKeywordForInParameterAnalyzerTests.cs
@@ -275,4 +275,93 @@ public sealed class UseInKeywordForInParameterAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task OverloadRule_ReorderedNamedArguments_ShouldReportDiagnosticOnMatchingParameter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class C
+            {
+                public void Test()
+                {
+                    int a = 1, b = 2;
+                    M(y: b, {|MA0210:x: a|});
+                }
+
+                private static void M(int x, int y) { }
+                private static void M(in int x, int y) { }
+            }
+            """;
+        test.FixedCode = """
+            class C
+            {
+                public void Test()
+                {
+                    int a = 1, b = 2;
+                    M(y: b, x: in a);
+                }
+
+                private static void M(int x, int y) { }
+                private static void M(in int x, int y) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OverloadRule_NamedArgumentsWithDifferentParameterNames_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class C
+            {
+                public void Test()
+                {
+                    int a = 1, b = 2;
+                    M(x: a, y: b);
+                }
+
+                private static void M(int x, int y) { }
+                private static void M(in int y, int x) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OverloadRule_PositionalArgumentsWithDifferentParameterNames_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class C
+            {
+                public void Test()
+                {
+                    int a = 1, b = 2;
+                    M({|MA0210:a|}, b);
+                }
+
+                private static void M(int x, int y) { }
+                private static void M(in int y, int x) { }
+            }
+            """;
+        test.FixedCode = """
+            class C
+            {
+                public void Test()
+                {
+                    int a = 1, b = 2;
+                    M(in a, b);
+                }
+
+                private static void M(int x, int y) { }
+                private static void M(in int y, int x) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## Problem

With reordered named arguments, MA0210 reports an argument whose parameter has no `in` overload, and its code fix produces code that does not compile:

```csharp
static void F(int x, int y) { }
static void F(in int x, int y) { }

F(y: b, x: a); // reported on `y: b`, fixed to `F(y: in b, x: a)` → CS1615
```

The analyzer used the argument's position in `IInvocationOperation.Arguments` to index the method's parameters. Those arguments are in source order, which differs from the parameter order when named arguments are reordered, so the overload check verified a different parameter from the one the fixer modified.

## Changes

- Use `IArgumentOperation.Parameter.Ordinal` to identify the parameter to check. The example above is now reported on `x: a` and fixed to `F(y: b, x: in a)`.
- When the invocation uses named arguments, require the `in` overload to use the same parameter names. Otherwise `M(x: a, y: b)` with `M(int x, int y)` / `M(in int y, int x)` would be reported and fixed to `M(x: in a, y: b)`, which also fails with CS1615. Positional calls are unaffected, as they bind by position.
- Document the named-arguments condition in `docs/Rules/MA0210.md`.

## Tests

Added to `UseInKeywordForInParameterAnalyzerTests`:
- reordered named arguments, reported and fixed on the matching parameter;
- named arguments with an overload using different parameter names, not reported;
- positional arguments with an overload using different parameter names, still reported and fixed.

The first two fail without the analyzer change. `UseInKeywordForInParameterAnalyzerTests` passes (14/14) on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9; the full suite was not run locally. `dotnet run --project src/DocumentationGenerator` reports no further changes.
