### PR TITLE
Do not report MA0106 when the factory writes the captured variable

### DIFF
--- a/docs/Rules/MA0106.md
+++ b/docs/Rules/MA0106.md
@@ -12,6 +12,9 @@ var dict = new ConcurrentDictionary<int, int>();
 dict.GetOrAdd(key, _ => value); // report diagnostic
 
 dict.GetOrAdd(key, (_, v) => v, value); // ok
+
+var counter = 0;
+dict.GetOrAdd(key, _ => ++counter); // ok, the closure is needed as the factory writes the captured variable
 ````
 
 - [ConcurrentDictionary + closure = 💔](https://www.meziantou.net/concurrentdictionary-closure.htm)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidClosureWhenUsingConcurrentDictionaryFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/AvoidClosureWhenUsingConcurrentDictionaryFixer.cs
@@ -39,12 +39,15 @@ public sealed class AvoidClosureWhenUsingConcurrentDictionaryFixer : CodeFixProv
                 context.Diagnostics);
         }
 
-        if (context.Diagnostics.Any(d => d.Id == RuleIdentifiers.AvoidClosureWhenUsingConcurrentDictionaryByUsingFactoryArg))
+        if (context.Diagnostics.Any(d => d.Id == RuleIdentifiers.AvoidClosureWhenUsingConcurrentDictionaryByUsingFactoryArg)
+            && invocationOperation.Syntax is InvocationExpressionSyntax invocationSyntax
+            && GetFactoriesToUpdate(invocationOperation) is { } factories
+            && TryGetFactoryArgumentSymbol(semanticModel, factories, lambdaOperation, out var capturedSymbol))
         {
             context.RegisterCodeFix(
                 CodeAction.Create(
                     "Use factoryArgument overload",
-                    ct => UseFactoryArgumentOverload(context.Document, semanticModel, invocationOperation, lambdaOperation, ct),
+                    ct => UseFactoryArgumentOverload(context.Document, semanticModel, invocationSyntax, factories, capturedSymbol, ct),
                     equivalenceKey: "Use factoryArgument overload"),
                 context.Diagnostics);
         }
@@ -67,86 +70,70 @@ public sealed class AvoidClosureWhenUsingConcurrentDictionaryFixer : CodeFixProv
         return editor.GetChangedDocument();
     }
 
-    private static async Task<Document> UseFactoryArgumentOverload(Document document, SemanticModel semanticModel, IInvocationOperation invocationOperation, IAnonymousFunctionOperation lambdaOperation, CancellationToken cancellationToken)
+    private static async Task<Document> UseFactoryArgumentOverload(Document document, SemanticModel semanticModel, InvocationExpressionSyntax invocationSyntax, List<IAnonymousFunctionOperation> factories, ISymbol capturedSymbol, CancellationToken cancellationToken)
     {
-        if (invocationOperation.Syntax is not InvocationExpressionSyntax invocationSyntax)
-            return document;
+        var parameterName = GetUniqueParameterName(factories.SelectMany(factory => factory.Symbol.Parameters).Select(p => p.Name), "arg");
 
-        var capturedSymbol = GetCapturedSymbols(semanticModel, lambdaOperation).FirstOrDefault();
-        if (capturedSymbol is not ILocalSymbol and not IParameterSymbol)
-            return document;
-
-        var newInvocation = invocationOperation.TargetMethod.Name switch
+        var arguments = invocationSyntax.ArgumentList.Arguments;
+        for (var i = 0; i < factories.Count; i++)
         {
-            "GetOrAdd" => CreateGetOrAddInvocationWithFactoryArg(invocationOperation, invocationSyntax, lambdaOperation, capturedSymbol, semanticModel),
-            "AddOrUpdate" => CreateAddOrUpdateInvocationWithFactoryArg(invocationOperation, invocationSyntax, capturedSymbol, semanticModel),
-            _ => null,
-        };
+            var updatedLambda = ReplaceSymbolReferences((AnonymousFunctionExpressionSyntax)factories[i].Syntax, semanticModel, capturedSymbol, parameterName);
+            var lambdaWithParameter = AddParameterToLambda(updatedLambda, parameterName);
 
-        if (newInvocation is null)
-            return document;
+            // The factories are the arguments following the key
+            var argumentIndex = i + 1;
+            arguments = arguments.Replace(arguments[argumentIndex], arguments[argumentIndex].WithExpression(lambdaWithParameter));
+        }
+
+        arguments = arguments.Add(Argument(IdentifierName(capturedSymbol.Name)));
+        var newInvocation = invocationSyntax.WithArgumentList(invocationSyntax.ArgumentList.WithArguments(arguments));
 
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         editor.ReplaceNode(invocationSyntax, newInvocation.WithAdditionalAnnotations(Formatter.Annotation));
         return editor.GetChangedDocument();
     }
 
-    private static InvocationExpressionSyntax? CreateGetOrAddInvocationWithFactoryArg(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, IAnonymousFunctionOperation lambdaOperation, ISymbol capturedSymbol, SemanticModel semanticModel)
+    /// <summary>
+    /// Gets the factories the code fix must rewrite to use the 'factoryArgument' parameter, in the order of the arguments following the key.
+    /// </summary>
+    private static List<IAnonymousFunctionOperation>? GetFactoriesToUpdate(IInvocationOperation invocationOperation)
     {
-        if (invocationOperation.Arguments.Length != 2)
-            return null;
+        if (invocationOperation.TargetMethod.Name is "GetOrAdd" && invocationOperation.Arguments.Length == 2)
+        {
+            if (TryGetAnonymousFunctionOperation(invocationOperation.Arguments[1].Value, out var valueFactory))
+                return [valueFactory];
+        }
+        else if (invocationOperation.TargetMethod.Name is "AddOrUpdate" && invocationOperation.Arguments.Length == 3)
+        {
+            if (TryGetAnonymousFunctionOperation(invocationOperation.Arguments[1].Value, out var addValueFactory) &&
+                TryGetAnonymousFunctionOperation(invocationOperation.Arguments[2].Value, out var updateValueFactory))
+            {
+                return [addValueFactory, updateValueFactory];
+            }
+        }
 
-        var lambda = lambdaOperation.Syntax as AnonymousFunctionExpressionSyntax;
-        if (lambda is null)
-            return null;
-
-        var parameterName = GetUniqueParameterName(lambdaOperation.Symbol.Parameters.Select(p => p.Name), "arg");
-        var updatedLambda = ReplaceSymbolReferences(lambda, semanticModel, capturedSymbol, parameterName);
-        updatedLambda = AddParameterToLambda(updatedLambda, parameterName);
-        if (updatedLambda is null)
-            return null;
-
-        var arguments = invocationSyntax.ArgumentList.Arguments;
-        arguments = arguments.Replace(arguments[1], arguments[1].WithExpression(updatedLambda));
-        arguments = arguments.Add(Argument(IdentifierName(capturedSymbol.Name)));
-        return invocationSyntax.WithArgumentList(invocationSyntax.ArgumentList.WithArguments(arguments));
+        return null;
     }
 
-    private static InvocationExpressionSyntax? CreateAddOrUpdateInvocationWithFactoryArg(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, ISymbol capturedSymbol, SemanticModel semanticModel)
+    private static bool TryGetFactoryArgumentSymbol(SemanticModel semanticModel, List<IAnonymousFunctionOperation> factories, IAnonymousFunctionOperation lambdaOperation, [NotNullWhen(true)] out ISymbol? capturedSymbol)
     {
-        if (invocationOperation.Arguments.Length != 3)
-            return null;
+        capturedSymbol = null;
 
-        if (!TryGetAnonymousFunctionOperation(invocationOperation.Arguments[1].Value, out var addValueFactoryOperation))
-            return null;
+        // The code fix adds a parameter to every rewritten factory
+        if (factories.Any(factory => factory.Syntax is not (ParenthesizedLambdaExpressionSyntax or SimpleLambdaExpressionSyntax)))
+            return false;
 
-        if (!TryGetAnonymousFunctionOperation(invocationOperation.Arguments[2].Value, out var updateValueFactoryOperation))
-            return null;
+        var symbol = GetCapturedSymbols(semanticModel, lambdaOperation).FirstOrDefault();
+        if (symbol is not ILocalSymbol and not IParameterSymbol)
+            return false;
 
-        var addValueFactory = addValueFactoryOperation.Syntax as AnonymousFunctionExpressionSyntax;
-        var updateValueFactory = updateValueFactoryOperation.Syntax as AnonymousFunctionExpressionSyntax;
-        if (addValueFactory is null || updateValueFactory is null)
-            return null;
+        // The captured variable is a shared storage, whereas the 'factoryArgument' parameter is a copy of its value.
+        // Replacing the references to the variable by the parameter would drop the writes made by the factories.
+        if (factories.Any(factory => IsWrittenInside(semanticModel, factory, symbol)))
+            return false;
 
-        var parameterName = GetUniqueParameterName(
-            addValueFactoryOperation.Symbol.Parameters.Select(p => p.Name).Concat(updateValueFactoryOperation.Symbol.Parameters.Select(p => p.Name)),
-            "arg");
-
-        addValueFactory = ReplaceSymbolReferences(addValueFactory, semanticModel, capturedSymbol, parameterName);
-        addValueFactory = AddParameterToLambda(addValueFactory, parameterName);
-        if (addValueFactory is null)
-            return null;
-
-        updateValueFactory = ReplaceSymbolReferences(updateValueFactory, semanticModel, capturedSymbol, parameterName);
-        updateValueFactory = AddParameterToLambda(updateValueFactory, parameterName);
-        if (updateValueFactory is null)
-            return null;
-
-        var arguments = invocationSyntax.ArgumentList.Arguments;
-        arguments = arguments.Replace(arguments[1], arguments[1].WithExpression(addValueFactory));
-        arguments = arguments.Replace(arguments[2], arguments[2].WithExpression(updateValueFactory));
-        arguments = arguments.Add(Argument(IdentifierName(capturedSymbol.Name)));
-        return invocationSyntax.WithArgumentList(invocationSyntax.ArgumentList.WithArguments(arguments));
+        capturedSymbol = symbol;
+        return true;
     }
 
     private static List<(ISymbol Symbol, string ParameterName)> GetReplacementMappings(IInvocationOperation invocationOperation, IAnonymousFunctionOperation lambdaOperation, IArgumentOperation lambdaArgument)
@@ -210,11 +197,21 @@ public sealed class AvoidClosureWhenUsingConcurrentDictionaryFixer : CodeFixProv
 
         foreach (var symbol in dataFlow.CapturedInside)
         {
-            if (!parameters.Contains(symbol, SymbolEqualityComparer.Default))
+            if (!parameters.Contains(symbol, SymbolEqualityComparer.Default) && !dataFlow.WrittenInside.Contains(symbol, SymbolEqualityComparer.Default))
             {
                 yield return symbol;
             }
         }
+    }
+
+    private static bool IsWrittenInside(SemanticModel semanticModel, IAnonymousFunctionOperation lambdaOperation, ISymbol symbol)
+    {
+        var dataFlowNode = GetDataFlowArgument(lambdaOperation.Syntax);
+        if (dataFlowNode is null)
+            return false;
+
+        var dataFlow = semanticModel.AnalyzeDataFlow(dataFlowNode);
+        return dataFlow.WrittenInside.Contains(symbol, SymbolEqualityComparer.Default);
     }
 
     private static AnonymousFunctionExpressionSyntax ReplaceSymbolReferences(AnonymousFunctionExpressionSyntax lambda, SemanticModel semanticModel, ISymbol symbolToReplace, string replacementParameterName)
@@ -223,7 +220,7 @@ public sealed class AvoidClosureWhenUsingConcurrentDictionaryFixer : CodeFixProv
         return (AnonymousFunctionExpressionSyntax)rewriter.Visit(lambda);
     }
 
-    private static ParenthesizedLambdaExpressionSyntax? AddParameterToLambda(AnonymousFunctionExpressionSyntax lambda, string parameterName)
+    private static ParenthesizedLambdaExpressionSyntax AddParameterToLambda(AnonymousFunctionExpressionSyntax lambda, string parameterName)
     {
         var parameter = Parameter(Identifier(parameterName));
 
@@ -232,28 +229,13 @@ public sealed class AvoidClosureWhenUsingConcurrentDictionaryFixer : CodeFixProv
             return parenthesizedLambda.WithParameterList(parenthesizedLambda.ParameterList.WithParameters(parenthesizedLambda.ParameterList.Parameters.Add(parameter)));
         }
 
-        if (lambda is SimpleLambdaExpressionSyntax simpleLambda)
-        {
-            var parameters = SeparatedList(new[] { simpleLambda.Parameter, parameter });
+        var simpleLambda = (SimpleLambdaExpressionSyntax)lambda;
+        var parameters = SeparatedList(new[] { simpleLambda.Parameter, parameter });
+        var updatedLambda = simpleLambda.Block is not null
+            ? ParenthesizedLambdaExpression(ParameterList(parameters), simpleLambda.Block)
+            : ParenthesizedLambdaExpression(ParameterList(parameters), simpleLambda.ExpressionBody!);
 
-            ParenthesizedLambdaExpressionSyntax updatedLambda;
-            if (simpleLambda.Block is not null)
-            {
-                updatedLambda = ParenthesizedLambdaExpression(ParameterList(parameters), simpleLambda.Block);
-            }
-            else if (simpleLambda.ExpressionBody is not null)
-            {
-                updatedLambda = ParenthesizedLambdaExpression(ParameterList(parameters), simpleLambda.ExpressionBody);
-            }
-            else
-            {
-                return null;
-            }
-
-            return updatedLambda.WithAsyncKeyword(simpleLambda.AsyncKeyword);
-        }
-
-        return null;
+        return updatedLambda.WithAsyncKeyword(simpleLambda.AsyncKeyword);
     }
 
     private static string GetUniqueParameterName(IEnumerable<string> existingParameterNames, string baseName)

--- a/src/Meziantou.Analyzer/Rules/AvoidClosureWhenUsingConcurrentDictionaryAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/AvoidClosureWhenUsingConcurrentDictionaryAnalyzer.cs
@@ -187,9 +187,16 @@ public class AvoidClosureWhenUsingConcurrentDictionaryAnalyzer : DiagnosticAnaly
             {
                 // A parameter can be captured inside (by another lambda)
                 var parameters = GetParameters(argumentOperation);
-                if (dataFlow.CapturedInside.Any(s => !parameters.Contains(s, SymbolEqualityComparer.Default)))
+
+                // A variable written inside the lambda must keep its shared storage. The 'factoryArgument' parameter is a copy,
+                // so the writes would not be visible outside of the lambda.
+                var capturedSymbols = dataFlow.CapturedInside
+                    .Where(symbol => !parameters.Contains(symbol, SymbolEqualityComparer.Default) && !dataFlow.WrittenInside.Contains(symbol, SymbolEqualityComparer.Default))
+                    .ToArray();
+
+                if (capturedSymbols.Length > 0)
                 {
-                    context.ReportDiagnostic(RuleFactoryArg, argumentOperation, string.Join(", ", dataFlow.Captured.Select(symbol => symbol.Name)));
+                    context.ReportDiagnostic(RuleFactoryArg, argumentOperation, string.Join(", ", capturedSymbols.Select(symbol => symbol.Name)));
                 }
             }
         }

--- a/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAnalyzerTests.cs
@@ -21,11 +21,11 @@ public sealed class ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAna
             var a = new ConcurrentDictionary<int, int>();
             a.GetOrAdd(key, (k) => k + 1);
             a.GetOrAdd(key, (k, v) => k + v, factoryArg);
-            a.GetOrAdd(key, {|MA0106:(k, v) =>
+            a.GetOrAdd(key, (k, v) =>
             {
                 key = 2; // ok to write a value
                 return key + v; // ok to use the value if it is written
-            }|}, factoryArg);
+            }, factoryArg);
             """;
 
         return test.RunAsync();
@@ -487,6 +487,64 @@ public sealed class ConcurrentDictionaryMustPreventClosureWhenAccessingTheKeyAna
             var value = 1;
             var a = new ConcurrentDictionary<int, int>();
             a.GetOrAdd(key, (_, arg) => arg, value);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task GetOrAdd_CapturedVariableIsWritten_IsValid()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var counter = 0;
+            var a = new ConcurrentDictionary<int, int>();
+            a.GetOrAdd(1, _ => ++counter);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task GetOrAdd_CapturedVariableIsWrittenInANestedLambda_IsValid()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System;
+            using System.Collections.Concurrent;
+
+            var counter = 0;
+            var a = new ConcurrentDictionary<int, int>();
+            a.GetOrAdd(1, _ => new Func<int>(() => ++counter)());
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AddOrUpdate_CapturedVariableIsWrittenByTheUpdateValueFactory_NoCodeFix()
+    {
+        var test = new CodeFixTest();
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.TestCode = """
+            using System.Collections.Concurrent;
+
+            var counter = 0;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(1, {|MA0106:k => counter|}, (k, v) => ++counter);
+            """;
+
+        // The update value factory writes 'counter', so it cannot use the 'factoryArgument' parameter
+        test.FixedCode = """
+            using System.Collections.Concurrent;
+
+            var counter = 0;
+            var a = new ConcurrentDictionary<int, int>();
+            a.AddOrUpdate(1, {|MA0106:k => counter|}, (k, v) => ++counter);
             """;
 
         return test.RunAsync();


### PR DESCRIPTION
## Problem

MA0106 was reported on factories that **write** the captured variable, and its code fix redirected those writes to the `factoryArgument` parameter, which is a copy of the value:

```csharp
int counter = 0;
var map = new ConcurrentDictionary<string, int>();

map.GetOrAdd("key", _ => ++counter);              // counter is 1 after the call
map.GetOrAdd("key", (_, arg) => ++arg, counter);  // after the code fix: counter is still 0
```

Both versions compile, so the change is silent. A captured variable is a shared storage; the `factoryArgument` parameter is not, so the closure cannot be removed when the factory writes the variable.

## Changes

**Analyzer** — `DetectClosure` excludes the captured symbols that appear in `WrittenInside` (which covers the writes made by a lambda nested in the factory) and reports only when a read-only captured symbol remains. The message lists those symbols instead of `dataFlow.Captured`. `DetectPotentialUsageOfLambdaParameter` (MA0105) already did the same.

**Code fix** — the `factoryArgument` fix now validates everything *before* registering itself, instead of returning an unchanged document from the code action:

- `GetFactoriesToUpdate` returns the lambdas the fix rewrites (`GetOrAdd` with 2 arguments → the value factory; `AddOrUpdate` with 3 arguments → both factories), or `null` for the shapes the fix does not support.
- `TryGetFactoryArgumentSymbol` requires every rewritten lambda to be a simple or parenthesized lambda, requires the captured symbol to be a local or a parameter, and rejects the symbol when **any** rewritten factory writes it. That last check is what the analyzer change alone does not cover: the diagnostic can be reported on the add value factory while the update value factory writes the variable, and the fix rewrites both.
- `GetCapturedSymbols` skips the written symbols too, so the candidate is never one of them.
- The two near-duplicate `Create*InvocationWithFactoryArg` methods are replaced by a single loop, and `AddParameterToLambda` is no longer nullable now that its preconditions are guaranteed.

**Documentation** — `docs/Rules/MA0106.md` documents the written-variable case as "ok".

## Tests

Three tests added: the `++counter` reproduction, a write made by a lambda nested in the factory, and an `AddOrUpdate` whose update value factory writes the variable. The last one sets `FixedCode` to the unchanged source, so an applied code fix fails the test. All three fail without the production changes.

One existing case in `GetOrAdd_IsValid` (a factory assigning `key`) lost its `{|MA0106:...|}` markup, as that closure is now correctly not reported.

The test class passes on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9 (28 tests each), the full test project passes on the default version (4383 tests), the solution builds without warnings, and `dotnet run --project src/DocumentationGenerator` reports no further markdown change.