### PR TITLE
Report MA0163 when an assignment cannot fix the configuration used by Process.Start

### DIFF
--- a/docs/Rules/MA0163.md
+++ b/docs/Rules/MA0163.md
@@ -35,6 +35,24 @@ var psi = new ProcessStartInfo("cmd"); // Non compliant as UseShellExecute is no
 psi.RedirectStandardOutput = true;
 Process.Start(psi);
 
+// The properties must be set before the process is started
+var lateShellExecutePsi = new ProcessStartInfo("cmd") { RedirectStandardOutput = true }; // Non compliant as UseShellExecute is set after the process is started
+Process.Start(lateShellExecutePsi);
+lateShellExecutePsi.UseShellExecute = false;
+
+// The properties must be set whatever the branch that is executed
+var conditionalPsi = new ProcessStartInfo("cmd") // Non compliant as UseShellExecute can still be true
+{
+    RedirectStandardOutput = true,
+    UseShellExecute = true,
+};
+if (condition)
+{
+    conditionalPsi.UseShellExecute = false;
+}
+
+Process.Start(conditionalPsi);
+
 // Compliant
 
 Process.Start(new ProcessStartInfo("https://www.meziantou.net/")

--- a/src/Meziantou.Analyzer/Rules/ProcessStartAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ProcessStartAnalyzer.cs
@@ -55,46 +55,74 @@ public sealed class ProcessStartAnalyzer : DiagnosticAnalyzer
 
     }
 
-    private enum PropertyValue
+    /// <summary>
+    /// The values a property can have when the process is started. It can have multiple values when it is
+    /// assigned by an operation that may not be executed, such as the body of an <c>if</c> statement.
+    /// </summary>
+    [Flags]
+    private enum PropertyValues
     {
-        NotSet,
-        False,
-        True,
-        Unknown,
+        None = 0x0,
+        NotSet = 0x1,
+        False = 0x2,
+        True = 0x4,
+        Unknown = 0x8,
     }
 
     // The property names cannot use nameof as System.Diagnostics.ProcessStartInfo is banned in analyzers (RS1035)
     [StructLayout(LayoutKind.Auto)]
-    private struct ProcessStartInfoProperties
+    private struct ProcessStartInfoProperties()
     {
-        public PropertyValue UseShellExecute { get; private set; }
-        private PropertyValue RedirectStandardError { get; set; }
-        private PropertyValue RedirectStandardInput { get; set; }
-        private PropertyValue RedirectStandardOutput { get; set; }
+        private PropertyValues UseShellExecute { get; set; } = PropertyValues.NotSet;
+        private PropertyValues RedirectStandardError { get; set; } = PropertyValues.NotSet;
+        private PropertyValues RedirectStandardInput { get; set; } = PropertyValues.NotSet;
+        private PropertyValues RedirectStandardOutput { get; set; } = PropertyValues.NotSet;
 
         public readonly bool IsRedirecting
-            => RedirectStandardError is PropertyValue.True || RedirectStandardInput is PropertyValue.True || RedirectStandardOutput is PropertyValue.True;
+            => ((RedirectStandardError | RedirectStandardInput | RedirectStandardOutput) & PropertyValues.True) is not PropertyValues.None;
 
-        public void Set(string propertyName, PropertyValue value)
+        /// <summary>
+        /// The shell can be used to start the process, either because UseShellExecute can be true or because
+        /// it can keep its default value, which is true on .NET Framework.
+        /// </summary>
+        public readonly bool CanUseShellExecute
+            => (UseShellExecute & (PropertyValues.NotSet | PropertyValues.True)) is not PropertyValues.None;
+
+        public readonly bool IsUseShellExecuteNotSet => UseShellExecute is PropertyValues.NotSet;
+
+        /// <summary>
+        /// Replaces the values the property can have, for an assignment that is always executed.
+        /// </summary>
+        public void Set(string propertyName, PropertyValues values) => Update(propertyName, values, replaceExistingValues: true);
+
+        /// <summary>
+        /// Adds a value the property can have, for an assignment that may not be executed.
+        /// </summary>
+        public void AddPossibleValues(string propertyName, PropertyValues values) => Update(propertyName, values, replaceExistingValues: false);
+
+        private void Update(string propertyName, PropertyValues values, bool replaceExistingValues)
         {
             switch (propertyName)
             {
                 case "UseShellExecute":
-                    UseShellExecute = value;
+                    UseShellExecute = Merge(UseShellExecute, values, replaceExistingValues);
                     break;
 
                 case "RedirectStandardError":
-                    RedirectStandardError = value;
+                    RedirectStandardError = Merge(RedirectStandardError, values, replaceExistingValues);
                     break;
 
                 case "RedirectStandardInput":
-                    RedirectStandardInput = value;
+                    RedirectStandardInput = Merge(RedirectStandardInput, values, replaceExistingValues);
                     break;
 
                 case "RedirectStandardOutput":
-                    RedirectStandardOutput = value;
+                    RedirectStandardOutput = Merge(RedirectStandardOutput, values, replaceExistingValues);
                     break;
             }
+
+            static PropertyValues Merge(PropertyValues currentValues, PropertyValues newValues, bool replaceExistingValues)
+                => replaceExistingValues ? newValues : currentValues | newValues;
         }
     }
 
@@ -128,13 +156,13 @@ public sealed class ProcessStartAnalyzer : DiagnosticAnalyzer
             var properties = GetProperties(operation);
             if (properties.IsRedirecting)
             {
-                if (properties.UseShellExecute is PropertyValue.NotSet or PropertyValue.True)
+                if (properties.CanUseShellExecute)
                 {
                     // Redirecting standard input or output while UseShellExecute is not explicitly set to false
                     context.ReportDiagnostic(SetToFalseWhenRedirectingOutput, operation);
                 }
             }
-            else if (properties.UseShellExecute is PropertyValue.NotSet)
+            else if (properties.IsUseShellExecuteNotSet)
             {
                 // Constructing ProcessStartInfo without setting UseShellExecute
                 context.ReportDiagnostic(UseShellExecuteMustBeExplicitlySet, operation);
@@ -143,7 +171,7 @@ public sealed class ProcessStartAnalyzer : DiagnosticAnalyzer
 
         private ProcessStartInfoProperties GetProperties(IObjectCreationOperation operation)
         {
-            var result = default(ProcessStartInfoProperties);
+            var result = new ProcessStartInfoProperties();
             if (operation.Initializer is not null)
             {
                 foreach (var assignment in operation.Initializer.Initializers.OfType<ISimpleAssignmentOperation>())
@@ -161,15 +189,34 @@ public sealed class ProcessStartAnalyzer : DiagnosticAnalyzer
             var target = GetAssignmentTargetSymbol(operation);
             if (target is not null)
             {
-                foreach (var descendant in GetRootOperation(operation).Descendants())
+                var root = GetRootOperation(operation);
+                var assignments = GetPropertyAssignments(root, operation, target);
+
+                // The configuration that matters is the one the instance has when the process is started
+                var startOperation = FindProcessStart(root, operation, target);
+
+                // The assignments of a nested function are executed when the function is invoked, so they cannot
+                // be ordered with the start of the process
+                if (startOperation is not null && assignments.Any(item => IsInNestedFunction(item.Assignment, operation)))
                 {
-                    // Only the assignments that follow the creation apply to the created instance
-                    if (descendant is ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Instance: { } instance } propertyReference } assignment
-                        && descendant.Syntax.SpanStart > operation.Syntax.SpanStart
-                        && propertyReference.Property.ContainingType.IsEqualTo(_processStartInfoSymbol)
-                        && target.IsEqualTo(GetReferencedSymbol(instance)))
+                    startOperation = null;
+                }
+
+                foreach (var (propertyReference, assignment) in assignments)
+                {
+                    // The assignments that follow the start of the process cannot change its configuration
+                    if (startOperation is not null && assignment.Syntax.SpanStart > startOperation.Syntax.SpanStart)
+                        continue;
+
+                    var value = GetAssignedValue(assignment.Value);
+                    if (startOperation is null || IsAlwaysExecutedBefore(assignment, startOperation))
                     {
-                        result.Set(propertyReference.Property.Name, GetAssignedValue(assignment.Value));
+                        result.Set(propertyReference.Property.Name, value);
+                    }
+                    else
+                    {
+                        // The assignment may not be executed, so the property can also keep its previous values
+                        result.AddPossibleValues(propertyReference.Property.Name, value);
                     }
                 }
             }
@@ -177,11 +224,113 @@ public sealed class ProcessStartAnalyzer : DiagnosticAnalyzer
             return result;
         }
 
-        private static PropertyValue GetAssignedValue(IOperation operation) => operation.ConstantValue switch
+        private List<(IPropertyReferenceOperation PropertyReference, ISimpleAssignmentOperation Assignment)> GetPropertyAssignments(IOperation root, IObjectCreationOperation operation, ISymbol target)
         {
-            { HasValue: true, Value: true } => PropertyValue.True,
-            { HasValue: true, Value: false } => PropertyValue.False,
-            _ => PropertyValue.Unknown,
+            var result = new List<(IPropertyReferenceOperation, ISimpleAssignmentOperation)>();
+            foreach (var descendant in root.Descendants())
+            {
+                // Only the assignments that follow the creation apply to the created instance
+                if (descendant is ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Instance: { } instance } propertyReference } assignment
+                    && descendant.Syntax.SpanStart > operation.Syntax.SpanStart
+                    && propertyReference.Property.ContainingType.IsEqualTo(_processStartInfoSymbol)
+                    && target.IsEqualTo(GetReferencedSymbol(instance)))
+                {
+                    result.Add((propertyReference, assignment));
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Finds the first call to Process.Start that uses the created instance, as this is where its
+        /// configuration is used.
+        /// </summary>
+        private IOperation? FindProcessStart(IOperation root, IObjectCreationOperation operation, ISymbol target)
+        {
+            foreach (var descendant in root.Descendants())
+            {
+                if (descendant.Syntax.SpanStart <= operation.Syntax.SpanStart)
+                    continue;
+
+                if (descendant is not IInvocationOperation invocation || !IsProcessStartInvocation(invocation))
+                    continue;
+
+                if (!invocation.Arguments.Any(argument => target.IsEqualTo(GetReferencedSymbol(argument.Value))))
+                    continue;
+
+                // A nested function is invoked at an unknown time, which can be before the operations that precede it
+                if (IsInNestedFunction(invocation, operation))
+                    continue;
+
+                // The descendants are enumerated in source order, so this is the first start of the process
+                return invocation;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Indicates whether the operation is executed every time the process is started. This is an approximation
+        /// as it only relies on the position of the operations and on the operations that can skip them.
+        /// </summary>
+        private static bool IsAlwaysExecutedBefore(IOperation operation, IOperation use)
+        {
+            if (operation.Syntax.SpanStart > use.Syntax.SpanStart)
+                return false;
+
+            var child = operation;
+            foreach (var ancestor in operation.Ancestors())
+            {
+                if (ancestor.Syntax.Span.Contains(use.Syntax.Span))
+                {
+                    // The operations are in the same branch when the branch that contains the operation also contains the use
+                    return !CanBeSkipped(ancestor) || child.Syntax.Span.Contains(use.Syntax.Span);
+                }
+
+                if (CanBeSkipped(ancestor))
+                    return false;
+
+                child = ancestor;
+            }
+
+            return true;
+        }
+
+        private static bool IsInNestedFunction(IOperation operation, IObjectCreationOperation creation)
+        {
+            foreach (var ancestor in operation.Ancestors())
+            {
+                if (ancestor.Syntax.Span.Contains(creation.Syntax.Span))
+                    return false;
+
+                if (ancestor is IAnonymousFunctionOperation or ILocalFunctionOperation)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool CanBeSkipped(IOperation operation) => operation is
+            IConditionalOperation or
+            ILoopOperation or
+            ISwitchOperation or
+            ISwitchCaseOperation or
+            ISwitchExpressionOperation or
+            ISwitchExpressionArmOperation or
+            ICatchClauseOperation or
+            IConditionalAccessOperation or
+            ICoalesceOperation or
+            ICoalesceAssignmentOperation or
+            IAnonymousFunctionOperation or
+            ILocalFunctionOperation or
+            IBinaryOperation { OperatorKind: BinaryOperatorKind.ConditionalAnd or BinaryOperatorKind.ConditionalOr };
+
+        private static PropertyValues GetAssignedValue(IOperation operation) => operation.ConstantValue switch
+        {
+            { HasValue: true, Value: true } => PropertyValues.True,
+            { HasValue: true, Value: false } => PropertyValues.False,
+            _ => PropertyValues.Unknown,
         };
 
         private static ISymbol? GetAssignmentTargetSymbol(IObjectCreationOperation operation) => operation.Parent switch

--- a/tests/Meziantou.Analyzer.Test/Rules/ProcessStartAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ProcessStartAnalyzerTests.cs
@@ -478,6 +478,221 @@ public sealed class ProcessStartAnalyzerTests
     }
 
     [Fact]
+    public Task Process_start_should_report_when_use_shell_execute_is_set_to_false_after_the_process_is_started()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = {|#0:new ProcessStartInfo()
+                    {
+                        RedirectStandardOutput = true,
+                        UseShellExecute = true,
+                    }|};
+                    Process.Start(processStartInfo);
+                    processStartInfo.UseShellExecute = false;
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0163", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("Set UseShellExecute to false when redirecting standard input or output"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_report_when_the_redirection_is_disabled_after_the_process_is_started()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = {|#0:new ProcessStartInfo() { RedirectStandardOutput = true, UseShellExecute = true }|};
+                    Process.Start(processStartInfo);
+                    processStartInfo.RedirectStandardOutput = false;
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0163", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("Set UseShellExecute to false when redirecting standard input or output"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_report_when_the_redirection_is_enabled_after_the_process_is_started()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = {|#0:new ProcessStartInfo()|};
+                    Process.Start(processStartInfo);
+                    processStartInfo.RedirectStandardOutput = true;
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0161", DiagnosticSeverity.Info).WithLocation(0).WithMessage("UseShellExecute must be explicitly set when initializing a ProcessStartInfo"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_report_when_use_shell_execute_is_only_set_to_false_in_a_conditional_branch()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test(bool condition)
+                {
+                    var processStartInfo = {|#0:new ProcessStartInfo() { RedirectStandardOutput = true, UseShellExecute = true }|};
+                    if (condition)
+                    {
+                        processStartInfo.UseShellExecute = false;
+                    }
+
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0163", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("Set UseShellExecute to false when redirecting standard input or output"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_report_when_the_redirection_is_enabled_in_a_conditional_branch()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test(bool condition)
+                {
+                    var processStartInfo = {|#0:new ProcessStartInfo() { UseShellExecute = true }|};
+                    if (condition)
+                    {
+                        processStartInfo.RedirectStandardOutput = true;
+                    }
+
+                    Process.Start(processStartInfo);
+                }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0163", DiagnosticSeverity.Warning).WithLocation(0).WithMessage("Set UseShellExecute to false when redirecting standard input or output"));
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_not_report_when_the_process_is_started_in_the_branch_that_sets_use_shell_execute()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test(bool condition)
+                {
+                    var processStartInfo = new ProcessStartInfo() { RedirectStandardOutput = true };
+                    if (condition)
+                    {
+                        processStartInfo.UseShellExecute = false;
+                        Process.Start(processStartInfo);
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_not_report_when_the_process_is_started_in_a_loop_after_use_shell_execute_is_set()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test(bool condition)
+                {
+                    var processStartInfo = new ProcessStartInfo() { RedirectStandardOutput = true };
+                    while (condition)
+                    {
+                        processStartInfo.UseShellExecute = false;
+                        Process.Start(processStartInfo);
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_not_report_when_use_shell_execute_is_set_in_a_local_function()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = new ProcessStartInfo() { RedirectStandardOutput = true };
+                    Configure();
+                    Process.Start(processStartInfo);
+
+                    void Configure() => processStartInfo.UseShellExecute = false;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Process_start_should_not_report_when_use_shell_execute_is_set_after_the_start_info_is_assigned_to_a_process()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Diagnostics;
+
+            class TypeName
+            {
+                public void Test()
+                {
+                    var processStartInfo = new ProcessStartInfo() { RedirectStandardOutput = true };
+                    using var process = new Process() { StartInfo = processStartInfo };
+                    processStartInfo.UseShellExecute = false;
+                    process.Start();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Process_start_should_report_when_use_shell_execute_is_not_set_2()
     {
         var test = new CodeFixTest();


### PR DESCRIPTION
## Problem

MA0163 collected the `ProcessStartInfo` properties from **every** assignment that followed the creation, whatever its position in the method and whatever the branch it was in. A later write therefore suppressed an earlier real configuration error:

```csharp
var info = new ProcessStartInfo("unused")
{
    UseShellExecute = true,
    RedirectStandardOutput = true,
};
Process.Start(info);          // throws: UseShellExecute must be false when redirecting I/O
info.UseShellExecute = false; // this assignment used to silence MA0163
```

Removing the last line made the analyzer report MA0163, so the assignment that cannot possibly affect the earlier call was hiding the diagnostic.

## Fix

`GetProperties` no longer folds every later assignment into the creation. It locates where the configuration is consumed and evaluates the state at that point:

1. `FindProcessStart` finds the first `Process.Start(psi)` call that receives the tracked instance (calls inside a lambda or local function are skipped, as their execution cannot be ordered by position).
2. Assignments **after** that call are ignored: they cannot fix the configuration it already used.
3. Assignments that **may be skipped** relative to that call no longer overwrite the state, they only add a value the property can have. `IsAlwaysExecutedBefore` walks the ancestors looking for `if`/loop/`switch`/`catch`/`?.`/`??`/`&&`/`||`/nested functions that do not also contain the start.
4. `PropertyValue` became the `[Flags] PropertyValues` set, so a property tracks every value it can have when the process is started, and MA0163 is reported when `UseShellExecute` can be `true` or can keep its default value (which is `true` on .NET Framework).

When no `Process.Start` call is visible, or when a nested function assigns the properties, the analyzer falls back to the previous last-write-wins behavior instead of guessing. Two tests pin that: `new Process { StartInfo = psi }` followed by a fix-up assignment, and a `Configure()` local function that sets `UseShellExecute`, must not report.

## Behavior changes

Newly reported:

- an assignment that follows `Process.Start` (the case above), including a redirection disabled after the start;
- `UseShellExecute = false` set only in a conditional branch while the initializer redirects and sets `UseShellExecute = true`.

One intentional shift: `new ProcessStartInfo(); Process.Start(psi); psi.RedirectStandardOutput = true;` now reports MA0161 instead of MA0163, since nothing is redirected at the start call, only `UseShellExecute` is unset.

The code fixer is untouched: it only fixes MA0161 and still reports on the object creation.

## Validation

- 9 tests added to `ProcessStartAnalyzerTests`. 4 of them fail against the unmodified analyzer (checked by restoring the original file and re-running), the other 5 guard against false positives.
- `ProcessStartAnalyzerTests`: 36 passed, 0 failed on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- Full test suite: 4389 passed, 0 failed on Roslyn 5.9, and 4272 passed, 0 failed on Roslyn 4.8. The whole solution builds with 0 warnings.
- `docs/Rules/MA0163.md` gained the two new non-compliant examples, and `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes.