### PR TITLE
Do not report MA0066 on ImmutableSortedDictionary

### DIFF
--- a/docs/Rules/MA0066.md
+++ b/docs/Rules/MA0066.md
@@ -9,8 +9,11 @@ Hash-based collections call `GetHashCode`/`Equals` frequently. When a struct key
 This rule reports usage of such structs in:
 
 - `HashSet<T>`, `Dictionary<TKey, TValue>`, `ConcurrentDictionary<TKey, TValue>`
-- immutable hash/dictionary factory methods (`Create`, `CreateBuilder`, `CreateRange`)
-- immutable `.Empty` instances used without `WithComparer` / `WithComparers`
+- `ImmutableHashSet` / `ImmutableDictionary` factory methods (`Create`, `CreateBuilder`, `CreateRange`)
+- `ImmutableHashSet<T>.Empty` / `ImmutableDictionary<TKey, TValue>.Empty` used without `WithComparer` / `WithComparers`
+
+Sorted collections such as `ImmutableSortedDictionary<TKey, TValue>` are not reported: they order and locate
+their keys with an `IComparer<TKey>` and never hash them, so the equality members of the key are irrelevant.
 
 Use one of these fixes:
 

--- a/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
@@ -43,11 +43,9 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
     {
         public Compilation Compilation { get; }
         private INamedTypeSymbol? IEqualityComparerSymbol { get; }
-        private INamedTypeSymbol? IComparerSymbol { get; }
         private ITypeSymbol? ValueTypeSymbol { get; }
         private ITypeSymbol? ImmutableDictionarySymbol { get; }
         private ITypeSymbol? ImmutableHashSetSymbol { get; }
-        private ITypeSymbol? ImmutableSortedDictionarySymbol { get; }
         private IMethodSymbol? ValueTypeEqualsSymbol { get; }
         private IMethodSymbol? ValueTypeGetHashCodeSymbol { get; }
         private ITypeSymbol[] HashSetSymbols { get; }
@@ -55,7 +53,6 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
         public Context(Compilation compilation)
         {
             IEqualityComparerSymbol = compilation.GetBestTypeByMetadataName("System.Collections.Generic.IEqualityComparer`1");
-            IComparerSymbol = compilation.GetBestTypeByMetadataName("System.Collections.Generic.IComparer`1");
             ValueTypeSymbol = compilation.GetBestTypeByMetadataName("System.ValueType");
             if (ValueTypeSymbol is not null)
             {
@@ -65,7 +62,6 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
 
             ImmutableDictionarySymbol = compilation.GetBestTypeByMetadataName("System.Collections.Immutable.ImmutableDictionary");
             ImmutableHashSetSymbol = compilation.GetBestTypeByMetadataName("System.Collections.Immutable.ImmutableHashSet");
-            ImmutableSortedDictionarySymbol = compilation.GetBestTypeByMetadataName("System.Collections.Immutable.ImmutableSortedDictionary");
 
             var types = new List<ITypeSymbol>();
             types.AddIfNotNull(compilation.GetBestTypeByMetadataName("System.Collections.Generic.HashSet`1"));
@@ -73,7 +69,6 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
             types.AddIfNotNull(compilation.GetTypesByMetadataName("System.Collections.Concurrent.ConcurrentDictionary`2"));
             types.AddIfNotNull(compilation.GetTypesByMetadataName("System.Collections.Immutable.ImmutableHashSet`1"));
             types.AddIfNotNull(compilation.GetTypesByMetadataName("System.Collections.Immutable.ImmutableDictionary`2"));
-            types.AddIfNotNull(compilation.GetTypesByMetadataName("System.Collections.Immutable.ImmutableSortedDictionary`2"));
             HashSetSymbols = [.. types];
             Compilation = compilation;
         }
@@ -109,16 +104,8 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
                 var type = operation.TargetMethod.TypeArguments[0];
                 if (IsStruct(type) && HasDefaultEqualsOrHashCodeImplementations(type))
                 {
-                    if (operation.TargetMethod.ContainingType.IsEqualTo(ImmutableSortedDictionarySymbol))
-                    {
-                        if (operation.TargetMethod.Parameters.Any(arg => arg.Type.IsEqualTo(IComparerSymbol?.Construct(type))))
-                            return;
-                    }
-                    else
-                    {
-                        if (operation.TargetMethod.Parameters.Any(arg => arg.Type.IsEqualTo(IEqualityComparerSymbol?.Construct(type))))
-                            return;
-                    }
+                    if (operation.TargetMethod.Parameters.Any(arg => arg.Type.IsEqualTo(IEqualityComparerSymbol?.Construct(type))))
+                        return;
 
                     context.ReportDiagnostic(Rule2, operation);
                 }
@@ -137,7 +124,6 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
                 {
                         ImmutableDictionarySymbol,
                         ImmutableHashSetSymbol,
-                        ImmutableSortedDictionarySymbol,
                     };
 
                 return methodSymbol.Arity >= 1 && names.Contains(methodSymbol.Name, StringComparer.Ordinal) && builderTypes.Any(type => type.IsEqualTo(methodSymbol.ContainingType.OriginalDefinition));

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzerTests.cs
@@ -230,10 +230,8 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzerTests
     [InlineData("new System.Collections.Concurrent.ConcurrentDictionary<Test, object>()")]
     [InlineData("System.Collections.Immutable.ImmutableHashSet.Create<Test>()")]
     [InlineData("System.Collections.Immutable.ImmutableDictionary.Create<Test, object>()")]
-    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary.Create<Test, object>()")]
     [InlineData("System.Collections.Immutable.ImmutableHashSet<Test>.Empty")]
     [InlineData("System.Collections.Immutable.ImmutableDictionary<Test, object>.Empty")]
-    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary<Test, object>.Empty")]
     public Task Constructor_DefaultImplementation(string text)
     {
         var test = new AnalyzerTest();
@@ -270,7 +268,6 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzerTests
 
     [Theory]
     [InlineData("System.Collections.Immutable.ImmutableDictionary<Test, object>.Empty")]
-    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary<Test, object>.Empty")]
     public Task Empty_WithComparers(string text)
     {
         var test = new AnalyzerTest();
@@ -293,10 +290,8 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzerTests
     [InlineData("new System.Collections.Concurrent.ConcurrentDictionary<Test, object>()")]
     [InlineData("System.Collections.Immutable.ImmutableHashSet.Create<Test>()")]
     [InlineData("System.Collections.Immutable.ImmutableDictionary.Create<Test, object>()")]
-    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary.Create<Test, object>()")]
     [InlineData("System.Collections.Immutable.ImmutableHashSet<Test>.Empty")]
     [InlineData("System.Collections.Immutable.ImmutableDictionary<Test, object>.Empty")]
-    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary<Test, object>.Empty")]
     public Task Constructor_EqualsOverriden(string text)
     {
         var test = new AnalyzerTest();
@@ -322,8 +317,49 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzerTests
     [InlineData("new System.Collections.Concurrent.ConcurrentDictionary<Test, object>(System.Collections.Generic.EqualityComparer<Test>.Default)")]
     [InlineData("System.Collections.Immutable.ImmutableHashSet.Create<Test>(System.Collections.Generic.EqualityComparer<Test>.Default)")]
     [InlineData("System.Collections.Immutable.ImmutableDictionary.Create<Test, object>(System.Collections.Generic.EqualityComparer<Test>.Default)")]
-    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary.Create<Test, object>(null, System.Collections.Generic.EqualityComparer<object>.Default)")]
     public Task Constructor_EqualityComparer(string text)
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = $$"""
+            struct Test
+            {
+                void A()
+                {
+                    _ = {{text}};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary.Create<Test, object>()")]
+    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary.CreateBuilder<Test, object>()")]
+    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary.CreateRange<Test, object>(default)")]
+    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary<Test, object>.Empty")]
+    public Task SortedDictionary_DefaultImplementation(string text)
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = $$"""
+            struct Test : System.IComparable<Test>
+            {
+                public int CompareTo(Test other) => throw null;
+
+                void A()
+                {
+                    _ = {{text}};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary.Create<Test, object>()")]
+    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary<Test, object>.Empty")]
+    public Task SortedDictionary_NotComparable(string text)
     {
         var test = new AnalyzerTest();
         test.TestCode = $$"""
@@ -345,7 +381,6 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzerTests
     [InlineData("new System.Collections.Concurrent.ConcurrentDictionary<Test, object>()")]
     [InlineData("System.Collections.Immutable.ImmutableHashSet.Create<Test>()")]
     [InlineData("System.Collections.Immutable.ImmutableDictionary.Create<Test, object>()")]
-    [InlineData("System.Collections.Immutable.ImmutableSortedDictionary.Create<Test, object>()")]
     public Task Constructor_Enum(string text)
     {
         var test = new AnalyzerTest();


### PR DESCRIPTION
## What

MA0066 (*Hash table unfriendly type is used in a hash table*) no longer reports `ImmutableSortedDictionary<TKey, TValue>`.

## Why

`ImmutableSortedDictionary<TKey, TValue>` is a balanced binary tree that orders and locates its keys through an `IComparer<TKey>`. It never calls `GetHashCode` or `Equals` on the key, so a key struct without equality overrides is not a hash table problem.

```csharp
using System;
using System.Collections.Immutable;

public struct Key : IComparable<Key>
{
    public int CompareTo(Key other) => 0;
}

// Reported MA0066 before this change, although nothing here hashes a Key
_ = ImmutableSortedDictionary.Create<Key, int>();
```

The rule also had an inconsistent escape hatch for that type: it skipped the report only when the selected overload *declared* an `IComparer<TKey>` parameter. So `Create<Key, int>(null, EqualityComparer<int>.Default)` was accepted even though it passes a null comparer, while `Create<Key, int>()` relying on `Comparer<Key>.Default` was reported.

## What changed

- `DoNotUseDefaultEqualsOnValueTypeAnalyzer`: removed `ImmutableSortedDictionary` from the factory methods (`Create` / `CreateBuilder` / `CreateRange`) and from the `.Empty` fields covered by the rule. That also removes the special-case branch and the now unused `IComparer<T>` symbol lookup. `ImmutableSortedSet` was already excluded, so sorted collections are now handled consistently.
- Tests: the `ImmutableSortedDictionary` cases moved out of the reporting theories into two new no-diagnostic theories — `SortedDictionary_DefaultImplementation` (comparable key, covering `Create`/`CreateBuilder`/`CreateRange`/`.Empty`) and `SortedDictionary_NotComparable`.
- `docs/Rules/MA0066.md`: the list of reported constructs now names the hash-based immutable types explicitly, with a note on why sorted collections are excluded.

## Notes for the reviewer

The 6 new test cases fail against the pre-fix analyzer and pass after it, so they pin the actual regression rather than just documenting current behavior.

Deliberately out of scope: `ImmutableSortedDictionary.Create<Key, int>()` on a key struct that implements neither `IComparable<T>` nor supplies a comparer throws at runtime on the first insert. That is a real defect, but it is an ordering problem rather than a hashing one, so it belongs in a separate rule instead of MA0066. The `SortedDictionary_NotComparable` test records that MA0066 stays silent there.

MA0002 (`UseStringComparerAnalyzer`) legitimately covers `ImmutableSortedDictionary` through `IComparer<string>` and is untouched.

## Validation

- `DoNotUseDefaultEqualsOnValueTypeAnalyzerTests`: 43 passed, 0 failed, 0 skipped on each of Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- `UseStringComparerAnalyzerTests`: 83 passed (Roslyn 5.9).
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.
- The full suite was not run locally; CI covers it.