### PR TITLE
Do not report MA0065 when the invoked equality member is overridden

### DIFF
--- a/docs/Rules/MA0065.md
+++ b/docs/Rules/MA0065.md
@@ -8,6 +8,9 @@ This rule reports direct equality/hash calls on non-enum structs that still rely
 To avoid the warning and improve runtime behavior, implement your own `Equals(object)` and `GetHashCode()`
 for the struct (ideally with `IEquatable<T>` too).
 
+Only the invoked member matters: calling an overridden `GetHashCode()` is compliant even when the struct does not
+override `Equals(object)`, and the other way around. [MA0066](MA0066.md) reports such a struct when it is used in a hash table.
+
 ````csharp
 struct Sample
 {

--- a/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzer.cs
@@ -82,24 +82,19 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
         {
             var operation = (IInvocationOperation)context.Operation;
 
-            if (operation.TargetMethod.Name == nameof(ValueType.GetHashCode))
+            if (operation.TargetMethod.Name is nameof(ValueType.GetHashCode) or nameof(ValueType.Equals))
             {
+                // The invoked method is the default implementation only when the type does not override it.
+                // An override, an overload such as Equals(T), or a method hiding the default implementation is invoked instead.
+                var defaultImplementation = operation.TargetMethod.Name is nameof(ValueType.GetHashCode) ? ValueTypeGetHashCodeSymbol : ValueTypeEqualsSymbol;
+                if (!operation.TargetMethod.IsEqualTo(defaultImplementation))
+                    return;
+
                 var actualType = operation.GetChildOperations().FirstOrDefault()?.GetActualType(context.CancellationToken);
                 if (actualType is null)
                     return;
 
-                if (IsStruct(actualType) && HasDefaultEqualsOrHashCodeImplementations(actualType))
-                {
-                    context.ReportDiagnostic(Rule, operation);
-                }
-            }
-            else if (operation.TargetMethod.Name == nameof(ValueType.Equals))
-            {
-                var actualType = operation.GetChildOperations().FirstOrDefault()?.GetActualType(context.CancellationToken);
-                if (actualType is null)
-                    return;
-
-                if (IsStruct(actualType) && HasDefaultEqualsOrHashCodeImplementations(actualType))
+                if (IsStruct(actualType))
                 {
                     context.ReportDiagnostic(Rule, operation);
                 }
@@ -195,13 +190,18 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzer : DiagnosticAnalyze
 
         private bool HasDefaultEqualsOrHashCodeImplementations(ITypeSymbol typeSymbol)
         {
-            if (ValueTypeEqualsSymbol is not null && typeSymbol.GetMembers(ValueTypeEqualsSymbol.Name).OfType<IMethodSymbol>().FirstOrDefault(member => member.IsOverride && ValueTypeEqualsSymbol.IsEqualTo(member.OverriddenMethod)) is null)
+            if (ValueTypeEqualsSymbol is not null && !HasOverride(typeSymbol, ValueTypeEqualsSymbol))
                 return true;
 
-            if (ValueTypeGetHashCodeSymbol is not null && typeSymbol.GetMembers(ValueTypeGetHashCodeSymbol.Name).OfType<IMethodSymbol>().FirstOrDefault(member => member.IsOverride && ValueTypeGetHashCodeSymbol.IsEqualTo(member.OverriddenMethod)) is null)
+            if (ValueTypeGetHashCodeSymbol is not null && !HasOverride(typeSymbol, ValueTypeGetHashCodeSymbol))
                 return true;
 
             return false;
+        }
+
+        private static bool HasOverride(ITypeSymbol typeSymbol, IMethodSymbol overriddenMethod)
+        {
+            return typeSymbol.GetMembers(overriddenMethod.Name).OfType<IMethodSymbol>().Any(member => member.IsOverride && overriddenMethod.IsEqualTo(member.OverriddenMethod));
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseDefaultEqualsOnValueTypeAnalyzerTests.cs
@@ -155,6 +155,73 @@ public sealed class DoNotUseDefaultEqualsOnValueTypeAnalyzerTests
         return test.RunAsync();
     }
 
+    [Fact]
+    public Task GetHashCode_OnlyGetHashCodeOverriden()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            struct Test
+            {
+                public override int GetHashCode() => throw null;
+            }
+
+            class Sample
+            {
+                public void A()
+                {
+                    _ = new Test().GetHashCode();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Equals_OnlyEqualsOverriden()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            #pragma warning disable CS0659
+            struct Test
+            {
+                public override bool Equals(object o) => throw null;
+            }
+
+            class Sample
+            {
+                public void A()
+                {
+                    _ = new Test().Equals(new Test());
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Equals_IEquatableOverload()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            struct Test : System.IEquatable<Test>
+            {
+                public bool Equals(Test other) => throw null;
+            }
+
+            class Sample
+            {
+                public void A()
+                {
+                    _ = new Test().Equals(new Test());
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Theory]
     [InlineData("new System.Collections.Generic.HashSet<Test>()")]
     [InlineData("new System.Collections.Generic.Dictionary<Test, object>()")]


### PR DESCRIPTION
## What

MA0065 reported a struct as soon as *either* `ValueType.Equals` or `ValueType.GetHashCode` was left un-overridden, even when the invocation resolved to the member the struct *did* override:

```csharp
public struct Value
{
    public override int GetHashCode() => 42;
}

_ = new Value().GetHashCode(); // MA0065 reported, but the override runs and returns 42
```

The analyzer now reports only when `operation.TargetMethod` **is** `ValueType.Equals` / `ValueType.GetHashCode`, i.e. when the default implementation is the method that actually runs. An override, an overload such as `IEquatable<T>.Equals(T)`, or a member hiding the default implementation no longer triggers the rule. The two `GetHashCode`/`Equals` branches are merged, and the `IsStruct` check on the receiver's actual type is kept, so enums and non-struct receivers stay excluded.

The combined "either member missing" check is unchanged and still used by MA0066 (struct used as a hash-table key), which genuinely needs both members; it just shares an extracted `HasOverride` helper now.

## Behavior

| Code | Before | After |
| --- | --- | --- |
| `GetHashCode()` on a struct overriding only `GetHashCode` | MA0065 (false positive) | no diagnostic |
| `Equals(o)` on a struct overriding only `Equals(object)` | MA0065 (false positive) | no diagnostic |
| `Equals(other)` resolving to `IEquatable<T>.Equals(T)`, no `Equals(object)` override | MA0065 (false positive) | no diagnostic |
| `GetHashCode()` on a struct overriding only `Equals` | MA0065 | MA0065 (unchanged) |
| `Equals(o)` on a struct overriding only `GetHashCode` | MA0065 | MA0065 (unchanged) |
| struct used as a hash-table key with either member missing | MA0066 | MA0066 (unchanged) |

## Notes for reviewers

- Three tests added to `DoNotUseDefaultEqualsOnValueTypeAnalyzerTests` for the three fixed rows; the existing `GetHashCode_OnlyEqualsOverriden` / `Equals_OnlyGetHashCodeOverriden` tests still assert the true positives.
- Pre-existing gap left untouched: `object.Equals(structA, structB)` (the static, boxing overload) was never reported, because for a static invocation the first child operation is an `IArgumentOperation` whose `Type` is `null` and the analyzer bails out. Extending the rule there felt out of scope for a false-positive fix.
- `docs/Rules/MA0065.md` gained a note that only the invoked member matters, pointing at MA0066 for the hash-table case.

## Validation

- MA0065/MA0066 test class: 47 passed on Roslyn 5.9 and on Roslyn 4.8 (44 before, +3 new).
- Full test project on Roslyn 5.9: 4383 passed, 0 failed, 0 skipped.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes.