### PR TITLE
Do not report MA0152 when the inner await suppresses the exceptions

### DIFF
--- a/docs/Rules/MA0152.md
+++ b/docs/Rules/MA0152.md
@@ -1,4 +1,4 @@
-# MA0152 - Use Unwrap instead of using await twice
+﻿# MA0152 - Use Unwrap instead of using await twice
 <!-- sources -->
 Sources: [UseTaskUnwrapAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/UseTaskUnwrapAnalyzer.cs), [UseTaskUnwrapFixer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer.CodeFixers/Rules/UseTaskUnwrapFixer.cs)
 <!-- sources -->
@@ -10,4 +10,16 @@ Task<Task> t;
 await await t; // non-compliant
 
 await t.Unwrap(); // compliant
+````
+
+The rule is not reported when the inner task is awaited with `ConfigureAwaitOptions.SuppressThrowing`, as `Unwrap()` would also suppress the exceptions of the outer task:
+
+````c#
+Task<Task> t;
+
+// The exceptions of t are propagated, only the ones of the inner task are suppressed
+await (await t).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+
+// The exceptions of t are suppressed too
+await t.Unwrap().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 ````

--- a/src/Meziantou.Analyzer/Rules/UseTaskUnwrapAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseTaskUnwrapAnalyzer.cs
@@ -40,6 +40,9 @@ public sealed class UseTaskUnwrapAnalyzer : DiagnosticAnalyzer
             ConfiguredTaskAwaitableSymbol = compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredTaskAwaitable");
             ConfiguredTaskAwaitableOfTSymbol = compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1");
 
+            ConfigureAwaitOptionsSymbol = compilation.GetBestTypeByMetadataName("System.Threading.Tasks.ConfigureAwaitOptions");
+            SuppressThrowingValue = ConfigureAwaitOptionsSymbol?.GetMembers("SuppressThrowing").OfType<IFieldSymbol>().FirstOrDefault()?.ConstantValue as int?;
+
             if (TaskSymbol is not null && TaskOfTSymbol is not null)
             {
                 TaskOfTaskSymbol = TaskOfTSymbol.Construct(TaskSymbol);
@@ -54,6 +57,9 @@ public sealed class UseTaskUnwrapAnalyzer : DiagnosticAnalyzer
 
         public INamedTypeSymbol? ConfiguredTaskAwaitableSymbol { get; }
         public INamedTypeSymbol? ConfiguredTaskAwaitableOfTSymbol { get; }
+
+        public INamedTypeSymbol? ConfigureAwaitOptionsSymbol { get; }
+        public int? SuppressThrowingValue { get; }
 
         public bool IsValid => TaskOfTaskSymbol is not null || TaskOfTaskOfTSymbol is not null;
 
@@ -77,8 +83,13 @@ public sealed class UseTaskUnwrapAnalyzer : DiagnosticAnalyzer
                     context.ReportDiagnostic(Rule, operation);
                 }
             }
-            else if (operation.Operation is IInvocationOperation { Instance: IAwaitOperation { Operation.Type: INamedTypeSymbol childAwaitOperationType }, Type: var invocationType } && invocationType.IsEqualToAny(ConfiguredTaskAwaitableSymbol, ConfiguredTaskAwaitableOfTSymbol))
+            else if (operation.Operation is IInvocationOperation { Instance: IAwaitOperation { Operation.Type: INamedTypeSymbol childAwaitOperationType } } invocation && invocation.Type.IsEqualToAny(ConfiguredTaskAwaitableSymbol, ConfiguredTaskAwaitableOfTSymbol))
             {
+                // The inner task is the only one configured with SuppressThrowing, whereas Unwrap() would also
+                // suppress the exceptions of the outer task, which the outer await currently propagates
+                if (MaySuppressThrowing(invocation))
+                    return;
+
                 // Task<Task>
                 if (childAwaitOperationType.IsEqualTo(TaskOfTaskSymbol))
                 {
@@ -90,6 +101,23 @@ public sealed class UseTaskUnwrapAnalyzer : DiagnosticAnalyzer
                     context.ReportDiagnostic(Rule, operation);
                 }
             }
+        }
+
+        private bool MaySuppressThrowing(IInvocationOperation operation)
+        {
+            if (SuppressThrowingValue is not { } suppressThrowing)
+                return false;
+
+            foreach (var argument in operation.Arguments)
+            {
+                if (!argument.Parameter!.Type.IsEqualTo(ConfigureAwaitOptionsSymbol))
+                    continue;
+
+                // The options are only known not to suppress the exceptions when they are a constant
+                return argument.Value.ConstantValue is not { HasValue: true, Value: int options } || (options & suppressThrowing) is not 0;
+            }
+
+            return false;
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseTaskUnwrapAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseTaskUnwrapAnalyzerTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseTaskUnwrapAnalyzer,
@@ -64,6 +64,70 @@ public sealed class UseTaskUnwrapAnalyzerTests
 
             Task<Task> a = null;
             await a.Unwrap().ConfigureAwait(false);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TaskOfTask_ConfigureAwaitOptions_Root()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+
+            Task<Task> a = null;
+            {|MA0152:await (await a).ConfigureAwait(ConfigureAwaitOptions.ForceYielding | ConfigureAwaitOptions.ContinueOnCapturedContext)|};
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+
+            Task<Task> a = null;
+            await a.Unwrap().ConfigureAwait(ConfigureAwaitOptions.ForceYielding | ConfigureAwaitOptions.ContinueOnCapturedContext);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TaskOfTask_ConfigureAwaitOptions_SuppressThrowing_Root()
+    {
+        // Unwrap() would also suppress the exceptions of the outer task
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+
+            Task<Task> a = null;
+            await (await a).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TaskOfTask_ConfigureAwaitOptions_SuppressThrowing_Combined_Root()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+
+            Task<Task> a = null;
+            await (await a).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ForceYielding);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TaskOfTask_ConfigureAwaitOptions_NotConstant_Root()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+
+            Task<Task> a = null;
+            ConfigureAwaitOptions options = default;
+            await (await a).ConfigureAwait(options);
             """;
 
         return test.RunAsync();


### PR DESCRIPTION
## Problem

MA0152 suggested replacing a double `await` with `Unwrap()`, and its code fix changed the behavior when the inner task was awaited with `ConfigureAwaitOptions.SuppressThrowing`:

```csharp
Task<Task> outer = Task.FromException<Task>(new InvalidOperationException());
try
{
    await (await outer).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
    return "success";
}
catch (InvalidOperationException) { return "caught"; }
```

The outer `await` is *outside* the configured awaitable, so only the exceptions of the inner task are suppressed and the failure of `outer` still propagates: the snippet above returns `caught`. The code fix rewrote it to `await outer.Unwrap().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing)`, and since `Unwrap()` folds the faults of the outer task into the unwrapped one, `SuppressThrowing` swallows those too: the fixed code returns `success`. Both versions compile, so the exception was silently lost.

I confirmed the difference by executing both forms:

```
original: caught
fixed   : success
```

## Fix

There is no `Unwrap()` form that preserves the semantics here, so this is fixed in the analyzer rather than in the fixer — reporting a diagnostic whose only code fix is unsound would be worse than not reporting it.

`UseTaskUnwrapAnalyzer` now bails out of the `ConfigureAwait` branch when the options may contain `SuppressThrowing`:

- the diagnostic is still reported when the argument is a constant without the `SuppressThrowing` bit, so `ConfigureAwait(false)` and `ConfigureAwait(ForceYielding | ContinueOnCapturedContext)` are unaffected;
- it is not reported when the options are not a constant (a variable or a parameter), as the flag cannot be ruled out.

The value of `SuppressThrowing` is read from the `ConstantValue` of the enum member instead of being hardcoded, and the whole check is inert on the target frameworks that do not have `ConfigureAwaitOptions`.

## Notes for reviewers

- The `Task<Task<T>>` case is covered by the same guard. `Task<TResult>.ConfigureAwait` rejects `SuppressThrowing` at run time anyway, so this only makes the two branches consistent.
- `docs/Rules/MA0152.md` documents the case that is not reported. `dotnet run --project src/DocumentationGenerator` exits 0 afterwards.

## Tests

Four tests added to `UseTaskUnwrapAnalyzerTests`: the plain `SuppressThrowing` case, a combined-flags case, a non-constant-options case, and a positive `ForceYielding | ContinueOnCapturedContext` case that still reports and fixes.

I checked the new tests are meaningful by neutralizing the guard: 3 of the 11 fail without it, all 11 pass with it.

**11 tests passed, 0 failed, 0 skipped, on every Roslyn version (4.8, 4.14, 5.0, 5.6, 5.9).** The full solution builds with 0 warnings and 0 errors. The whole test suite was not run locally; CI covers it.
