### PR TITLE
Do not report MA0111 in expression trees

### DIFF
--- a/docs/Rules/MA0111.md
+++ b/docs/Rules/MA0111.md
@@ -11,6 +11,12 @@ FormattableString.Invariant($""); // report diagnostic
 string.Create(CultureInfo.Invariant, $""); // ok
 ````
 
+The rule does not report a diagnostic in expression trees, as they cannot contain interpolated string handler conversions.
+
+````c#
+Expression<Func<int, string>> expression = x => FormattableString.Invariant($"{x}"); // ok
+````
+
 # Benchmark
 
 ````c#

--- a/src/Meziantou.Analyzer/Rules/UseStringCreateInsteadOfFormattableStringAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseStringCreateInsteadOfFormattableStringAnalyzer.cs
@@ -37,6 +37,7 @@ public sealed class UseStringCreateInsteadOfFormattableStringAnalyzer : Diagnost
             if (stringCreateSymbol is null || formatProviderSymbol is null)
                 return;
 
+            var operationUtilities = new OperationUtilities(ctx.Compilation);
             ctx.RegisterOperationAction(AnalyzeSymbol, OperationKind.Invocation);
 
             void AnalyzeSymbol(OperationAnalysisContext context)
@@ -49,6 +50,10 @@ public sealed class UseStringCreateInsteadOfFormattableStringAnalyzer : Diagnost
 
                 if (method.Name is "Invariant" or "CurrentCulture" && method.Parameters.Length == 1 && operation.Arguments[0].Value.UnwrapImplicitConversions() is IInterpolatedStringOperation)
                 {
+                    // Expression trees cannot contain interpolated string handler conversions (CS8952)
+                    if (operationUtilities.IsInExpressionContext(operation))
+                        return;
+
                     context.ReportDiagnostic(Rule, operation);
                     return;
                 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringCreateInsteadOfFormattableStringAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringCreateInsteadOfFormattableStringAnalyzerTests.cs
@@ -130,4 +130,58 @@ public sealed class UseStringCreateInsteadOfFormattableStringAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task ExpressionTree_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Linq;
+            using System.Linq.Expressions;
+
+            class TypeName
+            {
+                public void Test(IQueryable<int> query)
+                {
+                    Expression<Func<int, string>> invariant = x => FormattableString.Invariant($"{x}");
+                    Expression<Func<int, string>> currentCulture = x => FormattableString.CurrentCulture($"{x}");
+                    query.Select(x => FormattableString.Invariant($"{x}"));
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Lambda_Diagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    Func<int, string> func = x => {|MA0111:FormattableString.Invariant($"{x}")|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Globalization;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    Func<int, string> func = x => string.Create(CultureInfo.InvariantCulture, $"{x}");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## Summary

MA0111 suggested replacing `FormattableString.Invariant($"...")` / `FormattableString.CurrentCulture($"...")` with `string.Create(...)` even inside expression trees. The replacement uses the `DefaultInterpolatedStringHandler` overload, which expression trees can't represent, so applying the fix broke code that compiled before (CS8952, plus CS8640 for the restricted handler type):

```csharp
Expression<Func<int, string>> e = x => FormattableString.Invariant($"{x}");
// fixed to: x => string.Create(CultureInfo.InvariantCulture, $"{x}") -> CS8952
```

## Changes

- `UseStringCreateInsteadOfFormattableStringAnalyzer` now skips invocations in an expression context, using the existing `OperationUtilities.IsInExpressionContext` helper (the same one MA0006 and others use). The fixer is unchanged: it only runs when the analyzer reports.
- New tests:
  - `ExpressionTree_NoDiagnostic`: `Expression<Func<...>>` lambdas with both `Invariant` and `CurrentCulture`, plus a lambda passed to `IQueryable.Select`.
  - `Lambda_Diagnostic`: a plain `Func<...>` lambda is still reported and fixed.
- `docs/Rules/MA0111.md` now describes the expression-tree exclusion.

## Testing

- `UseStringCreateInsteadOfFormattableStringAnalyzerTests` passes on Roslyn 5.9 and 4.8 (7/7 each).
- With the new check disabled, `ExpressionTree_NoDiagnostic` fails, so the test catches the bug.
- `dotnet run --project src/DocumentationGenerator` exits 0 and leaves no pending changes.
- I didn't run the full test suite locally.
