### PR TITLE
Do not offer the MA0098 Last() code fix when the source cannot be evaluated twice

### DIFF
--- a/docs/Rules/MA0098.md
+++ b/docs/Rules/MA0098.md
@@ -40,3 +40,9 @@ var last = array[^1];
 // For older language versions or target frameworks, it uses the traditional syntax
 var last = array[array.Length - 1];
 ````
+
+The traditional syntax evaluates the collection twice, while `Last()` evaluates it once. So, the code fix is not offered for older language versions or target frameworks when the collection is not a local variable, a parameter, `this`, or a field, as evaluating a method or a property twice could have different side effects or return a different collection:
+
+````csharp
+_ = GetValues().Last(); // non-compliant, but the code fix is not offered with C# 7.3
+````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
@@ -97,6 +97,9 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
                 break;
 
             case OptimizeLinqUsageData.UseIndexerLast:
+                if (!await CanUseIndexerLast(context.Document, nodeToFix, context.CancellationToken).ConfigureAwait(false))
+                    return;
+
                 context.RegisterCodeFix(CodeAction.Create(title, ct => UseIndexerLast(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
@@ -550,6 +553,38 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
+    private static async Task<bool> CanUseIndexerLast(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return false;
+
+        if (CanUseIndexFromEnd(nodeToFix, semanticModel.Compilation))
+            return true;
+
+        // 'source[source.Count - 1]' evaluates the source twice, while 'source.Last()' evaluates it once
+        return semanticModel.GetOperation(nodeToFix, cancellationToken) is IInvocationOperation { Arguments: [var source] }
+            && CanBeEvaluatedTwice(source.Value.UnwrapImplicitConversions());
+    }
+
+    private static bool CanUseIndexFromEnd(SyntaxNode node, Compilation compilation)
+    {
+        return node.SyntaxTree.GetCSharpLanguageVersion() >= LanguageVersion.CSharp8 && compilation.GetBestTypeByMetadataName("System.Index") is not null;
+    }
+
+    private static bool CanBeEvaluatedTwice(IOperation operation)
+    {
+        return operation switch
+        {
+            ILocalReferenceOperation or IParameterReferenceOperation => true,
+            IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance } => true,
+            IFieldReferenceOperation { Instance: var instance } => instance is null || CanBeEvaluatedTwice(instance),
+
+            // The properties, indexers, and methods can execute any code, such as modifying a state or creating a new collection
+            _ => false,
+        };
+    }
+
     private static async Task<Document> UseIndexerLast(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
     {
         var expression = GetParentMemberExpression(nodeToFix);
@@ -563,7 +598,7 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
             return document;
 
         // if C# 8.0, use ^1
-        if (expression.SyntaxTree.GetCSharpLanguageVersion() >= LanguageVersion.CSharp8 && editor.SemanticModel.Compilation.GetBestTypeByMetadataName("System.Index") is not null)
+        if (CanUseIndexFromEnd(expression, semanticModel.Compilation))
         {
             var newExpression = generator.ElementAccessExpression(operation.Arguments[0].Syntax, PrefixUnaryExpression(SyntaxKind.IndexExpression, LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(1))));
             editor.ReplaceNode(nodeToFix, newExpression);

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
@@ -2081,6 +2081,87 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     }
 
     [Fact]
+    public Task Last_List_CSharp7_3_Field()
+    {
+        var test = new CodeFixTest();
+        test.LanguageVersion = LanguageVersion.CSharp7_3;
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                List<int> values;
+
+                void A() => _ = values.{|MA0098:Last|}();
+            }
+            """;
+        test.FixedCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                List<int> values;
+
+                void A() => _ = values[values.Count - 1];
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("Values()")]
+    [InlineData("ValuesProperty")]
+    public Task Last_List_CSharp7_3_ReceiverWithSideEffects_NoCodeFix(string receiver)
+    {
+        var code = $$"""
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                static List<int> Values() => new List<int> { 1 };
+                static List<int> ValuesProperty => new List<int> { 1 };
+
+                void A() => _ = {{receiver}}.{|MA0098:Last|}();
+            }
+            """;
+        var test = new CodeFixTest();
+        test.LanguageVersion = LanguageVersion.CSharp7_3;
+        test.TestCode = code;
+        test.FixedCode = code;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Last_List_CSharp8_ReceiverWithSideEffects()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                static List<int> Values() => new List<int> { 1 };
+
+                void A() => _ = Values().{|MA0098:Last|}();
+            }
+            """;
+        test.FixedCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Test
+            {
+                static List<int> Values() => new List<int> { 1 };
+
+                void A() => _ = Values()[^1];
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task ElementAt_VariableTypedAsEnumerableAssignedToList()
     {
         var test = new CodeFixTest();


### PR DESCRIPTION
## Problem

When the C# 8 index-from-end form is not available (language version before C# 8, or `System.Index` missing), the MA0098 fixer rewrites `source.Last()` to `source[source.Count - 1]`, which evaluates `source` twice:

```csharp
// C# 7.3
var last = Values().Last();
// became
var last = Values()[Values().Count - 1];
```

`Last()` evaluates the source once, so the rewrite could run a factory or getter twice, or take the count from a different collection than the indexed one, changing side effects, results, or exceptions.

## Change

- `RegisterCodeFixesAsync` now validates the `UseIndexerLast` case before registering the fix (`CanUseIndexerLast`):
  - When `^1` can be used, the fix is always offered — `source[^1]` evaluates the source once, so `Values().Last()` still becomes `Values()[^1]`.
  - Otherwise the fallback is only offered when the source (after unwrapping implicit conversions) is a local, a parameter, `this`, or a field whose instance is one of those. Invocations, properties, indexers, and other expressions get no fix; the diagnostic is still reported.
- The C# 8 condition is extracted to `CanUseIndexFromEnd`, shared by the check and the rewrite.
- `docs/Rules/MA0098.md` documents when the fix is not offered.

Introducing a temporary variable was not used, as it would require rewriting the enclosing statement, which is not possible in every context before C# 8 (expression-bodied members, field initializers, lambdas).

## Tests

Added to `OptimizeLinqUsageAnalyzerTests`:
- `Last_List_CSharp7_3_ReceiverWithSideEffects_NoCodeFix` (method and property receivers): diagnostic reported, no fix.
- `Last_List_CSharp7_3_Field`: field receiver still gets `values[values.Count - 1]`.
- `Last_List_CSharp8_ReceiverWithSideEffects`: method receiver still gets `Values()[^1]`.

The two no-fix cases fail without the fixer change. `OptimizeLinqUsageAnalyzerTests` passes on Roslyn 5.9 and 4.8 (157/157 each); the full suite and other Roslyn versions were not run locally. `dotnet run --project src/DocumentationGenerator` produces no further changes.
