### PR TITLE
Fix MA0028 changing escaped braces when replacing AppendFormat with Append

### DIFF
--- a/docs/Rules/MA0028.md
+++ b/docs/Rules/MA0028.md
@@ -27,8 +27,12 @@ new StringBuilder().Append(10);
 
 ```csharp
 new StringBuilder().AppendFormat("no placeholders", arg);
+new StringBuilder().AppendFormat("{{escaped braces}}", arg);
 
 // Should be
 new StringBuilder().Append("no placeholders");
+new StringBuilder().Append("{escaped braces}");
 ```
+
+The rule does not report `AppendFormat` when the format string is invalid (e.g. `"{text}"` or `"}"`), as `AppendFormat` throws a `FormatException` for such format strings.
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
@@ -86,7 +86,26 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
                 break;
 
             case OptimizeStringBuilderUsageData.ReplaceAppendFormatWithAppend:
-                context.RegisterCodeFix(CodeAction.Create(title, ct => ReplaceAppendFormatWithAppend(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
+                var appendFormatSemanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                if (appendFormatSemanticModel?.GetOperation(nodeToFix, context.CancellationToken) is not IInvocationOperation appendFormatOperation)
+                    return;
+
+                var formatProviderType = appendFormatSemanticModel.Compilation.GetBestTypeByMetadataName("System.IFormatProvider");
+                var parameters = appendFormatOperation.TargetMethod.Parameters;
+                var formatArgIndex = parameters.Length > 0 && parameters[0].Type.IsEqualTo(formatProviderType) ? 1 : 0;
+                if (formatArgIndex >= appendFormatOperation.Arguments.Length)
+                    return;
+
+                // AppendFormat unescapes the doubled braces ("{{" and "}}"), whereas Append appends the string as-is
+                var formatArg = appendFormatOperation.Arguments[formatArgIndex].Value;
+                if (OptimizeStringBuilderUsageAnalyzerCommon.GetConstStringValue(formatArg) is not { } formatString ||
+                    !OptimizeStringBuilderUsageAnalyzerCommon.TryGetCompositeFormatLiteralText(formatString, out var literalText))
+                {
+                    return;
+                }
+
+                var formatArgReplacement = string.Equals(formatString, literalText, StringComparison.Ordinal) ? null : literalText;
+                context.RegisterCodeFix(CodeAction.Create(title, ct => ReplaceAppendFormatWithAppend(context.Document, appendFormatOperation, formatArg, formatArgReplacement, ct), equivalenceKey: title), context.Diagnostics);
                 break;
         }
     }
@@ -379,24 +398,16 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
-    private static async Task<Document> ReplaceAppendFormatWithAppend(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static async Task<Document> ReplaceAppendFormatWithAppend(Document document, IInvocationOperation operation, IOperation formatArg, string? formatArgReplacement, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         var generator = editor.Generator;
-        var operation = (IInvocationOperation?)editor.SemanticModel.GetOperation(nodeToFix, cancellationToken);
-        if (operation is null)
-            return document;
 
-        var formatProviderType = editor.SemanticModel.Compilation.GetBestTypeByMetadataName("System.IFormatProvider");
-        var parameters = operation.TargetMethod.Parameters;
-        var formatArgIndex = parameters.Length > 0 && parameters[0].Type.IsEqualTo(formatProviderType) ? 1 : 0;
-
-        var formatArg = operation.Arguments[formatArgIndex];
         var newExpression = generator.InvocationExpression(
             generator.MemberAccessExpression(operation.GetChildOperations().First().Syntax, "Append"),
-            formatArg.Value.Syntax);
+            formatArgReplacement is null ? formatArg.Syntax : generator.LiteralExpression(formatArgReplacement));
 
-        editor.ReplaceNode(nodeToFix, newExpression);
+        editor.ReplaceNode(operation.Syntax, newExpression);
         return editor.GetChangedDocument();
     }
 }

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
@@ -127,7 +127,7 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
             if (!TryGetConstStringValue(formatArg.Value, out var formatString))
                 return;
 
-            if (!OptimizeStringBuilderUsageAnalyzerCommon.HasFormatPlaceholders(formatString))
+            if (OptimizeStringBuilderUsageAnalyzerCommon.TryGetCompositeFormatLiteralText(formatString, out _))
             {
                 var properties = CreateProperties(OptimizeStringBuilderUsageData.ReplaceAppendFormatWithAppend);
                 context.ReportDiagnostic(Rule, properties, operation, "Replace AppendFormat with Append as the format string has no placeholders");

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzerCommon.cs
@@ -68,50 +68,45 @@ internal static class OptimizeStringBuilderUsageAnalyzerCommon
         return false;
     }
 
-    public static bool HasFormatPlaceholders(string formatString)
+    /// <summary>
+    /// Gets the text produced by a composite format string that contains no format item, such as <c>"{{text}}"</c> which produces <c>"{text}"</c>.
+    /// Returns <see langword="false"/> when the format string contains a format item, or when it is invalid, as the formatting methods throw a <see cref="FormatException"/> in this case.
+    /// </summary>
+    public static bool TryGetCompositeFormatLiteralText(string formatString, [NotNullWhen(true)] out string? text)
     {
-        var i = 0;
-        while (i < formatString.Length)
+        if (formatString.IndexOfAny(['{', '}']) < 0)
         {
-            var braceIndex = formatString.IndexOf('{', i, StringComparison.Ordinal);
-            if (braceIndex == -1)
-                return false;
-
-            i = braceIndex;
-
-            // Escaped opening brace
-            if (i + 1 < formatString.Length && formatString[i + 1] == '{')
-            {
-                i += 2;
-                continue;
-            }
-
-            // Check for {digit...}
-            var j = i + 1;
-            var hasDigit = false;
-            while (j < formatString.Length && formatString[j] is >= '0' and <= '9')
-            {
-                hasDigit = true;
-                j++;
-            }
-
-            if (hasDigit)
-            {
-                while (j < formatString.Length)
-                {
-                    if (formatString[j] == '}')
-                        return true;
-
-                    if (formatString[j] == '{')
-                        break;
-
-                    j++;
-                }
-            }
-
-            i++;
+            text = formatString;
+            return true;
         }
 
-        return false;
+        var sb = ObjectPool.SharedStringBuilderPool.Get();
+        try
+        {
+            for (var i = 0; i < formatString.Length; i++)
+            {
+                var c = formatString[i];
+                if (c is '{' or '}')
+                {
+                    // A brace that is not doubled starts a format item, or is invalid
+                    if (i + 1 >= formatString.Length || formatString[i + 1] != c)
+                    {
+                        text = null;
+                        return false;
+                    }
+
+                    i++;
+                }
+
+                sb.Append(c);
+            }
+
+            text = sb.ToString();
+            return true;
+        }
+        finally
+        {
+            ObjectPool.SharedStringBuilderPool.Return(sb);
+        }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -133,6 +133,130 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     }
 
     [Theory]
+    [InlineData(@"""{{text}}""", @"""{text}""")]
+    [InlineData(@"""{{0}}""", @"""{0}""")]
+    [InlineData(@"""a {{{{ b }}}} c""", @"""a {{ b }} c""")]
+    [InlineData(@"@""{{""""text""""}}""", @"""{\""text\""}""")]
+    [InlineData(@"""""""{{text}}""""""", @"""{text}""")]
+    public Task AppendFormat_NoPlaceholders_EscapedBraces_FixUnescapesBraces(string format, string expectedArgument)
+    {
+        var test = CreateTest();
+        test.TestCode = $$""""
+            using System.Text;
+            class Test
+            {
+                void A()
+                {
+                    {|MA0028:new StringBuilder().AppendFormat({{format}}, 1)|};
+                }
+            }
+            """";
+        test.FixedCode = $$""""
+            using System.Text;
+            class Test
+            {
+                void A()
+                {
+                    new StringBuilder().Append({{expectedArgument}});
+                }
+            }
+            """";
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AppendFormat_NoPlaceholders_ConstantWithEscapedBraces_FixUnescapesBraces()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Text;
+            class Test
+            {
+                const string Format = "{{text}}";
+
+                void A()
+                {
+                    {|MA0028:new StringBuilder().AppendFormat(Format, 1)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Text;
+            class Test
+            {
+                const string Format = "{{text}}";
+
+                void A()
+                {
+                    new StringBuilder().Append("{text}");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AppendFormat_NoPlaceholders_ConstantWithoutBraces_FixKeepsConstant()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Text;
+            class Test
+            {
+                const string Format = "text";
+
+                void A()
+                {
+                    {|MA0028:new StringBuilder().AppendFormat(Format, 1)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Text;
+            class Test
+            {
+                const string Format = "text";
+
+                void A()
+                {
+                    new StringBuilder().Append(Format);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData(@"""{text}""")]
+    [InlineData(@"""{""")]
+    [InlineData(@"""}""")]
+    [InlineData(@"""text}""")]
+    [InlineData(@"""{0""")]
+    [InlineData(@"""{ 0}""")]
+    [InlineData(@"""{{{text}}""")]
+    [InlineData(@"""{{0}}}""")]
+    [InlineData(@"$""{{text}}""")]
+    public Task AppendFormat_InvalidFormat_NoDiagnostic(string format)
+    {
+        var test = CreateTest();
+        test.TestCode = $$""""
+            using System.Text;
+            class Test
+            {
+                void A()
+                {
+                    new StringBuilder().AppendFormat({{format}}, 1);
+                }
+            }
+            """";
+
+        return test.RunAsync();
+    }
+
+    [Theory]
     [InlineData("10")]
     [InlineData("10 + 20")]
     [InlineData(@"""abc""")]


### PR DESCRIPTION
## Problem

MA0028 reports `AppendFormat` calls whose format string has no placeholders and offers to replace them with `Append`. The fix passed the format string to `Append` unchanged, but `AppendFormat` renders doubled braces as single braces, so the fix changed the output:

```csharp
new StringBuilder().AppendFormat("{{text}}", 1).ToString(); // "{text}"
new StringBuilder().Append("{{text}}").ToString();          // "{{text}}" (after the fix)
```

The placeholder detection only looked for `{digit…}`, so invalid format strings such as `"{text}"`, `"}"` or `$"{{text}}"` were also reported, and the fix removed the `FormatException` that `AppendFormat` throws for them.

## Changes

- **Analyzer**: `HasFormatPlaceholders` is replaced by `TryGetCompositeFormatLiteralText`, which returns the rendered text only when every brace of the format string is doubled. A single brace is either a format item or makes `AppendFormat` throw, so the call is not reported in both cases.
- **Code fix**: all the conditions are validated before registering the fix. When the rendered text differs from the format string, the argument is replaced by a literal containing the rendered text (`AppendFormat("{{text}}", 1)` → `Append("{text}")`); otherwise the original argument is kept, so constant references are preserved (`AppendFormat(Format, 1)` → `Append(Format)`).
- **Docs**: added an escaped-brace example and a note about invalid format strings to `docs/Rules/MA0028.md`.

## Tests

New tests in `OptimizeStringBuilderUsageAnalyzerTests`:
- escaped braces in regular, verbatim and raw string literals, including `"{{0}}"` and `"a {{{{ b }}}} c"`
- a constant containing escaped braces, and a constant without braces
- invalid format strings (`"{text}"`, `"{"`, `"}"`, `"text}"`, `"{0"`, `"{ 0}"`, `"{{{text}}"`, `"{{0}}}"`, `$"{{text}}"`) that must not be reported

`OptimizeStringBuilderUsageAnalyzerTests` passes on Roslyn 5.9 and 4.8 (123 tests each); the code fixers build on Roslyn 4.14, 5.0 and 5.6. I also checked at runtime that each fixed expression produces the same string as the original `AppendFormat` call, and that every format string in the invalid list throws a `FormatException`.

## Not addressed

The fix still drops the other arguments of `AppendFormat`, so their side effects (e.g. `AppendFormat("text", Foo())`) are not preserved. This is unchanged by this PR.
