### PR TITLE
Do not report MA0148/MA0149 when the constant does not convert to the operand type

### DIFF
--- a/docs/Rules/MA0148.md
+++ b/docs/Rules/MA0148.md
@@ -24,3 +24,13 @@ class Sample
 Sample value = null;
 _ = value == 0; // ok
 ````
+
+Cases where the constant cannot be implicitly converted to the type of the value are also ignored. The equality operator converts both operands to a common type, while the pattern is matched against the type of the value:
+
+````c#
+int value = 0;
+_ = value == 1L; // ok, 'value is 1L' does not compile
+
+byte b = 0;
+_ = b == 1; // not compliant, 'b is 1' is valid
+````

--- a/docs/Rules/MA0149.md
+++ b/docs/Rules/MA0149.md
@@ -24,3 +24,13 @@ class Sample
 Sample value = null;
 _ = value != 0; // ok
 ````
+
+Cases where the constant cannot be implicitly converted to the type of the value are also ignored. The equality operator converts both operands to a common type, while the pattern is matched against the type of the value:
+
+````c#
+int value = 0;
+_ = value != 1L; // ok, 'value is not 1L' does not compile
+
+byte b = 0;
+_ = b != 1; // not compliant, 'b is not 1' is valid
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
@@ -210,7 +210,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
             return false;
 
         var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
-        if (!UsePatternMatchingForEqualityComparisonsCommon.CanUseConstantPattern(expressionOperation, constantOperation, cancellationToken))
+        if (!UsePatternMatchingForEqualityComparisonsCommon.CanUseConstantPattern(expressionOperation, constantOperation))
             return false;
 
         if (expressionOperation.Syntax is not ExpressionSyntax valueExpression || constantOperation.Syntax is not ExpressionSyntax constantExpression)
@@ -246,7 +246,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
 
         var constantOperation = leftIsConstant ? operation.LeftOperand : operation.RightOperand;
         var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
-        if (!UsePatternMatchingForEqualityComparisonsCommon.CanUseConstantPattern(expressionOperation, constantOperation, cancellationToken))
+        if (!UsePatternMatchingForEqualityComparisonsCommon.CanUseConstantPattern(expressionOperation, constantOperation))
             return false;
 
         if (constantOperation.Syntax is not ExpressionSyntax constantExpression || expressionOperation.Syntax is not ExpressionSyntax valueExpression)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UsePatternMatchingForEqualityComparisonsFixer.cs
@@ -210,7 +210,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
             return false;
 
         var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
-        if (UsePatternMatchingForEqualityComparisonsCommon.HasImplicitUserDefinedConversion(expressionOperation))
+        if (!UsePatternMatchingForEqualityComparisonsCommon.CanUseConstantPattern(expressionOperation, constantOperation, cancellationToken))
             return false;
 
         if (expressionOperation.Syntax is not ExpressionSyntax valueExpression || constantOperation.Syntax is not ExpressionSyntax constantExpression)
@@ -246,7 +246,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsFixer : CodeFixProvi
 
         var constantOperation = leftIsConstant ? operation.LeftOperand : operation.RightOperand;
         var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
-        if (UsePatternMatchingForEqualityComparisonsCommon.HasImplicitUserDefinedConversion(expressionOperation))
+        if (!UsePatternMatchingForEqualityComparisonsCommon.CanUseConstantPattern(expressionOperation, constantOperation, cancellationToken))
             return false;
 
         if (constantOperation.Syntax is not ExpressionSyntax constantExpression || expressionOperation.Syntax is not ExpressionSyntax valueExpression)

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
@@ -88,8 +88,9 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzer : Diagnosti
                     var rightIsConstant = UsePatternMatchingForEqualityComparisonsCommon.IsConstantLiteral(operation.RightOperand);
                     if (leftIsConstant ^ rightIsConstant)
                     {
+                        var constantOperation = leftIsConstant ? operation.LeftOperand : operation.RightOperand;
                         var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
-                        if (UsePatternMatchingForEqualityComparisonsCommon.HasImplicitUserDefinedConversion(expressionOperation))
+                        if (!UsePatternMatchingForEqualityComparisonsCommon.CanUseConstantPattern(expressionOperation, constantOperation, context.CancellationToken))
                             return;
 
                         if (_operationUtilities.IsInExpressionContext(operation))

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsAnalyzer.cs
@@ -90,7 +90,7 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzer : Diagnosti
                     {
                         var constantOperation = leftIsConstant ? operation.LeftOperand : operation.RightOperand;
                         var expressionOperation = leftIsConstant ? operation.RightOperand : operation.LeftOperand;
-                        if (!UsePatternMatchingForEqualityComparisonsCommon.CanUseConstantPattern(expressionOperation, constantOperation, context.CancellationToken))
+                        if (!UsePatternMatchingForEqualityComparisonsCommon.CanUseConstantPattern(expressionOperation, constantOperation))
                             return;
 
                         if (_operationUtilities.IsInExpressionContext(operation))

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsCommon.cs
@@ -1,4 +1,8 @@
-﻿namespace Meziantou.Analyzer.Rules;
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Meziantou.Analyzer.Rules;
+
 internal static class UsePatternMatchingForEqualityComparisonsCommon
 {
     public static bool IsNull(IOperation operation)
@@ -20,16 +24,23 @@ internal static class UsePatternMatchingForEqualityComparisonsCommon
         return false;
     }
 
-    public static bool HasImplicitUserDefinedConversion(IOperation operation)
+    // The equality operator may implicitly convert the operand (numeric promotion, user-defined conversion, etc.),
+    // while the pattern is matched against the type of the operand itself. For instance, 'intValue == 1L' is valid
+    // but 'intValue is 1L' is not. The constant pattern is valid only if the constant implicitly converts to the operand type.
+    public static bool CanUseConstantPattern(IOperation expressionOperation, IOperation constantOperation, CancellationToken cancellationToken)
     {
-        while (operation is IConversionOperation { IsImplicit: true } conversionOperation)
-        {
-            if (conversionOperation.Conversion.IsUserDefined)
-                return true;
+        if (expressionOperation is not IConversionOperation { IsImplicit: true })
+            return true;
 
-            operation = conversionOperation.Operand;
-        }
+        var semanticModel = expressionOperation.SemanticModel;
+        if (semanticModel is null || expressionOperation.Syntax is not ExpressionSyntax expression || constantOperation.Syntax is not ExpressionSyntax constantExpression)
+            return false;
 
-        return false;
+        var operandType = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
+        if (operandType is null)
+            return false;
+
+        var conversion = semanticModel.ClassifyConversion(constantExpression, operandType.GetUnderlyingNullableTypeOrSelf());
+        return conversion is { IsImplicit: true, IsUserDefined: false };
     }
 }

--- a/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UsePatternMatchingForEqualityComparisonsCommon.cs
@@ -27,20 +27,19 @@ internal static class UsePatternMatchingForEqualityComparisonsCommon
     // The equality operator may implicitly convert the operand (numeric promotion, user-defined conversion, etc.),
     // while the pattern is matched against the type of the operand itself. For instance, 'intValue == 1L' is valid
     // but 'intValue is 1L' is not. The constant pattern is valid only if the constant implicitly converts to the operand type.
-    public static bool CanUseConstantPattern(IOperation expressionOperation, IOperation constantOperation, CancellationToken cancellationToken)
+    public static bool CanUseConstantPattern(IOperation expressionOperation, IOperation constantOperation)
     {
-        if (expressionOperation is not IConversionOperation { IsImplicit: true })
+        if (expressionOperation is not IConversionOperation { IsImplicit: true } conversionOperation)
             return true;
 
         var semanticModel = expressionOperation.SemanticModel;
-        if (semanticModel is null || expressionOperation.Syntax is not ExpressionSyntax expression || constantOperation.Syntax is not ExpressionSyntax constantExpression)
+        var operandType = conversionOperation.Operand.Type?.GetUnderlyingNullableTypeOrSelf();
+        if (semanticModel is null || operandType is null || constantOperation.Syntax is not ExpressionSyntax constantExpression)
             return false;
 
-        var operandType = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
-        if (operandType is null)
-            return false;
-
-        var conversion = semanticModel.ClassifyConversion(constantExpression, operandType.GetUnderlyingNullableTypeOrSelf());
+        // The conversion depends on the value of the constant ('byteValue == 1' is valid, whereas 'byteValue == 300' is not),
+        // so it must be classified from the expression instead of the type of the constant
+        var conversion = semanticModel.ClassifyConversion(constantExpression, operandType);
         return conversion is { IsImplicit: true, IsUserDefined: false };
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UsePatternMatchingForEqualityComparisonsAnalyzerTests.cs
@@ -369,4 +369,94 @@ public sealed class UsePatternMatchingForEqualityComparisonsAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Theory]
+    [InlineData("int", "1L")]
+    [InlineData("int", "1.0")]
+    [InlineData("int", "1m")]
+    [InlineData("int?", "1L")]
+    [InlineData("float", "0.1")]
+    [InlineData("byte", "300")]
+    [InlineData("char", "65")]
+    public async Task EqualityComparison_NumericPromotion_ConstantNotConvertibleToOperandType_NoDiagnostic(string type, string constant)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            {{type}} value = default;
+            _ = value == {{constant}};
+            _ = {{constant}} != value;
+            """;
+
+        await test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("byte", "1")]
+    [InlineData("short", "1")]
+    [InlineData("ushort", "1")]
+    [InlineData("byte?", "1")]
+    public async Task EqualityComparison_NumericPromotion_ConstantConvertibleToOperandType(string type, string constant)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            {{type}} value = default;
+            _ = {|MA0148:value == {{constant}}|};
+            _ = {|MA0149:{{constant}} != value|};
+            """;
+        test.FixedCode = $$"""
+            {{type}} value = default;
+            _ = value is {{constant}};
+            _ = value is not {{constant}};
+            """;
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public Task EqualityComparison_MixedWithNumericPromotion_OnlyFixValidExpression()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            int value = 0;
+            _ = {|MA0148:value == 1|} || value == 2L;
+            """;
+        test.FixedCode = """
+            int value = 0;
+            _ = value is 1 || value == 2L;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InequalityComparison_MixedWithNumericPromotion_OnlyFixValidExpression()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            int value = 0;
+            _ = value != 1L && {|MA0149:value != 2|};
+            """;
+        test.FixedCode = """
+            int value = 0;
+            _ = value != 1L && value is not 2;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task EqualityComparison_MergeWithNumericPromotion()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            byte value = 0;
+            _ = {|MA0148:value == 1|} || {|MA0148:value == 2|};
+            """;
+        test.FixedCode = """
+            byte value = 0;
+            _ = value is 1 or 2;
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## Problem

MA0148/MA0149 rewrite `value == 1L` (with `int value`) into `value is 1L`, which fails with **CS0266**. The binary equality operator promotes the `int` operand to `long`, but the fixer copies the operand syntax into an `is` expression, dropping the implicit conversion. Constant patterns are matched against the operand's own type, so the `long` constant is not valid there.

The existing guard only excluded implicit user-defined conversions, not built-in numeric promotion.

## Fix

When the comparison implicitly converts the operand, the analyzer and the fixer now check that the constant is implicitly convertible (without user-defined conversion) to the type of the operand as written in source (or its underlying type when nullable). If not, the comparison is not reported nor rewritten. This check replaces `HasImplicitUserDefinedConversion`, which it covers.

- Still reported/fixed: `byteValue == 1` → `byteValue is 1` (same for `short`, `ushort`, `byte?`)
- No longer reported: `int` vs `1L` / `1.0` / `1m`, `int?` vs `1L`, `float` vs `0.1`, `byte` vs `300`, `char` vs `65`
- Merged chains keep the valid terms only: `value == 1 || value == 2L` → `value is 1 || value == 2L`

The fixer shares the check for both single comparisons and merged `||`/`&&` candidates, so a fix triggered on a valid term can no longer merge an invalid one.

### Note for reviewers

The operand type is taken from `SemanticModel.GetTypeInfo(operandSyntax).Type` rather than by unwrapping the conversion operations: Roslyn 4.8 represents `(DayOfWeek?)1` as a chain of implicit conversions down to the `int` literal, so unwrapping overshoots and broke the existing `EqualityComparison_NullableEnum` test on that version.

## Tests

- New tests in `UsePatternMatchingForEqualityComparisonsAnalyzerTests` for non-convertible constants, convertible promoted operands, and mixed/merged comparisons (verified that 9 of the new cases fail without the fix).
- MA0148/MA0149 tests pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9 (46/46 each).
- Full test suite passes on Roslyn 5.9 (4394/4394).
- `docs/Rules/MA0148.md` and `docs/Rules/MA0149.md` document the new exclusion; `DocumentationGenerator` reports no further changes.
