### PR TITLE
Do not report MA0173 when the value cannot be captured by a lambda

### DIFF
--- a/docs/Rules/MA0173.md
+++ b/docs/Rules/MA0173.md
@@ -8,3 +8,12 @@ Interlocked.CompareExchange(ref _field, new Sample(), null); // non-compliant
 LazyInitializer.EnsureInitialized(ref _field, () => new Sample()); // compliant
 ```
 
+The rule is not reported when the value cannot be moved into a lambda, such as when it uses a `ref`/`out`/`in` parameter, a `ref` local, a variable of a `ref struct` type, or the `this` reference of a `struct`:
+
+```c#
+void Sample(ref int value)
+{
+    // compliant as "() => new StringBuilder(value)" would not compile
+    Interlocked.CompareExchange(ref _field, new StringBuilder(value), null);
+}
+```

--- a/src/Meziantou.Analyzer/Rules/UseLazyInitializerEnsureInitializeAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLazyInitializerEnsureInitializeAnalyzer.cs
@@ -41,6 +41,10 @@ public class UseLazyInitializerEnsureInitializeAnalyzer : DiagnosticAnalyzer
                     var value = operation.Arguments[1].Value.UnwrapImplicitConversions();
                     if (value is IObjectCreationOperation or ILocalReferenceOperation)
                     {
+                        // The fix moves the value into a lambda, so it must only use values that a lambda can capture
+                        if (!CanBeCapturedByLambda(value))
+                            return;
+
                         context.ReportDiagnostic(Rule, operation);
                     }
                 }
@@ -48,4 +52,31 @@ public class UseLazyInitializerEnsureInitializeAnalyzer : DiagnosticAnalyzer
         });
     }
 
+    private static bool CanBeCapturedByLambda(IOperation operation)
+    {
+        foreach (var descendant in operation.DescendantsAndSelf())
+        {
+            if (CannotBeCapturedByLambda(descendant))
+                return false;
+        }
+
+        return true;
+
+        static bool CannotBeCapturedByLambda(IOperation operation) => operation switch
+        {
+            // ref, out and in parameters cannot be used inside a lambda (CS1628)
+            IParameterReferenceOperation { Parameter.RefKind: not RefKind.None } => true,
+
+            // ref locals cannot be used inside a lambda (CS8175)
+            ILocalReferenceOperation { Local.IsRef: true } => true,
+
+            // Locals and parameters of a ref struct type cannot be used inside a lambda (CS8175)
+            IParameterReferenceOperation or ILocalReferenceOperation => operation.Type is { IsRefLikeType: true },
+
+            // The 'this' reference of a struct cannot be captured by a lambda (CS1673)
+            IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance } => operation.Type is { IsValueType: true },
+
+            _ => false,
+        };
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseLazyInitializerEnsureInitializeAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseLazyInitializerEnsureInitializeAnalyzerTests.cs
@@ -146,4 +146,171 @@ public sealed class UseLazyInitializerEnsureInitializeAnalyzerTests
 
         return test.RunAsync();
     }
+    [Fact]
+    public Task Parameter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            Sample.Run(0);
+
+            class Sample
+            {
+                private static object? s_target;
+
+                public static void Run(int value)
+                {
+                    {|MA0173:System.Threading.Interlocked.CompareExchange(ref s_target, new System.Text.StringBuilder(value), null)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            Sample.Run(0);
+
+            class Sample
+            {
+                private static object? s_target;
+
+                public static void Run(int value)
+                {
+                    System.Threading.LazyInitializer.EnsureInitialized(ref s_target, () => new System.Text.StringBuilder(value));
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefParameter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            var value = 0;
+            Sample.Run(ref value);
+
+            class Sample
+            {
+                private static object? s_target;
+
+                public static void Run(ref int value)
+                {
+                    System.Threading.Interlocked.CompareExchange(ref s_target, new System.Text.StringBuilder(value), null);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OutParameter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            Sample.Run(out _);
+
+            class Sample
+            {
+                private static object? s_target;
+
+                public static void Run(out int value)
+                {
+                    value = 0;
+                    System.Threading.Interlocked.CompareExchange(ref s_target, new System.Text.StringBuilder(value), null);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InParameter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            var value = 0;
+            Sample.Run(in value);
+
+            class Sample
+            {
+                private static object? s_target;
+
+                public static void Run(in int value)
+                {
+                    System.Threading.Interlocked.CompareExchange(ref s_target, new System.Text.StringBuilder(value), null);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefLocal()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            Sample.Run();
+
+            class Sample
+            {
+                private static object? s_target;
+                private static int s_value;
+
+                public static void Run()
+                {
+                    ref var value = ref s_value;
+                    System.Threading.Interlocked.CompareExchange(ref s_target, new System.Text.StringBuilder(value), null);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefStructLocal()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            Sample.Run();
+
+            class Sample
+            {
+                private static object? s_target;
+
+                public static void Run()
+                {
+                    System.Span<char> value = stackalloc char[1];
+                    System.Threading.Interlocked.CompareExchange(ref s_target, new string(value), null);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StructThis()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            default(Sample).Run();
+
+            struct Sample
+            {
+                private static object? s_target;
+                private int _value;
+
+                public void Run()
+                {
+                    System.Threading.Interlocked.CompareExchange(ref s_target, new System.Text.StringBuilder(_value), null);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
 }


### PR DESCRIPTION
## Problem

The MA0173 code fix rewrites `Interlocked.CompareExchange(ref field, value, null)` into `LazyInitializer.EnsureInitialized(ref field, () => value)`. It wraps the value expression in a lambda without checking that the expression can legally live inside one, so it can turn compiling code into code that does not compile:

```c#
using System.Threading;
public class Sample
{
    static object target;
    public static void Run(ref int value)
    {
        Interlocked.CompareExchange(ref target, new System.Text.StringBuilder(value), null);
    }
}
```

The fixed code fails with **CS1628**, as a lambda cannot capture the `ref` parameter `value`.

## Change

`UseLazyInitializerEnsureInitializeAnalyzer` now walks the value operation before reporting and skips the diagnostic when any descendant is something a lambda cannot capture:

| Operation | Compiler error avoided |
|---|---|
| `ref`/`out`/`in`/`ref readonly` parameter reference | CS1628 |
| `ref` local reference | CS8175 |
| local or parameter of a `ref struct` type | CS8175 |
| `this` of a `struct` | CS1673 |

## Notes for the reviewer

- The check is in the analyzer rather than the code fix: the point of the rule is "you can write this as `EnsureInitialized`", so when the lambda form cannot exist there is nothing to report. The fixer is only reachable through this diagnostic, so it cannot produce the broken code any more, and no unfixable diagnostic is left behind.
- The `ref struct` and struct-`this` cases were not in the original report, but they are the same defect (a value that is legal as an argument and illegal inside a lambda), so they are handled together.
- The check is deliberately conservative: it scans all the descendants, including nested lambdas, so `new Foo((ref int x) => ...)` is skipped even though hoisting it would compile. That is a missed diagnostic, not a broken fix.
- `docs/Rules/MA0173.md` documents the exclusion.

## Tests

Added to `UseLazyInitializerEnsureInitializeAnalyzerTests`: six no-diagnostic tests (`RefParameter`, `OutParameter`, `InParameter`, `RefLocal`, `RefStructLocal`, `StructThis`) and a `Parameter` test that still reports and fixes, to guard against over-restricting the rule.

All six new negative tests were confirmed to fail against the unmodified analyzer and to pass with the change.

## Validation

- `dotnet build` succeeds with no warnings.
- MA0173 tests pass on all five Roslyn versions (4.8, 4.14, 5.0, 5.6, 5.9): 14 passed, 0 failed each.
- Full suite on Roslyn 5.9: 4387 passed, 0 failed, 0 skipped. Full suite on Roslyn 4.8: 4270 passed, 0 failed, 0 skipped.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes, re-run after the documentation edit.