### PR TITLE
Do not report MA0028 for string.Join overloads without an AppendJoin equivalent

### DIFF
--- a/docs/Rules/MA0028.md
+++ b/docs/Rules/MA0028.md
@@ -32,3 +32,12 @@ new StringBuilder().AppendFormat("no placeholders", arg);
 new StringBuilder().Append("no placeholders");
 ```
 
+
+```csharp
+new StringBuilder().Append(string.Join(", ", values));
+
+// Should be
+new StringBuilder().AppendJoin(", ", values);
+```
+
+`string.Join(separator, value, startIndex, count)` is not reported, as `AppendJoin` has no overload that takes a range.

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeStringBuilderUsageFixer.cs
@@ -295,10 +295,11 @@ public sealed class OptimizeStringBuilderUsageFixer : CodeFixProvider
         var methodName = operation.TargetMethod.Name; // Append or AppendLine
         var isAppendLine = string.Equals(methodName, nameof(StringBuilder.AppendLine), StringComparison.Ordinal);
 
-        var stringFormatOperation = (IInvocationOperation)operation.Arguments[0].Value;
+        // Use the syntax arguments, as the argument operation of an expanded params parameter is the whole invocation
+        var stringJoinSyntax = (InvocationExpressionSyntax)operation.Arguments[0].Value.Syntax;
 
         var newExpression = generator.InvocationExpression(generator.MemberAccessExpression(operation.GetChildOperations().First().Syntax, "AppendJoin"),
-            [.. stringFormatOperation.Arguments.Select(a => a.Syntax)]);
+            [.. stringJoinSyntax.ArgumentList.Arguments]);
 
         if (isAppendLine)
         {

--- a/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStringBuilderUsageAnalyzer.cs
@@ -35,7 +35,7 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
         private readonly ITypeSymbol? _stringBuilderSymbol;
         private readonly ITypeSymbol? _formatProviderSymbol;
         private readonly HashSet<ISymbol> _appendOverloadTypes = new(SymbolEqualityComparer.Default);
-        private readonly bool _hasAppendJoin;
+        private readonly IMethodSymbol[] _appendJoinMethods = [];
 
         public AnalyzerContext(Compilation compilation)
         {
@@ -44,7 +44,7 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
             if (_stringBuilderSymbol is null)
                 return;
 
-            _hasAppendJoin = _stringBuilderSymbol.GetMembers("AppendJoin").Length > 0;
+            _appendJoinMethods = [.. _stringBuilderSymbol.GetMembers("AppendJoin").OfType<IMethodSymbol>().Where(static method => !method.IsStatic && method.DeclaredAccessibility == Accessibility.Public)];
 
             _appendOverloadTypes.AddIfNotNull(_stringBuilderSymbol);
             _appendOverloadTypes.AddIfNotNull(compilation.GetSpecialType(SpecialType.System_Int16));
@@ -267,8 +267,10 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
                 }
                 else if (methodName != "Insert" && string.Equals(targetMethod.Name, nameof(string.Join), System.StringComparison.Ordinal) && targetMethod.ContainingType.IsString() && targetMethod.IsStatic)
                 {
-                    // Check if StringBuilder.AppendJoin exists
-                    if (_hasAppendJoin)
+                    // The arguments are moved to AppendJoin as-is, so it needs an overload with the same parameters.
+                    // Join(string, string[], int, int) has no counterpart, and AppendJoin(string, params object[])
+                    // would append the array and the range as three separate values.
+                    if (HasEquivalentAppendJoinOverload(targetMethod))
                     {
                         var properties = CreateProperties(OptimizeStringBuilderUsageData.ReplaceStringJoinWithAppendJoin);
                         if (string.Equals(methodName, nameof(StringBuilder.AppendLine), System.StringComparison.Ordinal))
@@ -292,6 +294,65 @@ public sealed class OptimizeStringBuilderUsageAnalyzer : DiagnosticAnalyzer
             }
 
             return false;
+        }
+
+        private bool HasEquivalentAppendJoinOverload(IMethodSymbol joinMethod)
+        {
+            foreach (var appendJoinMethod in _appendJoinMethods)
+            {
+                if (IsEquivalentAppendJoinOverload(joinMethod, appendJoinMethod))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsEquivalentAppendJoinOverload(IMethodSymbol joinMethod, IMethodSymbol appendJoinMethod)
+        {
+            if (joinMethod.Parameters.Length != appendJoinMethod.Parameters.Length)
+                return false;
+
+            // AppendJoin<T>(string, IEnumerable<T>) is the counterpart of Join<T>(string, IEnumerable<T>) and of Join(string, IEnumerable<string>)
+            if (appendJoinMethod.IsGenericMethod)
+            {
+                if (appendJoinMethod.TypeParameters is not [var typeParameter])
+                    return false;
+
+                var typeArgument = InferTypeArgument(joinMethod, appendJoinMethod, typeParameter);
+                if (typeArgument is null)
+                    return false;
+
+                appendJoinMethod = appendJoinMethod.Construct(typeArgument);
+            }
+
+            for (var i = 0; i < joinMethod.Parameters.Length; i++)
+            {
+                var joinParameter = joinMethod.Parameters[i];
+                var appendJoinParameter = appendJoinMethod.Parameters[i];
+                if (joinParameter.RefKind != appendJoinParameter.RefKind || joinParameter.IsParams != appendJoinParameter.IsParams)
+                    return false;
+
+                if (!joinParameter.Type.IsEqualTo(appendJoinParameter.Type))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static ITypeSymbol? InferTypeArgument(IMethodSymbol joinMethod, IMethodSymbol appendJoinMethod, ITypeParameterSymbol typeParameter)
+        {
+            for (var i = 0; i < appendJoinMethod.Parameters.Length; i++)
+            {
+                if (appendJoinMethod.Parameters[i].Type is INamedTypeSymbol { TypeArguments: [var appendJoinTypeArgument] } appendJoinParameterType &&
+                    appendJoinTypeArgument.IsEqualTo(typeParameter) &&
+                    joinMethod.Parameters[i].Type is INamedTypeSymbol { TypeArguments: [var joinTypeArgument] } joinParameterType &&
+                    joinParameterType.OriginalDefinition.IsEqualTo(appendJoinParameterType.OriginalDefinition))
+                {
+                    return joinTypeArgument;
+                }
+            }
+
+            return null;
         }
 
         private static bool IsConstString(IOperation operation)

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeStringBuilderUsageAnalyzerTests.cs
@@ -1018,6 +1018,68 @@ public sealed class OptimizeStringBuilderUsageAnalyzerTests
     }
 
     [Fact]
+    public Task Append_StringJoin_Range_NoDiagnostic()
+    {
+        // AppendJoin has no overload with a range, so AppendJoin(",", array, 1, 2) would append "System.String[],1,2"
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Text;
+            class Test
+            {
+                void A(string[] values)
+                {
+                    new StringBuilder().Append(string.Join(",", values, 1, 2));
+                    new StringBuilder().AppendLine(string.Join(',', values, 1, 2));
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Append_StringJoin_AppendJoin_AllOverloads()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Text;
+            class Test
+            {
+                void A(string[] strings, object[] objects, IEnumerable<string> stringEnumerable, List<int> ints, string a, object b)
+                {
+                    {|MA0028:new StringBuilder().Append(string.Join(",", strings))|};
+                    {|MA0028:new StringBuilder().Append(string.Join(',', strings))|};
+                    {|MA0028:new StringBuilder().Append(string.Join(",", objects))|};
+                    {|MA0028:new StringBuilder().Append(string.Join(",", stringEnumerable))|};
+                    {|MA0028:new StringBuilder().Append(string.Join(',', ints))|};
+                    {|MA0028:new StringBuilder().Append(string.Join(",", a, a))|};
+                    {|MA0028:new StringBuilder().Append(string.Join(',', a, b))|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Collections.Generic;
+            using System.Text;
+            class Test
+            {
+                void A(string[] strings, object[] objects, IEnumerable<string> stringEnumerable, List<int> ints, string a, object b)
+                {
+                    new StringBuilder().AppendJoin(",", strings);
+                    new StringBuilder().AppendJoin(',', strings);
+                    new StringBuilder().AppendJoin(",", objects);
+                    new StringBuilder().AppendJoin(",", stringEnumerable);
+                    new StringBuilder().AppendJoin(',', ints);
+                    new StringBuilder().AppendJoin(",", a, a);
+                    new StringBuilder().AppendJoin(',', a, b);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task AppendLine_AppendSubString()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

MA0028 suggested replacing `sb.Append(string.Join(...))` with `sb.AppendJoin(...)` whenever `StringBuilder.AppendJoin` existed, and the fixer copied the `string.Join` arguments unchanged. `string.Join(separator, value, startIndex, count)` has no `AppendJoin` counterpart, so the rewritten call silently bound to `AppendJoin(string, params object[])`:

```csharp
new StringBuilder().Append(string.Join(",", new[] { "a", "b", "c" }, 1, 2));   // "b,c"
new StringBuilder().AppendJoin(",", new[] { "a", "b", "c" }, 1, 2);             // "System.String[],1,2"
```

Both versions compile, so the behavior change went unnoticed.

## Changes

- **Analyzer**: reports only when an `AppendJoin` overload has the same parameters (count, types, ref kind, `params`) as the called `string.Join` overload. For the generic `AppendJoin<T>(separator, IEnumerable<T>)`, `T` is inferred from the `Join` call, so both `Join<T>(separator, IEnumerable<T>)` and `Join(separator, IEnumerable<string>)` still match. The ranged overloads (string and char separators) are no longer reported.
- **Fixer**: for an expanded `params` call such as `string.Join(",", a, b)`, the fix produced `AppendJoin(",", string.Join(",", a, b))`, because the argument operation of an expanded params parameter has the whole invocation as its syntax. It now copies the syntax arguments, like the `AppendFormat` fix does.
- **Docs**: `docs/Rules/MA0028.md` documents the `string.Join` → `AppendJoin` rewrite and the range exclusion.

## Tests

- `Append_StringJoin_Range_NoDiagnostic` covers the ranged overloads with string and char separators through `Append` and `AppendLine`. It fails against the previous analyzer.
- `Append_StringJoin_AppendJoin_AllOverloads` checks that the other overloads (arrays, `IEnumerable<string>`, generic `List<int>`, expanded params) are still reported and fixed correctly.

`OptimizeStringBuilderUsageAnalyzerTests` passes on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9 (109 tests each). The full test suite was not run locally.

## Note for reviewers

Not addressed here: the fix keeps argument names, and `string.Join` names its array parameter `value` while `AppendJoin` uses `values`, so a named-argument call like `string.Join(",", value: arr)` would likely produce code that doesn't compile. That's unverified and left for a follow-up.
