### PR TITLE
Do not report MA0184 when the interpolated string is converted to IFormattable

### DIFF
--- a/docs/Rules/MA0184.md
+++ b/docs/Rules/MA0184.md
@@ -21,9 +21,10 @@ var message = "Required attribute 'output' not found.";
 
 This rule does not report diagnostics when:
 
-1. The interpolated string is assigned to or converted to `FormattableString`:
+1. The interpolated string is assigned to or converted to `FormattableString` or `IFormattable`, as a string literal cannot be converted to these types:
    ```csharp
    FormattableString fs = $"Hello"; // OK
+   IFormattable f = $"Hello"; // OK
    ```
 
 2. The interpolated string is used with a custom `InterpolatedStringHandler`:

--- a/src/Meziantou.Analyzer/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzer.cs
@@ -23,13 +23,14 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersAnalyzer : Diagno
         context.RegisterCompilationStartAction(ctx =>
         {
             var formattableStringSymbol = ctx.Compilation.GetBestTypeByMetadataName("System.FormattableString");
+            var formattableSymbol = ctx.Compilation.GetBestTypeByMetadataName("System.IFormattable");
             var interpolatedStringHandlerAttributeSymbol = ctx.Compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute");
 
-            ctx.RegisterOperationAction(context => AnalyzeInterpolatedString(context, formattableStringSymbol, interpolatedStringHandlerAttributeSymbol), OperationKind.InterpolatedString);
+            ctx.RegisterOperationAction(context => AnalyzeInterpolatedString(context, formattableStringSymbol, formattableSymbol, interpolatedStringHandlerAttributeSymbol), OperationKind.InterpolatedString);
         });
     }
 
-    private static void AnalyzeInterpolatedString(OperationAnalysisContext context, INamedTypeSymbol? formattableStringSymbol, INamedTypeSymbol? interpolatedStringHandlerAttributeSymbol)
+    private static void AnalyzeInterpolatedString(OperationAnalysisContext context, INamedTypeSymbol? formattableStringSymbol, INamedTypeSymbol? formattableSymbol, INamedTypeSymbol? interpolatedStringHandlerAttributeSymbol)
     {
         var operation = (IInterpolatedStringOperation)context.Operation;
 
@@ -45,46 +46,17 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersAnalyzer : Diagno
         if (IsInterpolatedStringHandler(operation.Type, interpolatedStringHandlerAttributeSymbol))
             return;
 
-        // Walk up the parent chain to find the target type
-        var current = operation.Parent;
-        while (current is not null)
+        // An interpolated string can be converted to FormattableString, IFormattable, or a custom handler, but a
+        // string literal cannot. Only the conversion applied to the interpolated string itself matters, as the
+        // conversions of the enclosing operations still apply to the string literal.
+        if (operation.Parent is IInterpolatedStringHandlerCreationOperation)
+            return;
+
+        if (operation.Parent is IConversionOperation conversionOperation)
         {
-            // Check for conversion to FormattableString or custom handler
-            if (current is IConversionOperation conversionOperation)
-            {
-                // If converting to FormattableString, don't report
-                if (conversionOperation.Type?.IsEqualTo(formattableStringSymbol) == true)
-                    return;
-
-                // If converting to a custom InterpolatedStringHandler, don't report
-                if (IsInterpolatedStringHandler(conversionOperation.Type, interpolatedStringHandlerAttributeSymbol))
-                    return;
-            }
-
-            // Check if used as method argument with custom InterpolatedStringHandler parameter
-            if (current is IArgumentOperation argumentOperation)
-            {
-                if (argumentOperation.Parameter?.Type is not null)
-                {
-                    if (IsInterpolatedStringHandler(argumentOperation.Parameter.Type, interpolatedStringHandlerAttributeSymbol))
-                        return;
-                }
-            }
-
-            // If assigned to FormattableString or custom handler, don't report
-            if (current is IVariableInitializerOperation variableInitializer)
-            {
-                if (variableInitializer.Parent is IVariableDeclaratorOperation declarator)
-                {
-                    if (declarator.Symbol?.Type?.IsEqualTo(formattableStringSymbol) == true)
-                        return;
-
-                    if (IsInterpolatedStringHandler(declarator.Symbol?.Type, interpolatedStringHandlerAttributeSymbol))
-                        return;
-                }
-            }
-
-            current = current.Parent;
+            var targetType = conversionOperation.Type;
+            if (targetType.IsEqualTo(formattableStringSymbol) || targetType.IsEqualTo(formattableSymbol))
+                return;
         }
 
         // Report diagnostic as a suggestion (Hidden severity with unnecessary tag)

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseInterpolatedStringWithoutParametersAnalyzerTests.cs
@@ -104,6 +104,139 @@ public sealed class DoNotUseInterpolatedStringWithoutParametersAnalyzerTests
     }
 
     [Fact]
+    public Task InterpolatedStringWithoutParameters_ReturnedAsIFormattable_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Sample
+            {
+                public static System.IFormattable Run() => $"text";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InterpolatedStringWithoutParameters_AssignedToIFormattable_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Sample
+            {
+                private System.IFormattable _value;
+
+                public void Run()
+                {
+                    System.IFormattable local = $"text";
+                    _value = $"text";
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InterpolatedStringWithoutParameters_ConvertedToIFormattable_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Sample
+            {
+                public void Test(System.IFormattable value)
+                {
+                }
+
+                public void Run()
+                {
+                    Test($"text");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InterpolatedStringWithoutParameters_CastToIFormattable_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Sample
+            {
+                public object Run() => (System.IFormattable)$"text";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InterpolatedStringWithoutParameters_ConditionalConvertedToIFormattable_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Sample
+            {
+                public System.IFormattable Run(bool condition) => condition ? $"a" : (System.IFormattable)$"b";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InterpolatedStringWithoutParameters_ConvertedToObject_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Sample
+            {
+                public object Run() => [|$"text"|];
+            }
+            """;
+        test.FixedCode = """
+            class Sample
+            {
+                public object Run() => "text";
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InterpolatedStringWithoutParameters_ArgumentOfMethodReturningFormattableString_ShouldReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Sample
+            {
+                public void Run()
+                {
+                    System.FormattableString value = Create([|$"text"|]);
+                }
+
+                private static System.FormattableString Create(string value) => throw null;
+            }
+            """;
+        test.FixedCode = """
+            class Sample
+            {
+                public void Run()
+                {
+                    System.FormattableString value = Create("text");
+                }
+
+                private static System.FormattableString Create(string value) => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task InterpolatedStringWithoutParameters_CustomInterpolatedStringHandler_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

MA0184 reported interpolated strings without holes that are converted to `System.IFormattable`, and its code fix broke the build:

```csharp
public static System.IFormattable Run() => $"text";
// Fixed code: error CS0029, a string cannot be converted to System.IFormattable
public static System.IFormattable Run() => "text";
```

Interpolated strings support a conversion to `IFormattable` (like `FormattableString`), but a string literal does not. The analyzer only excluded `FormattableString`.

## Changes

- The analyzer now looks at the conversion applied to the interpolated string itself, and does not report when it targets `FormattableString` or `IFormattable`, or when the string is used by a custom interpolated string handler.
- This replaces the walk up the parent chain, which looked at every enclosing operation. Only the conversion of the interpolated string itself matters: the conversions of the enclosing operations still apply to the string literal. As a consequence, a string nested in an expression of type `FormattableString`, such as `FormattableString value = Create($"text")` where `Create` takes a `string`, is now reported, and the fix is valid there.
- `docs/Rules/MA0184.md` lists `IFormattable` in the exceptions.

## Tests

New tests with an `IFormattable` target: return expression, local and field assignments, method argument, explicit cast, and conditional branch. New tests checking that the diagnostic and fix still apply for a conversion to `object` and for the `Create($"text")` case.

- `DoNotUseInterpolatedStringWithoutParametersAnalyzerTests`: 20/20 on Roslyn 4.8, 4.14, 5.0, 5.6, and 5.9 (the 5 `IFormattable` tests failed before the fix)
- Full Roslyn 5.9 test suite: 4387/4387
- `dotnet run --project src/DocumentationGenerator`: no further changes
