### PR TITLE
Do not report MA0078 when the selector does more than casting its element

### DIFF
--- a/docs/Rules/MA0078.md
+++ b/docs/Rules/MA0078.md
@@ -14,5 +14,7 @@ var stringsAsObjects = strings.Select(str => (object)str);
 
 ```csharp
 System.Linq.Enumerable<string> strings = GetStrings();
-var stringsAsObjects = strings.Cast<object>(str);
+var stringsAsObjects = strings.Cast<object>();
 ```
+
+The rule only reports a selector whose body is a single cast of its element. A selector that contains other statements, such as `str => { count++; return (object)str; }`, is not reported, as `Cast<T>()` would remove them.

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -854,22 +854,22 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (operation.Arguments.Length != 2)
                 return;
 
-            var selectorArg = operation.Arguments[1];
-
-            var returnOp = selectorArg.Descendants().OfType<IReturnOperation>().FirstOrDefault();
-            if (returnOp is null)
+            if (operation.Arguments[1].Value is not IDelegateCreationOperation { Target: IAnonymousFunctionOperation selectorLambda })
                 return;
 
-            // If what's returned is not a cast value or the cast is done by 'as' operator
-            if (returnOp.ReturnedValue is not IConversionOperation castOp || castOp.IsTryCast || castOp.Type is null)
+            // The selector must only return the cast value. Cast<T>() would remove any other statement of the selector.
+            if (selectorLambda.Body.Operations is not [IReturnOperation { ReturnedValue: IConversionOperation castOp }])
+                return;
+
+            // If the cast is done by 'as' operator
+            if (castOp.IsTryCast || castOp.Type is null)
                 return;
 
             // If the cast is not applied directly to the source element (the first parameter of the selector)
             if (castOp.Operand is not IParameterReferenceOperation parameterReference)
                 return;
 
-            var selectorLambda = selectorArg.Descendants().OfType<IAnonymousFunctionOperation>().FirstOrDefault();
-            if (selectorLambda is null || selectorLambda.Symbol.Parameters.Length == 0 || !parameterReference.Parameter.IsEqualTo(selectorLambda.Symbol.Parameters[0]))
+            if (selectorLambda.Symbol.Parameters.Length == 0 || !parameterReference.Parameter.IsEqualTo(selectorLambda.Symbol.Parameters[0]))
                 return;
 
             // Ensure the code is valid after replacement. The semantic may be different if you use Cast<T>() instead of Select(x => (T)x).

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
@@ -1535,6 +1535,8 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     [InlineData("source.{|MA0078:Select<DerivedType, object>|}(i => i)",
                 "source.Cast<object>()",
                 true)]
+    [InlineData("source.{|MA0078:Select|}(dt => { return (BaseType)dt; })",
+                "source.Cast<BaseType>()")]
     public Task OptimizeLinq_WhenSelectorReturnsCastElement_ReplacesSelectByCast(
         string selectInvocation,
         string expectedReplacement,
@@ -1585,21 +1587,29 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     [InlineData("source.Select(dt => dt as BaseType)")]     // 'as' operator should not be replaced by Cast<>
     [InlineData("source.Select(dt => (BaseType)other)")]    // Cast of a captured parameter, not of the element itself
     [InlineData("source.Select((dt, index) => (object)index)")] // Cast of the index, not of the element itself
+    [InlineData("source.Select(dt => { count++; return (BaseType)dt; })")] // Cast<T> would remove the side effect
+    [InlineData("source.Select(dt => { if (dt.Name is not null) return (BaseType)dt; return null; })")] // Multiple return paths
+    [InlineData("source.Select(Wrap(dt => (BaseType)dt))")] // The cast is in a lambda which is not the selector
     public Task OptimizeLinq_WhenSelectorDoesNotReturnCastElement_NoDiagnosticReported(string selectInvocation)
     {
         var test = new CodeFixTest();
         test.TestCode = $$"""
+            using System;
             using System.Linq;
             class Test
             {
                 class BaseType { public string Name { get; set; } }
                 class DerivedType : BaseType {}
 
+                static int count;
+
                 public Test(object other)
                 {
                     var source = System.Linq.Enumerable.Empty<DerivedType>();
                     {{selectInvocation}};
                 }
+
+                static Func<DerivedType, BaseType> Wrap(Func<DerivedType, BaseType> selector) => selector;
             }
             """;
 


### PR DESCRIPTION
## Problem

MA0078 took the first `return` operation and the first lambda found anywhere under the `Select` selector argument, without checking that the cast was the whole selector body. The code fix then replaced `Select` with `Cast<T>()`, which could change behavior:

```csharp
static int count;

var values = new object[] { "a" }
    .Select(x => { count++; return (string)x; }).ToArray();
// Fixed to: (new object[] { "a" }).Cast<string>().ToArray();  -> count++ is silently removed
```

The same logic also reported:
- selectors with several return paths, e.g. `dt => { if (dt.Name is not null) return (BaseType)dt; return null; }`
- a cast in a lambda that is not the selector itself, e.g. `source.Select(Wrap(dt => (BaseType)dt))`

## Fix

The selector must now be a lambda passed directly as the argument (`IDelegateCreationOperation` targeting an `IAnonymousFunctionOperation`), whose body is exactly one `return` of a cast of its first parameter. The existing checks (no `as`, no numeric/user-defined conversions, enum handling) are unchanged.

`x => (T)x` and `x => { return (T)x; }` are still reported and fixed.

Note for reviewers: a lambda explicitly cast to a delegate type, such as `Select((Func<A, B>)(x => (B)x))`, may no longer be reported. This errs on the safe side, and no existing test covered it.

## Tests

- Added no-diagnostic cases for the side effect, the multiple return paths, and the nested lambda. All three fail with the previous analyzer.
- Added a code fix case for a statement-bodied selector with a single `return`.
- `OptimizeLinqUsageAnalyzerTests` (157 tests) pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9. The full suite was not run locally.

## Docs

`docs/Rules/MA0078.md` now states which selectors are reported, and its compliant example (`Cast<object>(str)`, which did not compile) is fixed.
