### PR TITLE
Do not report MA0158 when the value cannot be migrated to System.Threading.Lock

### DIFF
--- a/docs/Rules/MA0158.md
+++ b/docs/Rules/MA0158.md
@@ -5,6 +5,8 @@ Sources: [UseSystemThreadingLockInsteadOfObjectAnalyzer.cs](https://github.com/m
 
 Starting with .NET 9 and C# 13, you can use `System.Threading.Lock`. When a field or a local variable is only used inside `lock`, this rule will suggest using `System.Threading.Lock` instead of `object`.
 
+The rule is not reported when the field or the local variable gets a value that cannot be migrated to `System.Threading.Lock`, such as the result of a method call or a parameter, as the object may be shared with code that locks on it. The supported values are `new object()`, `new()`, `null`, `default`, and values of type `System.Threading.Lock`.
+
 ````c#
 using System.Threading;
 

--- a/src/Meziantou.Analyzer/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzer.cs
@@ -26,7 +26,8 @@ public sealed class UseSystemThreadingLockInsteadOfObjectAnalyzer : DiagnosticAn
 
         context.RegisterCompilationStartAction(context =>
         {
-            if (context.Compilation.GetBestTypeByMetadataName("System.Threading.Lock") is null)
+            var lockType = context.Compilation.GetBestTypeByMetadataName("System.Threading.Lock");
+            if (lockType is null)
                 return;
 
             if (!context.Compilation.GetCSharpLanguageVersion().IsCSharp13OrGreater())
@@ -38,20 +39,22 @@ public sealed class UseSystemThreadingLockInsteadOfObjectAnalyzer : DiagnosticAn
                 {
                     if (block.Syntax is StatementSyntax or ExpressionSyntax)
                     {
-                        var symbols = new SymbolLockContext();
+                        var symbols = new SymbolLockContext(lockType);
                         context.RegisterOperationAction(context => symbols.HandleOperation((ILocalReferenceOperation)context.Operation), OperationKind.LocalReference);
+                        context.RegisterOperationAction(context => symbols.HandleOperation((IVariableDeclaratorOperation)context.Operation), OperationKind.VariableDeclarator);
                         context.RegisterOperationBlockEndAction(context => symbols.ReportSymbols(context, Rule));
                     }
                 }
             });
 
-            var symbols = new SymbolLockContext();
+            var symbols = new SymbolLockContext(lockType);
             context.RegisterOperationAction(context => symbols.HandleOperation((IFieldReferenceOperation)context.Operation), OperationKind.FieldReference);
+            context.RegisterOperationAction(context => symbols.HandleOperation((IFieldInitializerOperation)context.Operation), OperationKind.FieldInitializer);
             context.RegisterCompilationEndAction(context => symbols.ReportSymbols(context, Rule));
         });
     }
 
-    private sealed class SymbolLockContext
+    private sealed class SymbolLockContext(INamedTypeSymbol lockType)
     {
         private readonly ConcurrentDictionary<ISymbol, bool> _symbols = new(SymbolEqualityComparer.Default);
 
@@ -71,10 +74,45 @@ public sealed class UseSystemThreadingLockInsteadOfObjectAnalyzer : DiagnosticAn
             if (symbol is IFieldSymbol { Type.SpecialType: SpecialType.System_Object } && !symbol.IsVisibleOutsideOfAssembly())
                 return true;
 
-            if (symbol is ILocalSymbol { Type.SpecialType: SpecialType.System_Object })
+            // Only the locals declared by a variable declaration can be declared with a different type.
+            // For instance, the type of a foreach variable or of a pattern variable is tied to the value it gets.
+            if (symbol is ILocalSymbol { Type.SpecialType: SpecialType.System_Object, DeclaringSyntaxReferences: [var syntaxReference] } && syntaxReference.GetSyntax() is VariableDeclaratorSyntax)
                 return true;
 
             return false;
+        }
+
+        // The value must still be valid once the type of the symbol is System.Threading.Lock.
+        // The code fixer replaces the creation of an object with `new()`, the other values are kept as-is.
+        private bool IsSupportedValue(IOperation value)
+        {
+            return value.UnwrapImplicitConversions() switch
+            {
+                IObjectCreationOperation { Type.SpecialType: SpecialType.System_Object } => true,
+                ILiteralOperation operation when operation.IsNull() => true,
+                IDefaultValueOperation { Syntax: LiteralExpressionSyntax } => true,
+                var operation => operation.Type.IsEqualTo(lockType),
+            };
+        }
+
+        public void HandleOperation(IFieldInitializerOperation operation)
+        {
+            foreach (var field in operation.InitializedFields)
+            {
+                if (IsPotentialSymbol(field) && !IsSupportedValue(operation.Value))
+                {
+                    ExcludeSymbol(field);
+                }
+            }
+        }
+
+        public void HandleOperation(IVariableDeclaratorOperation operation)
+        {
+            var symbol = operation.Symbol;
+            if (IsPotentialSymbol(symbol) && operation.GetVariableInitializer() is { } initializer && !IsSupportedValue(initializer.Value))
+            {
+                ExcludeSymbol(symbol);
+            }
         }
 
         public void HandleOperation(ILocalReferenceOperation operation)
@@ -94,9 +132,16 @@ public sealed class UseSystemThreadingLockInsteadOfObjectAnalyzer : DiagnosticAn
             if (!IsPotentialSymbol(symbol))
                 return;
 
-            // Assignment targets (e.g., initializations in constructors) are not usages
-            if (operation.Parent is IAssignmentOperation { Target: var assignTarget } && assignTarget == operation)
+            // Assignment targets (e.g., initializations in constructors) are not usages, but the assigned value must be compatible with the new type
+            if (operation.Parent is IAssignmentOperation assignment && assignment.Target == operation)
+            {
+                if (assignment is not (ISimpleAssignmentOperation or ICoalesceAssignmentOperation) || !IsSupportedValue(assignment.Value))
+                {
+                    ExcludeSymbol(symbol);
+                }
+
                 return;
+            }
 
             if (operation.Parent is not ILockOperation)
             {

--- a/tests/Meziantou.Analyzer.Test/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzerTests.cs
@@ -91,6 +91,71 @@ public sealed class UseSystemThreadingLockInsteadOfObjectAnalyzerTests
         return test.RunAsync();
     }
 
+    [Theory]
+    [InlineData("null")]
+    [InlineData("default")]
+    [InlineData("new System.Threading.Lock()")]
+    public Task Field_OnlyLockUsage_InitializerCompatibleWithLock(string value)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            class TypeName
+            {
+                object {|MA0158:_lock|} = {{value}};
+
+                void A() { lock(_lock) { } }
+            }
+            """;
+        test.FixedCode = $$"""
+            class TypeName
+            {
+                System.Threading.Lock _lock = {{value}};
+
+                void A() { lock(_lock) { } }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("CreateGate()")]
+    [InlineData("default(object)")]
+    [InlineData("(object)null")]
+    [InlineData("new object[0]")]
+    public Task Field_OnlyLockUsage_InitializerNotCompatibleWithLock(string value)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            class TypeName
+            {
+                object _lock = {{value}};
+
+                static object CreateGate() => new object();
+                void A() { lock(_lock) { } }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Field_OnlyLockUsage_OneInitializerNotCompatibleWithLock()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                object _lock1 = CreateGate(), {|MA0158:_lock2|} = new object();
+
+                static object CreateGate() => new object();
+                void A() { lock(_lock1) { } lock(_lock2) { } }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Fact]
     public Task Field_OnlyLockUsage_NET8()
     {
@@ -222,6 +287,83 @@ public sealed class UseSystemThreadingLockInsteadOfObjectAnalyzerTests
     }
 
     [Fact]
+    public Task LocalVariable_InitializerNotCompatibleWithLock()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                void A(object value)
+                {
+                    var o = value;
+                    lock(o) { }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task LocalVariable_AssignmentNotCompatibleWithLock()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                void A(object value)
+                {
+                    object o = null;
+                    o = value;
+                    lock(o) { }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task LocalVariable_ForEach()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                void A(object[] values)
+                {
+                    foreach (var o in values)
+                    {
+                        lock(o) { }
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task LocalVariable_Pattern()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class TypeName
+            {
+                void A(object value)
+                {
+                    if (value is object o)
+                    {
+                        lock(o) { }
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task LocalVariable_LockAndOtherUsages()
     {
         var test = CreateTest();
@@ -336,6 +478,84 @@ public sealed class UseSystemThreadingLockInsteadOfObjectAnalyzerTests
                 {
                     lock (_lock) { }
                     _lock.ToString();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Field_InitializedInConstructorFromParameter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public sealed class A
+            {
+                private readonly object _lock;
+
+                public A(object gate)
+                {
+                    _lock = gate;
+                }
+
+                public void Run()
+                {
+                    lock (_lock) { }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Field_InitializedWithCoalesceAssignment()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public sealed class A
+            {
+                private object {|MA0158:_lock|};
+
+                public void Run()
+                {
+                    _lock ??= new object();
+                    lock (_lock) { }
+                }
+            }
+            """;
+        test.FixedCode = """
+            public sealed class A
+            {
+                private System.Threading.Lock _lock;
+
+                public void Run()
+                {
+                    _lock ??= new();
+                    lock (_lock) { }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Field_InitializedWithObjectInitializer()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public sealed class A
+            {
+                private object _lock;
+
+                public static A Create() => new A { _lock = CreateGate() };
+                static object CreateGate() => new object();
+
+                public void Run()
+                {
+                    lock (_lock) { }
                 }
             }
             """;


### PR DESCRIPTION
## Problem

MA0158 tracked how a field or local was used, but never checked the values it was given. The code fix changed the declared type to `System.Threading.Lock` and rewrote the initializer only when it was a direct object creation, so this code:

```csharp
public class Sample
{
    private readonly object gate = CreateGate();
    static object CreateGate() => new object();
    public void Run() { lock (gate) { } }
}
```

became `private readonly System.Threading.Lock gate = CreateGate();`, which fails with CS0266. The same happened with values assigned from a parameter, `default(object)`, `(object)null`, and so on.

## Fix

The check is in the analyzer, not the code fix. A value that comes from a factory or a parameter may be shared with code that locks on it, so replacing it with a new `Lock` would change behavior even if the result compiled.

The analyzer now checks field initializers, local variable initializers, and assignments (constructors, object initializers, `??=`). It reports only when every value is one of:
- `new object()` / `new()`: the fix rewrites these to `new()`
- `null`, `default`, or a value that is already a `System.Threading.Lock`: the fix keeps these unchanged, and they still compile

Locals declared by `foreach` or by a pattern (`value is object o`) are no longer reported, because their type can't be changed.

`docs/Rules/MA0158.md` now describes which values the rule accepts.

## Tests

Added 15 cases to `UseSystemThreadingLockInsteadOfObjectAnalyzerTests`: the factory reproduction, other incompatible values, compatible values with the expected fix, a declaration with several fields where only one is compatible, and the `foreach` / pattern locals. 11 of them fail against the previous analyzer.

- MA0158 tests: 37/37 pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9
- Full Roslyn 5.9 test project: 4395/4395 pass
- `dotnet run --project src/DocumentationGenerator`: no changes

## Known gap (not addressed here)

The code fix only rewrites `new object()` assignments in the document that declares the field. A partial class or a derived class that assigns the field in another file still produces CS0029 after the fix. This problem predates this PR and is tracked separately.
