### PR TITLE
Do not report MA0173 when the return value of CompareExchange is used

### DIFF
--- a/docs/Rules/MA0173.md
+++ b/docs/Rules/MA0173.md
@@ -8,3 +8,12 @@ Interlocked.CompareExchange(ref _field, new Sample(), null); // non-compliant
 LazyInitializer.EnsureInitialized(ref _field, () => new Sample()); // compliant
 ```
 
+The rule is not reported when the return value of `Interlocked.CompareExchange` is used, as `Interlocked.CompareExchange` returns the previous value of the target whereas `LazyInitializer.EnsureInitialized` returns the initialized value.
+
+```c#
+// compliant as the return value is used to detect which caller initialized the value
+if (Interlocked.CompareExchange(ref _field, new Sample(), null) is null)
+{
+    // ...
+}
+```

--- a/src/Meziantou.Analyzer/Rules/UseLazyInitializerEnsureInitializeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLazyInitializerEnsureInitializeAnalyzer.cs
@@ -38,6 +38,11 @@ public class UseLazyInitializerEnsureInitializeAnalyzer : DiagnosticAnalyzer
                     if (operation.Arguments[0].Value.Type is not { IsReferenceType: true })
                         return;
 
+                    // Interlocked.CompareExchange returns the previous value of the target, whereas
+                    // LazyInitializer.EnsureInitialized returns the initialized value
+                    if (IsReturnValueUsed(operation))
+                        return;
+
                     var value = operation.Arguments[1].Value.UnwrapImplicitConversions();
                     if (value is IObjectCreationOperation or ILocalReferenceOperation)
                     {
@@ -48,4 +53,12 @@ public class UseLazyInitializerEnsureInitializeAnalyzer : DiagnosticAnalyzer
         });
     }
 
+    private static bool IsReturnValueUsed(IInvocationOperation operation)
+    {
+        var parent = operation.Parent;
+        if (parent is ISimpleAssignmentOperation { Target: IDiscardOperation })
+            return false;
+
+        return parent is not (null or IBlockOperation or IExpressionStatementOperation);
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseLazyInitializerEnsureInitializeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseLazyInitializerEnsureInitializeAnalyzerTests.cs
@@ -123,6 +123,47 @@ public sealed class UseLazyInitializerEnsureInitializeAnalyzerTests
     }
 
     [Fact]
+    public Task ReturnValueIsUsed()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            object a = default;
+            System.Console.WriteLine(System.Threading.Interlocked.CompareExchange(ref a, new object(), null) is null);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReturnValueIsAssignedToAVariable()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            object a = default;
+            object previous = System.Threading.Interlocked.CompareExchange(ref a, new object(), null);
+            System.Console.WriteLine(previous);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReturnValueIsDiscarded()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            object a = default;
+            _ = {|MA0173:System.Threading.Interlocked.CompareExchange(ref a, new object(), null)|};
+            """;
+        test.FixedCode = """
+            object a = default;
+            _ = System.Threading.LazyInitializer.EnsureInitialized(ref a, () => new object());
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task NewCustomStruct()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

MA0173 (`Use LazyInitializer.EnsureInitialize`) is no longer reported when the return value of `Interlocked.CompareExchange` is used.

## Why

`Interlocked.CompareExchange` returns the **previous** value of the target, whereas `LazyInitializer.EnsureInitialized` returns the **initialized** value. The code fix replaced one invocation with the other without preserving this distinction, so it silently changed the behavior of code that uses the return value to determine which caller initialized the value:

```csharp
object target = null;
return Interlocked.CompareExchange(ref target, new object(), null) is null; // true
```

was rewritten to:

```csharp
return LazyInitializer.EnsureInitialized(ref target, () => new object()) is null; // false
```

Both versions compile, so the regression was invisible at build time.

There is no correct rewrite when the return value is observed, so the fix is in the analyzer rather than in the code fixer: the diagnostic is no longer reported at all in that case.

## Notes for the reviewer

- `IsReturnValueUsed` considers the value unused when the parent operation is `null`, an `IBlockOperation` or an `IExpressionStatementOperation`.
- A discarded return value (`_ = Interlocked.CompareExchange(...)`) is still reported: the value is not observed, and the rewritten code keeps discarding it.
- The two other concerns raised in the report do not need a change: the factory moving from eager to lazy evaluation is the very point of the rule, and the analyzer already requires the comparand to be `null`, which matches the null check of `EnsureInitialized`.
- `docs/Rules/MA0173.md` documents the exclusion. `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown change.

## Tests

Three cases added to `UseLazyInitializerEnsureInitializeAnalyzerTests`: the reported `is null` repro and an assignment to a variable (no diagnostic), and a discarded return value (still diagnosed and fixed).

- `UseLazyInitializerEnsureInitializeAnalyzerTests` on all five Roslyn versions: 50 passed, 0 failed, 0 skipped.
- Full suite on Roslyn 5.9: 4383 passed, 0 failed, 0 skipped.