### PR TITLE
Do not report MA0215 when ConfigureAwait changes what the method does

### DIFF
--- a/docs/Rules/MA0215.md
+++ b/docs/Rules/MA0215.md
@@ -13,7 +13,20 @@ async Task Sample() => await DoSomethingAsync(); // non-compliant
 Task Sample() => DoSomethingAsync(); // compliant
 ````
 
-The rule reports only when it is safe to remove the `await`: **every** `return` statement must directly return an awaited task (`return await X;`), the returned task must be assignable to the method return type, and there must be no other `await` in the method (e.g. `await Task.Yield();` prevents the report). It is never reported inside `try`/`catch`/`finally`, `using` (statement or declaration), `lock`, or `fixed` blocks. A trailing `ConfigureAwait` call is removed by the code fix.
+The rule reports only when it is safe to remove the `await`: **every** `return` statement must directly return an awaited task (`return await X;`), the returned task must be assignable to the method return type, and there must be no other `await` in the method (e.g. `await Task.Yield();` prevents the report). It is never reported inside `try`/`catch`/`finally`, `using` (statement or declaration), `lock`, or `fixed` blocks.
+
+A trailing `ConfigureAwait` call is removed by the code fix, but only when dropping it cannot change what the method does: its argument must be a constant, and `ConfigureAwaitOptions` must not contain any option other than `ContinueOnCapturedContext`.
+
+````c#
+// Not reported: the method completes successfully when the task faults, whereas returning the task directly would not
+async Task Sample() => await DoSomethingAsync().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+
+// Not reported: the method always completes asynchronously, whereas returning the task directly would not
+async Task Sample() => await DoSomethingAsync().ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
+
+// Not reported: removing the call would stop evaluating the argument
+async Task Sample() => await DoSomethingAsync().ConfigureAwait(GetOptions());
+````
 
 ````c#
 // Also reported: every return awaits a directly-returnable task

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/ReturnTaskInsteadOfAwaitingItFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/ReturnTaskInsteadOfAwaitingItFixer.cs
@@ -13,38 +13,43 @@ public sealed class ReturnTaskInsteadOfAwaitingItFixer : CodeFixProvider
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        if (nodeToFix?.FirstAncestorOrSelf<SyntaxNode>(IsFunction) is null)
+        var function = root?.FindNode(context.Span, getInnermostNodeForTie: true).FirstAncestorOrSelf<SyntaxNode>(IsFunction);
+        if (function is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var replacements = GetReplacements(semanticModel, function, context.CancellationToken);
+        if (replacements is null)
             return;
 
         const string Title = "Return the task directly";
         context.RegisterCodeFix(
-            CodeAction.Create(Title, ct => FixAsync(context.Document, nodeToFix, ct), equivalenceKey: Title),
+            CodeAction.Create(Title, ct => FixAsync(context.Document, function, replacements, ct), equivalenceKey: Title),
             context.Diagnostics);
     }
 
-    private static async Task<Document> FixAsync(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    // Computes how every await of the function (excluding the nested functions) is rewritten,
+    // or null when one of them cannot be removed
+    private static Dictionary<SyntaxNode, SyntaxNode>? GetReplacements(SemanticModel semanticModel, SyntaxNode function, CancellationToken cancellationToken)
     {
-        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var semanticModel = editor.SemanticModel;
-
-        var function = nodeToFix.FirstAncestorOrSelf<SyntaxNode>(IsFunction);
-        if (function is null)
-            return document;
-
-        // Every await in the function (excluding nested functions) can be removed
+        var configureAwaitOptionsSymbol = semanticModel.Compilation.GetBestTypeByMetadataName("System.Threading.Tasks.ConfigureAwaitOptions");
         var awaitExpressions = function
             .DescendantNodesAndSelf(descendIntoChildren: node => node == function || !IsFunction(node))
-            .OfType<AwaitExpressionSyntax>()
-            .ToList();
+            .OfType<AwaitExpressionSyntax>();
 
         var replacements = new Dictionary<SyntaxNode, SyntaxNode>();
         foreach (var awaitExpression in awaitExpressions)
         {
             var innerExpression = awaitExpression.Expression;
-            if (semanticModel.GetOperation(awaitExpression, cancellationToken) is IAwaitOperation { Operation: IInvocationOperation { Instance: { } instance, TargetMethod.Name: "ConfigureAwait" } } &&
+            if (semanticModel.GetOperation(awaitExpression, cancellationToken) is IAwaitOperation { Operation: IInvocationOperation { Instance: { } instance, TargetMethod.Name: "ConfigureAwait" } invocation } &&
                 instance.Syntax is ExpressionSyntax instanceExpression)
             {
+                if (!ReturnTaskInsteadOfAwaitingItCommon.CanRemoveConfigureAwait(invocation, configureAwaitOptionsSymbol))
+                    return null;
+
                 innerExpression = instanceExpression;
             }
 
@@ -59,8 +64,12 @@ public sealed class ReturnTaskInsteadOfAwaitingItFixer : CodeFixProvider
             }
         }
 
-        if (replacements.Count == 0)
-            return document;
+        return replacements.Count > 0 ? replacements : null;
+    }
+
+    private static async Task<Document> FixAsync(Document document, SyntaxNode function, Dictionary<SyntaxNode, SyntaxNode> replacements, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
         var newFunction = function.ReplaceNodes(replacements.Keys, (original, _) => replacements[original]);
         newFunction = RemoveAsyncModifier(newFunction, editor.Generator);

--- a/src/Meziantou.Analyzer/Rules/ReturnTaskInsteadOfAwaitingItAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ReturnTaskInsteadOfAwaitingItAnalyzer.cs
@@ -54,6 +54,7 @@ public sealed class ReturnTaskInsteadOfAwaitingItAnalyzer : DiagnosticAnalyzer
         private readonly Compilation _compilation;
         private readonly AwaitableTypes _awaitableTypes;
         private readonly ITypeSymbol?[] _configuredAwaitableSymbols;
+        private readonly ITypeSymbol? _configureAwaitOptionsSymbol;
 
         public AnalyzerContext(Compilation compilation)
         {
@@ -66,6 +67,7 @@ public sealed class ReturnTaskInsteadOfAwaitingItAnalyzer : DiagnosticAnalyzer
                 compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"),
                 compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"),
             ];
+            _configureAwaitOptionsSymbol = compilation.GetBestTypeByMetadataName("System.Threading.Tasks.ConfigureAwaitOptions");
         }
 
         public bool IsValid => _awaitableTypes.TaskSymbol is not null;
@@ -187,9 +189,12 @@ public sealed class ReturnTaskInsteadOfAwaitingItAnalyzer : DiagnosticAnalyzer
         private bool IsDirectlyReturnable(IAwaitOperation awaitOperation, ITypeSymbol returnType)
         {
             var taskOperation = awaitOperation.Operation;
-            if (taskOperation is IInvocationOperation { Instance: { } instance, Type: { } configuredType } &&
+            if (taskOperation is IInvocationOperation { Instance: { } instance, Type: { } configuredType } invocation &&
                 configuredType.OriginalDefinition.IsEqualToAny(_configuredAwaitableSymbols))
             {
+                if (!ReturnTaskInsteadOfAwaitingItCommon.CanRemoveConfigureAwait(invocation, _configureAwaitOptionsSymbol))
+                    return false;
+
                 taskOperation = instance;
             }
 

--- a/src/Meziantou.Analyzer/Rules/ReturnTaskInsteadOfAwaitingItCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/ReturnTaskInsteadOfAwaitingItCommon.cs
@@ -1,0 +1,37 @@
+namespace Meziantou.Analyzer.Rules;
+
+internal static class ReturnTaskInsteadOfAwaitingItCommon
+{
+    private const int ContinueOnCapturedContext = 1; // System.Threading.Tasks.ConfigureAwaitOptions.ContinueOnCapturedContext
+
+    /// <summary>
+    /// Indicates whether a <c>ConfigureAwait</c> call can be dropped together with the <c>await</c> it configures.
+    /// </summary>
+    /// <remarks>
+    /// The configuration must be a constant, as a non-constant expression must keep being evaluated, and it must
+    /// only contain options that do not change what the method does once the <c>await</c> is gone:
+    /// <c>ConfigureAwaitOptions.SuppressThrowing</c> makes the method complete successfully when the awaited task
+    /// faults, and <c>ConfigureAwaitOptions.ForceYielding</c> makes it complete asynchronously even when the awaited
+    /// task is already completed.
+    /// </remarks>
+    internal static bool CanRemoveConfigureAwait(IInvocationOperation invocation, ITypeSymbol? configureAwaitOptionsSymbol)
+    {
+        if (invocation.Arguments.Length is not 1)
+            return false;
+
+        var argument = invocation.Arguments[0].Value;
+        if (!argument.ConstantValue.HasValue)
+            return false;
+
+        return argument.ConstantValue.Value switch
+        {
+            // ConfigureAwait(bool) only configures where the continuation runs, and no continuation is left
+            bool => true,
+
+            // Any other option, including the ones a future version of .NET may add, can change what the method does
+            int options when argument.Type.IsEqualTo(configureAwaitOptionsSymbol) => (options & ~ContinueOnCapturedContext) is 0,
+
+            _ => false,
+        };
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/ReturnTaskInsteadOfAwaitingItAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ReturnTaskInsteadOfAwaitingItAnalyzerTests.cs
@@ -917,4 +917,161 @@ public sealed class ReturnTaskInsteadOfAwaitingItAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task ConfigureAwaitOptions_None_IsStripped()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task Inner() => throw null;
+                async Task A()
+                {
+                    {|MA0215:await Inner().ConfigureAwait(ConfigureAwaitOptions.None)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task Inner() => throw null;
+                Task A()
+                {
+                    return Inner();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ConfigureAwaitOptions_ContinueOnCapturedContext_IsStripped()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task Inner() => throw null;
+                async Task A()
+                {
+                    {|MA0215:await Inner().ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task Inner() => throw null;
+                Task A()
+                {
+                    return Inner();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ConfigureAwaitOptions_SuppressThrowing_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task Inner() => throw null;
+                async Task A()
+                {
+                    await Inner().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ConfigureAwaitOptions_SuppressThrowingCombined_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task Inner() => throw null;
+                async Task A()
+                {
+                    await Inner().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ConfigureAwaitOptions_ForceYielding_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task Inner() => throw null;
+                async Task A()
+                {
+                    await Inner().ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ConfigureAwaitOptions_NotConstant_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task Inner() => throw null;
+                ConfigureAwaitOptions Options() => throw null;
+                async Task A()
+                {
+                    await Inner().ConfigureAwait(Options());
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ConfigureAwaitBool_NotConstant_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                Task<int> Inner() => throw null;
+                bool ContinueOnCapturedContext() => throw null;
+                async Task<int> A()
+                {
+                    return await Inner().ConfigureAwait(ContinueOnCapturedContext());
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## Problem

MA0215 (*Return the task instead of awaiting it*) recognized a configured awaitable by its type alone (`ConfiguredTaskAwaitable`, `ConfiguredValueTaskAwaitable`, …) and the code fix dropped the `ConfigureAwait` call whatever its argument was.

With `ConfigureAwaitOptions.SuppressThrowing`, the `async` method completes successfully even though the awaited task faults. Returning that faulted task directly changes the method contract, so the caller starts observing an exception it never saw before. Both versions compile, so the change is silent:

```csharp
public static object Run()
{
    try { Check().GetAwaiter().GetResult(); return "success"; }
    catch (InvalidOperationException) { return "caught"; }
}

static async Task Check()
{
    await Task.FromException(new InvalidOperationException()).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
}
```

Before the fix, MA0215 rewrote `Check` to `static Task Check() => Task.FromException(...);` and `Run()` returned `caught` instead of `success`.

## Change

The analyzer and the code fixer now share `ReturnTaskInsteadOfAwaitingItCommon.CanRemoveConfigureAwait`, which only allows dropping the call when doing so cannot change what the method does. It is a whitelist rather than a blacklist, so anything unknown is rejected:

| Argument | Reported |
|---|---|
| `ConfigureAwait(bool)`, constant | yes — no continuation is left, so the value is moot |
| `ConfigureAwaitOptions.None` / `ContinueOnCapturedContext`, constant | yes |
| `ConfigureAwaitOptions.SuppressThrowing` | no — the method would stop swallowing the fault |
| `ConfigureAwaitOptions.ForceYielding` | no — the method would stop always completing asynchronously |
| any other option, including the ones a future .NET may add | no |
| a non-constant expression | no — it must keep being evaluated |

`ForceYielding` is blocked for the same reason as `SuppressThrowing`: the original method always completes asynchronously, whereas the returned task may already be completed. The non-constant case also covers `ConfigureAwait(bool)`, whose argument would otherwise stop being evaluated.

The code fixer was restructured to follow the repository guidance on validating before registering: it computes its replacement map in `RegisterCodeFixesAsync` and registers nothing when one of the awaits of the function cannot be removed, instead of registering a fix that would return the document unchanged — or, worse, produce code that does not compile.

`docs/Rules/MA0215.md` documents the restriction. `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown change.

## Tests

7 tests added to `ReturnTaskInsteadOfAwaitingItAnalyzerTests`, covering `None`, `ContinueOnCapturedContext`, `SuppressThrowing`, `SuppressThrowing | ContinueOnCapturedContext`, `ForceYielding`, a non-constant `ConfigureAwaitOptions` and a non-constant `bool`.

Full suite: **4387/4387 passed on Roslyn 5.9** and **4270/4270 on Roslyn 4.8**, no failures, no skips.