### PR TITLE
MA0177: preserve nested XML elements such as <see/> when collapsing

### DIFF
--- a/docs/Rules/MA0177.md
+++ b/docs/Rules/MA0177.md
@@ -20,16 +20,16 @@ public class Sample { }
 
 The analyzer will suggest converting to single-line format when:
 - The XML element spans multiple lines
-- The element contains only a single line of actual text content (ignoring whitespace)
+- All the content of the element is on a single line (ignoring whitespace)
 - The resulting single-line comment would fit within the `max_line_length` configuration (if set)
+
+Nested content such as `<c>text</c>`, `<see cref="..."/>`, `<paramref name="..."/>` or a CDATA section is preserved by the code fix.
 
 ## When NOT to use single-line format
 
 The analyzer will NOT suggest converting when:
 - The element already uses single-line format
-- The element contains multiple lines of text content
-- The element contains CDATA sections
-- The element contains nested XML elements, whether they have content (like `<c>text</c>`) or not (like `<see cref="..."/>`, `<paramref name="..."/>`)
+- The content of the element spans multiple lines, whether it is text, a nested element or a CDATA section
 - The single-line version would exceed the `max_line_length` setting
 
 ## Configuration
@@ -63,19 +63,25 @@ public int Add(int a, int b) => a + b;
 /// </summary>
 public int Add(int a, int b) => a + b;
 
-// Compliant: Contains nested XML element
+// Non-compliant: Nested elements are preserved by the code fix
 /// <summary>
 /// Returns the sum using <see cref="Add"/> method
 /// </summary>
 public int Calculate(int a, int b) => Add(a, b);
 
-// Compliant: The only content is a nested XML element
-/// <summary>
-/// <see cref="Add"/>
-/// </summary>
-public int Calculate2(int a, int b) => Add(a, b);
+// Compliant: Single line
+/// <summary>Returns the sum using <see cref="Add"/> method</summary>
+public int Calculate(int a, int b) => Add(a, b);
 
-// Compliant: Contains CDATA section
+// Compliant: The nested element spans multiple lines
+/// <summary>
+/// Returns <c>
+/// the sum
+/// </c> of two numbers
+/// </summary>
+public int Compute(int a, int b) => Add(a, b);
+
+// Compliant: The CDATA section spans multiple lines
 /// <summary><![CDATA[
 /// Special content with <markup>
 /// ]]></summary>

--- a/docs/Rules/MA0177.md
+++ b/docs/Rules/MA0177.md
@@ -29,7 +29,7 @@ The analyzer will NOT suggest converting when:
 - The element already uses single-line format
 - The element contains multiple lines of text content
 - The element contains CDATA sections
-- The element contains nested XML elements (like `<c>`, `<see>`, etc.)
+- The element contains nested XML elements, whether they have content (like `<c>text</c>`) or not (like `<see cref="..."/>`, `<paramref name="..."/>`)
 - The single-line version would exceed the `max_line_length` setting
 
 ## Configuration
@@ -68,6 +68,12 @@ public int Add(int a, int b) => a + b;
 /// Returns the sum using <see cref="Add"/> method
 /// </summary>
 public int Calculate(int a, int b) => Add(a, b);
+
+// Compliant: The only content is a nested XML element
+/// <summary>
+/// <see cref="Add"/>
+/// </summary>
+public int Calculate2(int a, int b) => Add(a, b);
 
 // Compliant: Contains CDATA section
 /// <summary><![CDATA[

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseInlineXmlCommentSyntaxWhenPossibleFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseInlineXmlCommentSyntaxWhenPossibleFixer.cs
@@ -1,6 +1,4 @@
-﻿using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-
-namespace Meziantou.Analyzer.Rules;
+﻿namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public sealed class UseInlineXmlCommentSyntaxWhenPossibleFixer : CodeFixProvider
@@ -16,57 +14,24 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleFixer : CodeFixProvider
         if (nodeToFix is not XmlElementSyntax elementSyntax)
             return;
 
-        // The fix rebuilds the element from its text content, so it would drop any other node
-        foreach (var content in elementSyntax.Content)
-        {
-            if (content is not XmlTextSyntax)
-                return;
-        }
+        var inlineElement = UseInlineXmlCommentSyntaxWhenPossibleCommon.CreateInlineElement(elementSyntax);
+        if (inlineElement is null)
+            return;
 
         var title = "Use single-line XML comment syntax";
         var codeAction = CodeAction.Create(
             title,
-            cancellationToken => Fix(context.Document, elementSyntax, cancellationToken),
+            cancellationToken => Fix(context.Document, elementSyntax, inlineElement, cancellationToken),
             equivalenceKey: title);
 
         context.RegisterCodeFix(codeAction, context.Diagnostics);
     }
 
-    private static async Task<Document> Fix(Document document, XmlElementSyntax elementSyntax, CancellationToken cancellationToken)
+    private static async Task<Document> Fix(Document document, XmlElementSyntax elementSyntax, XmlElementSyntax inlineElement, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
-        // Extract the text content
-        var contentText = new StringBuilder();
-        foreach (var content in elementSyntax.Content)
-        {
-            if (content is XmlTextSyntax textSyntax)
-            {
-                foreach (var token in textSyntax.TextTokens)
-                {
-                    // Skip newline tokens
-                    if (token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
-                        continue;
-
-                    var text = token.Text.Trim();
-                    if (!string.IsNullOrWhiteSpace(text))
-                    {
-                        if (contentText.Length > 0)
-                            contentText.Append(' ');
-                        contentText.Append(text);
-                    }
-                }
-            }
-        }
-
-        // Create single-line syntax
-        var elementName = elementSyntax.StartTag.Name;
-        var attributes = elementSyntax.StartTag.Attributes;
-
-        var newNode = XmlElement(
-            XmlElementStartTag(elementName, attributes),
-            SingletonList<XmlNodeSyntax>(XmlText(contentText.ToString())),
-            XmlElementEndTag(elementName))
+        var newNode = inlineElement
             .WithLeadingTrivia(elementSyntax.GetLeadingTrivia())
             .WithTrailingTrivia(elementSyntax.GetTrailingTrivia());
 

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseInlineXmlCommentSyntaxWhenPossibleFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseInlineXmlCommentSyntaxWhenPossibleFixer.cs
@@ -16,6 +16,13 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleFixer : CodeFixProvider
         if (nodeToFix is not XmlElementSyntax elementSyntax)
             return;
 
+        // The fix rebuilds the element from its text content, so it would drop any other node
+        foreach (var content in elementSyntax.Content)
+        {
+            if (content is not XmlTextSyntax)
+                return;
+        }
+
         var title = "Use single-line XML comment syntax";
         var codeAction = CodeAction.Create(
             title,

--- a/src/Meziantou.Analyzer/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzer.cs
@@ -69,44 +69,15 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzer : DiagnosticAn
                         if (endLine == startLine)
                             continue; // Single line, no issue
 
-                        // Check if content is single-line (ignoring whitespace)
-                        // Skip if content contains CDATA sections or other non-text nodes as the code fix only preserves text
-                        var hasNonTextContent = false;
-                        var meaningfulTextTokenCount = 0;
-                        foreach (var content in elementSyntax.Content)
-                        {
-                            if (content is XmlTextSyntax textSyntax)
-                            {
-                                foreach (var token in textSyntax.TextTokens)
-                                {
-                                    // Skip whitespace-only tokens and newline tokens
-                                    if (token.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.XmlTextLiteralNewLineToken))
-                                        continue;
+                        // The content must fit on a single line, and the code fixer must be able to rewrite it
+                        var inlineElement = UseInlineXmlCommentSyntaxWhenPossibleCommon.CreateInlineElement(elementSyntax);
+                        if (inlineElement is null)
+                            continue;
 
-                                    var text = token.Text.Trim();
-                                    if (!string.IsNullOrWhiteSpace(text))
-                                    {
-                                        meaningfulTextTokenCount++;
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                // Skip elements with CDATA sections, nested elements such as <c>text</c> or <see cref="..."/>, comments or processing instructions
-                                hasNonTextContent = true;
-                                break;
-                            }
-                        }
-
-                        // Report diagnostic if content is effectively single-line (0 or 1 meaningful text tokens)
-                        // and only contains text
-                        if (!hasNonTextContent && meaningfulTextTokenCount <= 1)
+                        // Check if the single-line version would fit within max_line_length
+                        if (WouldFitInMaxLineLength(context, elementSyntax, inlineElement))
                         {
-                            // Check if the single-line version would fit within max_line_length
-                            if (WouldFitInMaxLineLength(context, elementSyntax))
-                            {
-                                context.ReportDiagnostic(Rule, elementSyntax.GetLocation());
-                            }
+                            context.ReportDiagnostic(Rule, elementSyntax.GetLocation());
                         }
                     }
                 }
@@ -114,7 +85,7 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzer : DiagnosticAn
         }
     }
 
-    private static bool WouldFitInMaxLineLength(SymbolAnalysisContext context, XmlElementSyntax elementSyntax)
+    private static bool WouldFitInMaxLineLength(SymbolAnalysisContext context, XmlElementSyntax elementSyntax, XmlElementSyntax inlineElement)
     {
         // Get max_line_length from .editorconfig
         if (!context.Options.TryGetConfigurationValue(elementSyntax.SyntaxTree, MaxLineLengthConfiguration, out var maxLineLengthValue))
@@ -130,51 +101,7 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzer : DiagnosticAn
         var lineText = line.ToString();
         var indentation = lineText.Length - lineText.TrimStart().Length;
 
-        // Build the single-line content
-        var contentLength = indentation;
-        var elementName = elementSyntax.StartTag.Name.LocalName.Text;
-        var attributes = elementSyntax.StartTag.Attributes;
-
-        // Calculate: "/// <elementName" + attributes + ">" + content + "</elementName>"
-        contentLength += 4; // "/// "
-        contentLength += 1; // "<"
-        contentLength += elementName.Length;
-
-        // Add attribute lengths
-        foreach (var attribute in attributes)
-        {
-            contentLength += attribute.Span.Length + 1; // +1 for space before attribute
-        }
-
-        contentLength += 1; // ">"
-
-        // Add text content
-        var hasContent = false;
-        foreach (var content in elementSyntax.Content)
-        {
-            if (content is XmlTextSyntax textSyntax)
-            {
-                foreach (var token in textSyntax.TextTokens)
-                {
-                    if (token.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.XmlTextLiteralNewLineToken))
-                        continue;
-
-                    var text = token.Text.Trim();
-                    if (!string.IsNullOrWhiteSpace(text))
-                    {
-                        if (hasContent)
-                            contentLength += 1; // space separator between multiple text tokens
-                        contentLength += text.Length;
-                        hasContent = true;
-                    }
-                }
-            }
-        }
-
-        contentLength += 2; // "</"
-        contentLength += elementName.Length;
-        contentLength += 1; // ">"
-
-        return contentLength <= maxLineLength;
+        // The resulting line is the indentation, the "/// " prefix, and the element written on a single line
+        return indentation + 4 + inlineElement.ToFullString().Length <= maxLineLength;
     }
 }

--- a/src/Meziantou.Analyzer/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzer.cs
@@ -70,8 +70,8 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzer : DiagnosticAn
                             continue; // Single line, no issue
 
                         // Check if content is single-line (ignoring whitespace)
-                        // Skip if content contains CDATA sections or other non-text elements
-                        var hasCDataOrOtherElements = false;
+                        // Skip if content contains CDATA sections or other non-text nodes as the code fix only preserves text
+                        var hasNonTextContent = false;
                         var meaningfulTextTokenCount = 0;
                         foreach (var content in elementSyntax.Content)
                         {
@@ -90,17 +90,17 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzer : DiagnosticAn
                                     }
                                 }
                             }
-                            else if (content is XmlCDataSectionSyntax || content is XmlElementSyntax)
+                            else
                             {
-                                // Skip elements with CDATA sections or nested elements
-                                hasCDataOrOtherElements = true;
+                                // Skip elements with CDATA sections, nested elements such as <c>text</c> or <see cref="..."/>, comments or processing instructions
+                                hasNonTextContent = true;
                                 break;
                             }
                         }
 
                         // Report diagnostic if content is effectively single-line (0 or 1 meaningful text tokens)
-                        // and doesn't contain CDATA or other nested elements
-                        if (!hasCDataOrOtherElements && meaningfulTextTokenCount <= 1)
+                        // and only contains text
+                        if (!hasNonTextContent && meaningfulTextTokenCount <= 1)
                         {
                             // Check if the single-line version would fit within max_line_length
                             if (WouldFitInMaxLineLength(context, elementSyntax))

--- a/src/Meziantou.Analyzer/Rules/UseInlineXmlCommentSyntaxWhenPossibleCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseInlineXmlCommentSyntaxWhenPossibleCommon.cs
@@ -1,0 +1,153 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Meziantou.Analyzer.Rules;
+
+internal static class UseInlineXmlCommentSyntaxWhenPossibleCommon
+{
+    /// <summary>
+    /// Rewrites the element on a single line, or returns <see langword="null"/> when its content doesn't fit on a single line.
+    /// </summary>
+    /// <remarks>
+    /// The analyzer and the code fixer both use this method, so the reported elements are exactly the ones the code fixer can rewrite,
+    /// and the length computed by the analyzer is the length of the code the fixer produces.
+    /// </remarks>
+    public static XmlElementSyntax? CreateInlineElement(XmlElementSyntax elementSyntax)
+    {
+        if (!IsContentOnSingleLine(elementSyntax))
+            return null;
+
+        var content = new List<XmlNodeSyntax>(elementSyntax.Content.Count);
+        foreach (var node in elementSyntax.Content)
+        {
+            // Nested elements, CDATA sections, comments and processing instructions are kept as-is, so their content is preserved
+            if (node is not XmlTextSyntax textSyntax)
+            {
+                content.Add(RemoveExteriorTrivia(node));
+                continue;
+            }
+
+            var tokens = new List<SyntaxToken>(textSyntax.TextTokens.Count);
+            foreach (var token in textSyntax.TextTokens)
+            {
+                if (token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
+                    continue;
+
+                tokens.Add(token.WithLeadingTrivia(RemoveExteriorTrivia(token.LeadingTrivia)).WithTrailingTrivia(RemoveExteriorTrivia(token.TrailingTrivia)));
+            }
+
+            if (tokens.Count > 0)
+            {
+                content.Add(textSyntax.WithTextTokens(TokenList(tokens)));
+            }
+        }
+
+        // Remove the whitespace that separated the content from the tags
+        if (content.Count > 0)
+        {
+            content[0] = TrimStart(content[0]);
+            content[^1] = TrimEnd(content[^1]);
+            content.RemoveAll(static node => node is XmlTextSyntax { TextTokens.Count: 0 });
+        }
+
+        var elementName = elementSyntax.StartTag.Name;
+
+        return XmlElement(
+            XmlElementStartTag(elementName, elementSyntax.StartTag.Attributes),
+            List(content),
+            XmlElementEndTag(elementName));
+    }
+
+    /// <summary>
+    /// Determines whether all the content of the element is on a single line, ignoring the whitespace.
+    /// </summary>
+    private static bool IsContentOnSingleLine(XmlElementSyntax elementSyntax)
+    {
+        var contentLine = -1;
+        foreach (var node in elementSyntax.Content)
+        {
+            if (node is XmlTextSyntax textSyntax)
+            {
+                foreach (var token in textSyntax.TextTokens)
+                {
+                    if (token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
+                        continue;
+
+                    if (string.IsNullOrWhiteSpace(token.Text))
+                        continue;
+
+                    if (!IsOnContentLine(token.GetLocation(), ref contentLine))
+                        return false;
+                }
+            }
+            else if (!IsOnContentLine(node.GetLocation(), ref contentLine))
+            {
+                return false;
+            }
+        }
+
+        return true;
+
+        static bool IsOnContentLine(Location location, ref int contentLine)
+        {
+            var lineSpan = location.GetLineSpan();
+            var startLine = lineSpan.StartLinePosition.Line;
+            if (startLine != lineSpan.EndLinePosition.Line)
+                return false;
+
+            if (contentLine < 0)
+            {
+                contentLine = startLine;
+                return true;
+            }
+
+            return contentLine == startLine;
+        }
+    }
+
+    private static XmlNodeSyntax TrimStart(XmlNodeSyntax node)
+    {
+        if (node is not XmlTextSyntax textSyntax)
+            return node;
+
+        var tokens = textSyntax.TextTokens;
+        if (tokens.Count == 0 || !tokens[0].IsKind(SyntaxKind.XmlTextLiteralToken))
+            return node;
+
+        return textSyntax.WithTextTokens(ReplaceText(tokens, index: 0, tokens[0].Text.TrimStart()));
+    }
+
+    private static XmlNodeSyntax TrimEnd(XmlNodeSyntax node)
+    {
+        if (node is not XmlTextSyntax textSyntax)
+            return node;
+
+        var tokens = textSyntax.TextTokens;
+        if (tokens.Count == 0 || !tokens[^1].IsKind(SyntaxKind.XmlTextLiteralToken))
+            return node;
+
+        return textSyntax.WithTextTokens(ReplaceText(tokens, index: tokens.Count - 1, tokens[^1].Text.TrimEnd()));
+    }
+
+    private static SyntaxTokenList ReplaceText(SyntaxTokenList tokens, int index, string text)
+    {
+        var token = tokens[index];
+        if (text.Length == 0)
+            return tokens.RemoveAt(index);
+
+        return tokens.Replace(token, XmlTextLiteral(text, text).WithTriviaFrom(token));
+    }
+
+    private static TNode RemoveExteriorTrivia<TNode>(TNode node)
+        where TNode : SyntaxNode
+    {
+        var exteriorTrivia = node.DescendantTrivia().Where(static trivia => trivia.IsKind(SyntaxKind.DocumentationCommentExteriorTrivia));
+        return node.ReplaceTrivia(exteriorTrivia, static (_, _) => default);
+    }
+
+    private static IEnumerable<SyntaxTrivia> RemoveExteriorTrivia(SyntaxTriviaList trivia)
+    {
+        return trivia.Where(static item => !item.IsKind(SyntaxKind.DocumentationCommentExteriorTrivia));
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests.cs
@@ -223,6 +223,51 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests
     }
 
     [Fact]
+    public Task InnerXmlEmptyElement_See_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            /// <summary>
+            /// <see cref="System.String"/>
+            /// </summary>
+            class Sample { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InnerXmlEmptyElement_ParamRef_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Sample
+            {
+                /// <param name="value">
+                /// <paramref name="value"/>
+                /// </param>
+                public void Method(int value) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InnerXmlEmptyElementWithText_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            /// <summary>
+            /// Uses <see cref="System.String"/> internally
+            /// </summary>
+            class Sample { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task EmptyContent_ShouldReportDiagnostic()
     {
         var test = CreateTest();

--- a/tests/Meziantou.Analyzer.Test/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests.cs
@@ -207,7 +207,7 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests
     }
 
     [Fact]
-    public Task InnerXmlElements_ShouldNotReportDiagnostic()
+    public Task InnerXmlElementSpanningMultipleLines_ShouldNotReportDiagnostic()
     {
         var test = CreateTest();
         test.TestCode = """
@@ -223,9 +223,88 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests
     }
 
     [Fact]
-    public Task InnerXmlEmptyElement_See_ShouldNotReportDiagnostic()
+    public Task InnerXmlEmptyElement_See_ShouldBePreserved()
     {
         var test = CreateTest();
+        test.TestCode = """
+            /// {|MA0177:<summary>
+            /// <see cref="System.String"/>
+            /// </summary>|}
+            class Sample { }
+            """;
+        test.FixedCode = """
+            /// <summary><see cref="System.String"/></summary>
+            class Sample { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InnerXmlEmptyElement_ParamRef_ShouldBePreserved()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Sample
+            {
+                /// {|MA0177:<param name="value">
+                /// <paramref name="value"/>
+                /// </param>|}
+                public void Method(int value) { }
+            }
+            """;
+        test.FixedCode = """
+            class Sample
+            {
+                /// <param name="value"><paramref name="value"/></param>
+                public void Method(int value) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InnerXmlEmptyElementSurroundedByText_ShouldBePreserved()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            /// {|MA0177:<summary>
+            /// Uses <see cref="System.String"/> internally
+            /// </summary>|}
+            class Sample { }
+            """;
+        test.FixedCode = """
+            /// <summary>Uses <see cref="System.String"/> internally</summary>
+            class Sample { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InnerXmlElementOnSingleLine_ShouldBePreserved()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            /// {|MA0177:<summary>
+            /// Uses <c>value</c> internally
+            /// </summary>|}
+            class Sample { }
+            """;
+        test.FixedCode = """
+            /// <summary>Uses <c>value</c> internally</summary>
+            class Sample { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InnerXmlEmptyElement_ExceedingMaxLineLength_ShouldNotReportDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestState.SetConfiguration("max_line_length", "40");
         test.TestCode = """
             /// <summary>
             /// <see cref="System.String"/>
@@ -237,30 +316,17 @@ public sealed class UseInlineXmlCommentSyntaxWhenPossibleAnalyzerTests
     }
 
     [Fact]
-    public Task InnerXmlEmptyElement_ParamRef_ShouldNotReportDiagnostic()
+    public Task SingleLineCData_ShouldBePreserved()
     {
         var test = CreateTest();
         test.TestCode = """
-            class Sample
-            {
-                /// <param name="value">
-                /// <paramref name="value"/>
-                /// </param>
-                public void Method(int value) { }
-            }
+            /// {|MA0177:<summary>
+            /// <![CDATA[Sample <markup>]]>
+            /// </summary>|}
+            class Sample { }
             """;
-
-        return test.RunAsync();
-    }
-
-    [Fact]
-    public Task InnerXmlEmptyElementWithText_ShouldNotReportDiagnostic()
-    {
-        var test = CreateTest();
-        test.TestCode = """
-            /// <summary>
-            /// Uses <see cref="System.String"/> internally
-            /// </summary>
+        test.FixedCode = """
+            /// <summary><![CDATA[Sample <markup>]]></summary>
             class Sample { }
             """;
 


### PR DESCRIPTION
## Problem

MA0177 reported a multi-line documentation element whose content was a self-closing element, and the code fix **deleted** it:

```csharp
/// <summary>
/// <see cref="System.String"/>
/// </summary>
public class Sample { }
```

Applying the fix produced `/// <summary></summary>`, silently losing the type reference. Both versions compile, so nothing surfaced the lost documentation. The same happened with `<paramref name="..."/>`.

## Cause

The analyzer skipped elements containing `XmlCDataSectionSyntax || XmlElementSyntax`. `XmlEmptyElementSyntax` — the node for self-closing tags like `<see/>` — is not an `XmlElementSyntax`, so it fell through the gap, as did `XmlCommentSyntax` and `XmlProcessingInstructionSyntax`. The fixer collected only `XmlTextSyntax` children and rebuilt the whole element from that text, so everything else was dropped.

## Fix

The code fix now **preserves every child node**, so the example above collapses to:

```csharp
/// <summary><see cref="System.String"/></summary>
```

- **New `UseInlineXmlCommentSyntaxWhenPossibleCommon`**, shared by the analyzer and the fixer via the existing `Rules\*Common.cs` link. `CreateInlineElement` keeps the content nodes, dropping only the newline tokens and the `///` exterior trivia, then trims the whitespace that separated the content from the tags. Nested elements, CDATA sections, comments and processing instructions are copied verbatim. It returns `null` when the element cannot be collapsed, which is both the analyzer's report condition and the fixer's validate-before-registering check — so the reported elements are exactly the ones the fixer can rewrite.
- **The report condition becomes "all the content is on a single line"** instead of "at most one text token and no other node". This replaces the list of excluded node types with the property that actually matters.
- **`WouldFitInMaxLineLength` measured the text content only**, so it under-counted any element with nested content. It now measures the rewritten element, which is the exact code the fixer produces.

## Behavior changes

| Input | Before | After |
| --- | --- | --- |
| `<summary>`, content is `<see cref="..."/>` | reported, **reference deleted** | reported, collapsed with the reference kept |
| `<summary>Uses <see cref="..."/> internally</summary>` over 3 lines | not reported | reported, collapsed |
| `<c>` / CDATA spanning several lines | not reported | not reported (unchanged) |
| CDATA on a single line | not reported | reported, collapsed verbatim |

Content spanning several lines is still never touched, so a nested `<c>` broken over several lines stays as it is.

## Verification

- MA0177 tests: **28 passed on each of Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9** — 0 failed, 0 skipped. New cases cover `<see/>` alone, `<paramref/>` alone, `<see/>` surrounded by text, `<c>text</c>` on one line, single-line CDATA, and a nested element pushing the line past `max_line_length`.
- Full suite on all five Roslyn versions: **21637 passed**, 0 failed, 0 skipped.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes.