### PR TITLE
Do not report MA0031 when the operand of the comparison has side effects

### DIFF
--- a/docs/Rules/MA0031.md
+++ b/docs/Rules/MA0031.md
@@ -11,3 +11,12 @@ enumerable.Count() > 10;
 // Should be
 enumerable.Skip(10).Any();
 ```
+
+The rewrite uses the value the count is compared to as the argument of `Take` or `Skip`, so it evaluates that value
+twice and before enumerating the sequence. The rule is not reported when the value is not a constant and reading it
+can have a side effect, such as a method call or a property access:
+
+```csharp
+// Not reported as 'GetLimit()' would be called twice
+enumerable.Count() > GetLimit();
+```

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -590,6 +590,12 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
             if (otherOperand is null)
                 return;
 
+            // The 'Take' and 'Skip' rewrites keep the operand in the comparison and also use it as the argument of the
+            // new method, so they evaluate it twice and before the enumeration instead of after it. A constant operand
+            // is replaced by its value, so only the non-constant operands must be side-effect free and stable.
+            if (!otherOperand.ConstantValue.HasValue && !IsSideEffectFree(otherOperand))
+                return;
+
             string? message = null;
             var properties = ImmutableDictionary<string, string?>.Empty;
             if (otherOperand.ConstantValue.HasValue && otherOperand.ConstantValue.Value is int value)
@@ -837,6 +843,27 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
 
                 return op.TargetMethod.Name == nameof(Enumerable.Take) && extensionMethodOwnerTypes.Contains(op.TargetMethod.ContainingType, SymbolEqualityComparer.Default);
             }
+        }
+
+        /// <summary>
+        /// Determines if evaluating the operation twice is equivalent to evaluating it once, and if it can be evaluated
+        /// before the enumeration of the sequence. Only the side-effect free reads are supported, as a call or a property
+        /// access can return a different value, modify a state, or throw.
+        /// </summary>
+        private static bool IsSideEffectFree(IOperation operation)
+        {
+            if (operation.ConstantValue.HasValue)
+                return true;
+
+            return operation.UnwrapImplicitConversions() switch
+            {
+                ILiteralOperation or ILocalReferenceOperation or IParameterReferenceOperation or IInstanceReferenceOperation => true,
+                // A volatile field is excluded as two reads can observe different values
+                IFieldReferenceOperation { Field.IsVolatile: false } fieldReference => fieldReference.Field.IsStatic || (fieldReference.Instance is not null && IsSideEffectFree(fieldReference.Instance)),
+                IUnaryOperation unary => unary.OperatorMethod is null && IsSideEffectFree(unary.Operand),
+                IBinaryOperation binary => binary.OperatorMethod is null && IsSideEffectFree(binary.LeftOperand) && IsSideEffectFree(binary.RightOperand),
+                _ => false,
+            };
         }
 
         private static void UseCastInsteadOfSelect(OperationAnalysisContext context, IInvocationOperation operation)

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
@@ -882,6 +882,81 @@ public sealed class OptimizeLinqUsageAnalyzerTests
         return test.RunAsync();
     }
 
+    [Theory]
+    [InlineData("Count() == Next()")]
+    [InlineData("Count() != Next()")]
+    [InlineData("Count() < Next()")]
+    [InlineData("Count() <= Next()")]
+    [InlineData("Count() > Next()")]
+    [InlineData("Count() >= Next()")]
+    [InlineData("Count() == Limit")]
+    [InlineData("Count() == limits[0]")]
+    [InlineData("Count() == Next() + 1")]
+    public Task Count_OperandIsNotSideEffectFree(string text)
+    {
+        var test = new CodeFixTest();
+        test.TestCode = $$"""
+            using System.Linq;
+            class Test
+            {
+                int Limit => 0;
+                static int Next() => 0;
+                public Test()
+                {
+                    var limits = new int[1];
+                    var enumerable = Enumerable.Empty<int>();
+                    _ = enumerable.{{text}};
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("_limit", "_limit")]
+    // The simplifier removes the redundant 'this.'
+    [InlineData("this._limit", "_limit")]
+    [InlineData("s_limit", "s_limit")]
+    [InlineData("n + 1", "n + 1")]
+    [InlineData("-n", "-n")]
+    public Task Count_SkipAndAny_SideEffectFreeOperand(string text, string fix)
+    {
+        var test = new CodeFixTest();
+        test.TestCode = $$"""
+            using System.Linq;
+            class Test
+            {
+                int _limit = 0;
+                static int s_limit = 0;
+                public Test(int n)
+                {
+                    var enumerable = Enumerable.Empty<int>();
+                    _ = {|#0:enumerable.Count() > {{text}}|};
+                }
+            }
+
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0031", DiagnosticSeverity.Info).WithLocation(0).WithMessage("Replace 'Count() > n' with 'Skip(n).Any()'"));
+        test.FixedCode = $$"""
+            using System.Linq;
+            class Test
+            {
+                int _limit = 0;
+                static int s_limit = 0;
+                public Test(int n)
+                {
+                    var enumerable = Enumerable.Empty<int>();
+                    _ = enumerable.Skip({{fix}}).Any();
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
     [Fact]
     public Task Any_List()
     {


### PR DESCRIPTION
## What

MA0031 no longer reports `Count()` comparisons whose other operand is not a constant and cannot be read twice safely.

## Why

The `Take` and `Skip` rewrites suggested by MA0031 keep the value the count is compared to in the comparison **and** use it as the argument of the new method, so the value is evaluated twice, and before the enumeration instead of after it. The code fix applied this rewrite to any expression:

```csharp
using System.Linq;
public class Sample
{
    static int calls;
    static int Next() => ++calls;
    public static object Run() => Enumerable.Range(1, 2).Count() == Next();
}
```

The offered fix produced `Enumerable.Range(1, 2).Take(Next() + 1).Count() == Next()`. Both versions compile, but on fresh assemblies `Run()` returns `false` before the fix and `true` after it: the original calls `Next()` once, the replacement calls it twice.

The fix is in the analyzer rather than in the code fixer, because the diagnostic message (`Replace 'Count() > n' with 'Skip(n).Any()'`) proposes the very same unsafe rewrite to anyone applying it by hand.

## How

- `OptimizeLinqUsageAnalyzer.OptimizeCountUsage` returns without reporting when the operand is not a constant and is not side-effect free. Constant operands are unaffected, as the code fix replaces them by their value.
- A new `IsSideEffectFree` helper accepts constants, literals, locals, parameters, `this`, non-volatile field reads, and the built-in unary and binary operators over those. Everything else (calls, property and indexer accesses, user-defined operators) is rejected. It mirrors the existing helpers of `UseHasFlagMethodCommon` and `UseTypeofInsteadOfGetTypeOnSealedTypeCommon`.
- `docs/Rules/MA0031.md` documents when the rule stays silent.

## Notes for the reviewer

The trade-off is that property accesses are excluded, so `enumerable.Count() > array.Length` is no longer reported. This is the same conservative bar the two existing helpers of the repository use, as a property getter can run any code.

## Tests

- `Count_OperandIsNotSideEffectFree`: 9 cases (the six operators with a method call, plus a property, an indexer, and `Next() + 1`) assert that nothing is reported. Each of them reported MA0031 and offered the duplicating fix before the change.
- `Count_SkipAndAny_SideEffectFreeOperand`: 5 cases assert that the rule and its code fix still apply to fields, `this.field`, static fields, `n + 1` and `-n`.
- MA0031 tests: 167 passed, 0 failed on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- Full test suite: 4394 passed, 0 failed on Roslyn 5.9; 4277 passed, 0 failed on Roslyn 4.8.
- `dotnet run --project src/DocumentationGenerator` exits 0, so no further markdown change is needed.