### PR TITLE
Fix MA0158 code fix when the field is assigned in another document

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseSystemThreadingLockInsteadOfObjectFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseSystemThreadingLockInsteadOfObjectFixer.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -29,7 +30,7 @@ public sealed class UseSystemThreadingLockInsteadOfObjectFixer : CodeFixProvider
         if (variableDeclarator is null)
             return;
 
-        if (semanticModel.GetDeclaredSymbol(variableDeclarator, context.CancellationToken) is null)
+        if (semanticModel.GetDeclaredSymbol(variableDeclarator, context.CancellationToken) is not { } symbol)
             return;
 
         if (variableDeclarator.Parent is not VariableDeclarationSyntax { } declaration || declaration.Variables.Count != 1)
@@ -37,49 +38,53 @@ public sealed class UseSystemThreadingLockInsteadOfObjectFixer : CodeFixProvider
 
         const string Title = "Use System.Threading.Lock";
         context.RegisterCodeFix(
-            CodeAction.Create(Title, ct => UseLockType(context.Document, nodeToFix, lockType, ct), equivalenceKey: Title),
+            CodeAction.Create(Title, ct => UseLockType(context.Document, declaration, symbol, lockType, ct), equivalenceKey: Title),
             context.Diagnostics);
     }
 
-    private static async Task<Document> UseLockType(Document document, SyntaxNode nodeToFix, INamedTypeSymbol lockType, CancellationToken cancellationToken)
+    private static async Task<Solution> UseLockType(Document document, VariableDeclarationSyntax declaration, ISymbol symbol, INamedTypeSymbol lockType, CancellationToken cancellationToken)
     {
-        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-
-        var variableDeclarator = nodeToFix.FirstAncestorOrSelf<VariableDeclaratorSyntax>();
-        if (variableDeclarator is null)
-            return document;
-
-        if (editor.SemanticModel.GetDeclaredSymbol(variableDeclarator, cancellationToken) is not ISymbol symbol)
-            return document;
-
-        if (variableDeclarator.Parent is not VariableDeclarationSyntax declaration || declaration.Variables.Count != 1)
-            return document;
+        var solution = document.Project.Solution;
+        var solutionEditor = new SolutionEditor(solution);
+        var editor = await solutionEditor.GetDocumentEditorAsync(document.Id, cancellationToken).ConfigureAwait(false);
 
         editor.ReplaceNode(
             declaration.Type,
             ((TypeSyntax)editor.Generator.TypeExpression(lockType)).WithTriviaFrom(declaration.Type).WithAdditionalAnnotations(Formatter.Annotation));
 
+        var variableDeclarator = declaration.Variables[0];
         if (variableDeclarator.Initializer is not null && IsObjectCreation(editor.SemanticModel, variableDeclarator.Initializer.Value, cancellationToken))
         {
             editor.ReplaceNode(variableDeclarator.Initializer.Value, ImplicitObjectCreationExpression().WithTriviaFrom(variableDeclarator.Initializer.Value));
         }
 
-        foreach (var assignment in editor.OriginalRoot.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        // The field can be assigned in another document, such as another part of a partial class or a derived class
+        var references = await SymbolFinder.FindReferencesAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
+        foreach (var location in references.SelectMany(reference => reference.Locations))
         {
-            var leftSymbol = editor.SemanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol;
-            if (!SymbolEqualityComparer.Default.Equals(leftSymbol, symbol))
+            // Source generated documents cannot be edited
+            if (solution.GetDocument(location.Document.Id) is null)
                 continue;
 
-            if (!IsObjectCreation(editor.SemanticModel, assignment.Right, cancellationToken))
+            var referenceEditor = await solutionEditor.GetDocumentEditorAsync(location.Document.Id, cancellationToken).ConfigureAwait(false);
+            var reference = referenceEditor.OriginalRoot.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
+            if (reference.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == reference)
+            {
+                reference = memberAccess;
+            }
+
+            if (reference.Parent is not AssignmentExpressionSyntax assignment || assignment.Left != reference)
                 continue;
 
-            editor.ReplaceNode(assignment.Right, ImplicitObjectCreationExpression().WithTriviaFrom(assignment.Right));
+            if (!IsObjectCreation(referenceEditor.SemanticModel, assignment.Right, cancellationToken))
+                continue;
+
+            referenceEditor.ReplaceNode(assignment.Right, ImplicitObjectCreationExpression().WithTriviaFrom(assignment.Right));
         }
 
-        return editor.GetChangedDocument();
+        return solutionEditor.GetChangedSolution();
 
         static bool IsObjectCreation(SemanticModel semanticModel, ExpressionSyntax expression, CancellationToken cancellationToken)
             => semanticModel.GetOperation(expression, cancellationToken) is IObjectCreationOperation { Type.SpecialType: SpecialType.System_Object };
-
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseSystemThreadingLockInsteadOfObjectAnalyzerTests.cs
@@ -344,6 +344,96 @@ public sealed class UseSystemThreadingLockInsteadOfObjectAnalyzerTests
     }
 
     [Fact]
+    public Task Field_PartialClass_InitializedInConstructorInAnotherDocument()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            partial class A
+            {
+                private readonly object {|MA0158:_lock|};
+
+                public void Run()
+                {
+                    lock (_lock) { }
+                }
+            }
+            """;
+        test.TestState.Sources.Add("""
+            partial class A
+            {
+                public A()
+                {
+                    _lock = new object();
+                }
+            }
+            """);
+        test.FixedCode = """
+            partial class A
+            {
+                private readonly System.Threading.Lock _lock;
+
+                public void Run()
+                {
+                    lock (_lock) { }
+                }
+            }
+            """;
+        test.FixedState.Sources.Add("""
+            partial class A
+            {
+                public A()
+                {
+                    _lock = new();
+                }
+            }
+            """);
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Field_AssignedInDerivedClassInAnotherDocument()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class BaseClass
+            {
+                private protected object {|MA0158:_lock|} = new object();
+
+                void A() { lock(_lock) { } }
+            }
+            """;
+        test.TestState.Sources.Add("""
+            class ChildClass : BaseClass
+            {
+                public ChildClass()
+                {
+                    this._lock = new object();
+                }
+            }
+            """);
+        test.FixedCode = """
+            class BaseClass
+            {
+                private protected System.Threading.Lock _lock = new();
+
+                void A() { lock(_lock) { } }
+            }
+            """;
+        test.FixedState.Sources.Add("""
+            class ChildClass : BaseClass
+            {
+                public ChildClass()
+                {
+                    this._lock = new();
+                }
+            }
+            """);
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task StaticField_InitializedInStaticConstructor_OnlyLockUsage()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

The MA0158 code fix changes the type of a field from `object` to `System.Threading.Lock`, then rewrites the `new object()` assignments of that field to `new()`. It only looked for those assignments in the document declaring the field, as it iterated `editor.OriginalRoot.DescendantNodes().OfType<AssignmentExpressionSyntax>()`.

When the field was assigned in another document, the assignment was left unchanged and the fixed code failed with `CS0029`. Two cases:

- a `partial` class whose constructor in another file does `_lock = new object();`
- a `private protected` field assigned in a derived class in another file

## Changes

The code fix is now solution wide:

- It returns a `Solution` and uses a `SolutionEditor`. The references of the field are found with `SymbolFinder.FindReferencesAsync`, so the assignments are rewritten in every document of the solution.
- A reference is rewritten only when it is the left side of an assignment (`_lock` or `this._lock`) and the right side creates a plain `object`. These are the same conditions as before, just no longer limited to one document.
- Source generated documents are skipped, as they cannot be edited.
- The declared symbol resolved in `RegisterCodeFixesAsync` is passed to the fix, so the fix no longer re-validates anything and can no longer return an unchanged document, per the "validate before registering" guidance of `AGENTS.md`.

Two regression tests with multiple documents cover the two cases above, the second one using `this._lock` to also cover a member access.

## Notes for the reviewer

- Both new tests fail against the previous code fix and pass with this change.
- All 24 tests of the class pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- `dotnet run --project src/DocumentationGenerator` reports no change. `docs/Rules/MA0158.md` does not document how far the code fix reaches, so it needed no update.
- One pre-existing gap is left out of scope, as it happens within a single document too: when the field is assigned something that is not a `new object()` (for example `_lock = GetObject();`), the code fix still changes the type and leaves that assignment failing to compile.