### PR TITLE
Fix MA0166 inserting the TimeProvider in an invalid argument position

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasTimeProviderFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasTimeProviderFixer.cs
@@ -11,52 +11,85 @@ public sealed class UseAnOverloadThatHasTimeProviderFixer : CodeFixProvider
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        if (nodeToFix is null)
+        if (nodeToFix is not InvocationExpressionSyntax invocationExpression)
             return;
 
-        if (nodeToFix.IsKind(SyntaxKind.InvocationExpression))
+        if (!int.TryParse(context.Diagnostics[0].Properties.GetValueOrDefault(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterIndexKey), NumberStyles.None, CultureInfo.InvariantCulture, out var parameterIndex))
+            return;
+
+        if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterNameKey, out var parameterName) || parameterName is null)
+            return;
+
+        if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasTimeProviderAnalyzerCommon.PathsKey, out var paths) || paths is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var timeProviderSymbol = semanticModel.Compilation.GetBestTypeByMetadataName("System.TimeProvider");
+        if (timeProviderSymbol is null)
+            return;
+
+        var generator = SyntaxGenerator.GetGenerator(context.Document);
+        foreach (var path in paths.Split(','))
         {
-            if (!int.TryParse(context.Diagnostics[0].Properties.GetValueOrDefault(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterIndexKey), NumberStyles.None, CultureInfo.InvariantCulture, out var parameterIndex))
-                return;
+            var newInvocation = CreateInvocation(semanticModel, generator, invocationExpression, parameterIndex, parameterName, path, timeProviderSymbol);
+            if (newInvocation is null)
+                continue;
 
-            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterNameKey, out var parameterName) || parameterName is null)
-                return;
+            var title = "Use TimeProvider:  " + path;
+            var codeAction = CodeAction.Create(
+                title,
+                ct => FixInvocation(context.Document, invocationExpression, newInvocation, ct),
+                equivalenceKey: title);
 
-            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasTimeProviderAnalyzerCommon.PathsKey, out var paths) || paths is null)
-                return;
-
-            foreach (var cancellationToken in paths.Split(','))
-            {
-                var title = "Use TimeProvider:  " + cancellationToken;
-                var codeAction = CodeAction.Create(
-                    title,
-                    ct => FixInvocation(context.Document, (InvocationExpressionSyntax)nodeToFix, parameterIndex, parameterName, cancellationToken, ct),
-                    equivalenceKey: title);
-
-                context.RegisterCodeFix(codeAction, context.Diagnostics);
-            }
+            context.RegisterCodeFix(codeAction, context.Diagnostics);
         }
     }
 
-    private static async Task<Document> FixInvocation(Document document, InvocationExpressionSyntax nodeToFix, int index, string parameterName, string cancellationTokenText, CancellationToken cancellationToken)
+    private static InvocationExpressionSyntax? CreateInvocation(SemanticModel semanticModel, SyntaxGenerator generator, InvocationExpressionSyntax nodeToFix, int parameterIndex, string parameterName, string timeProviderPath, INamedTypeSymbol timeProviderSymbol)
+    {
+        var timeProviderExpression = SyntaxFactory.ParseExpression(timeProviderPath);
+        var arguments = nodeToFix.ArgumentList.Arguments;
+
+        // A positional argument can only be added at the index of the parameter when all the arguments written before it are positional.
+        // Otherwise, C# does not allow it (CS1738, CS1739, CS8323) or it would be bound to the wrong parameter.
+        if (parameterIndex <= arguments.Count && !arguments.Take(parameterIndex).Any(argument => argument.NameColon is not null))
+        {
+            var positionalArgument = (ArgumentSyntax)generator.Argument(timeProviderExpression);
+            var candidate = ReplaceArguments(nodeToFix, arguments.Insert(parameterIndex, positionalArgument));
+            if (GetTargetMethod(semanticModel, nodeToFix, candidate) is { } method && parameterIndex < method.Parameters.Length && method.Parameters[parameterIndex].Type.IsEqualTo(timeProviderSymbol))
+                return candidate;
+        }
+
+        // A named argument added at the end of the list is valid whatever the order of the existing arguments
+        var namedArgument = (ArgumentSyntax)generator.Argument(parameterName, RefKind.None, timeProviderExpression);
+        var namedCandidate = ReplaceArguments(nodeToFix, arguments.Add(namedArgument));
+        var namedParameter = GetTargetMethod(semanticModel, nodeToFix, namedCandidate)?.Parameters.FirstOrDefault(parameter => string.Equals(parameter.Name, parameterName, StringComparison.Ordinal));
+        if (namedParameter is not null && namedParameter.Type.IsEqualTo(timeProviderSymbol))
+            return namedCandidate;
+
+        return null;
+    }
+
+    private static InvocationExpressionSyntax ReplaceArguments(InvocationExpressionSyntax nodeToFix, SeparatedSyntaxList<ArgumentSyntax> arguments)
+    {
+        return nodeToFix.WithArgumentList(nodeToFix.ArgumentList.WithArguments(arguments));
+    }
+
+    /// <summary>
+    /// Gets the method the invocation would be bound to, so the fix is only offered when the new invocation compiles
+    /// and the new argument is bound to the expected parameter.
+    /// </summary>
+    private static IMethodSymbol? GetTargetMethod(SemanticModel semanticModel, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation)
+    {
+        return semanticModel.GetSpeculativeSymbolInfo(nodeToFix.SpanStart, newInvocation, SpeculativeBindingOption.BindAsExpression).Symbol as IMethodSymbol;
+    }
+
+    private static async Task<Document> FixInvocation(Document document, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var generator = editor.Generator;
-
-        var cancellationTokenExpression = SyntaxFactory.ParseExpression(cancellationTokenText);
-
-        SyntaxNode newInvocation;
-        if (index > nodeToFix.ArgumentList.Arguments.Count)
-        {
-            var newArguments = nodeToFix.ArgumentList.Arguments.Add((ArgumentSyntax)generator.Argument(parameterName, RefKind.None, cancellationTokenExpression));
-            newInvocation = nodeToFix.WithArgumentList(SyntaxFactory.ArgumentList(newArguments));
-        }
-        else
-        {
-            var newArguments = nodeToFix.ArgumentList.Arguments.Insert(index, (ArgumentSyntax)generator.Argument(cancellationTokenExpression));
-            newInvocation = nodeToFix.WithArgumentList(SyntaxFactory.ArgumentList(newArguments));
-        }
-
         editor.ReplaceNode(nodeToFix, newInvocation);
         return editor.GetChangedDocument();
     }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
@@ -226,4 +226,207 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzerTests
 
         return test.RunAsync();
     }
+    [Fact]
+    public Task NamedArguments_OutOfOrder()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                System.Threading.Tasks.Task A(System.TimeProvider foo, System.Threading.CancellationToken token)
+                    => {|MA0166:System.Threading.Tasks.Task.Delay(cancellationToken: token, delay: System.TimeSpan.Zero)|};
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                System.Threading.Tasks.Task A(System.TimeProvider foo, System.Threading.CancellationToken token)
+                    => System.Threading.Tasks.Task.Delay(cancellationToken: token, delay: System.TimeSpan.Zero, timeProvider: foo);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task NamedArguments_InOrder()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                System.Threading.Tasks.Task A(System.TimeProvider foo, System.Threading.CancellationToken token)
+                    => {|MA0166:System.Threading.Tasks.Task.Delay(delay: System.TimeSpan.Zero, cancellationToken: token)|};
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                System.Threading.Tasks.Task A(System.TimeProvider foo, System.Threading.CancellationToken token)
+                    => System.Threading.Tasks.Task.Delay(delay: System.TimeSpan.Zero, cancellationToken: token, timeProvider: foo);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task NamedArgumentAfterTimeProviderParameter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                System.Threading.Tasks.Task A(System.TimeProvider foo, System.Threading.CancellationToken token)
+                    => {|MA0166:System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero, cancellationToken: token)|};
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                System.Threading.Tasks.Task A(System.TimeProvider foo, System.Threading.CancellationToken token)
+                    => System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero, foo, cancellationToken: token);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PositionalArgumentAfterTimeProviderParameter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                System.Threading.Tasks.Task A(System.TimeProvider foo, System.Threading.CancellationToken token)
+                    => {|MA0166:System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero, token)|};
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                System.Threading.Tasks.Task A(System.TimeProvider foo, System.Threading.CancellationToken token)
+                    => System.Threading.Tasks.Task.Delay(System.TimeSpan.Zero, foo, token);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionalParameter_WithNamedArgumentBeforeTimeProvider()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                static void Delay(int a = 0, int b = 0, System.TimeProvider timeProvider = null)
+                {
+                }
+
+                void A(System.TimeProvider foo)
+                {
+                    {|MA0166:Delay(b: 1)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                static void Delay(int a = 0, int b = 0, System.TimeProvider timeProvider = null)
+                {
+                }
+
+                void A(System.TimeProvider foo)
+                {
+                    Delay(b: 1, timeProvider: foo);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+    [Fact]
+    public Task ExtensionMethod()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            static class Test
+            {
+                static void A(this string str, int a) { }
+                static void A(this string str, int a, System.TimeProvider timeProvider) { }
+
+                static void B(System.TimeProvider foo) => {|MA0166:"".A(0)|};
+            }
+            """;
+        test.FixedCode = """
+            static class Test
+            {
+                static void A(this string str, int a) { }
+                static void A(this string str, int a, System.TimeProvider timeProvider) { }
+
+                static void B(System.TimeProvider foo) => "".A(0, timeProvider: foo);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ParamsParameter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                static void Delay(params int[] values) { }
+                static void Delay(System.TimeProvider timeProvider, params int[] values) { }
+
+                void A(System.TimeProvider foo)
+                {
+                    {|MA0166:Delay(1, 2)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                static void Delay(params int[] values) { }
+                static void Delay(System.TimeProvider timeProvider, params int[] values) { }
+
+                void A(System.TimeProvider foo)
+                {
+                    Delay(foo, 1, 2);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+    [Fact]
+    public Task NoFix_WhenTheProviderCannotBeAddedWithoutReorderingTheArguments()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            static class Test
+            {
+                static void A(this string str, int a) { }
+                static void A(this string str, System.TimeProvider timeProvider, int a) { }
+
+                static void B(System.TimeProvider foo) => {|MA0166:"".A(0)|};
+            }
+            """;
+        test.FixedCode = """
+            static class Test
+            {
+                static void A(this string str, int a) { }
+                static void A(this string str, System.TimeProvider timeProvider, int a) { }
+
+                static void B(System.TimeProvider foo) => {|MA0166:"".A(0)|};
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
The MA0166 code fix inserted the `TimeProvider` argument at the index of the parameter in the *written* argument list. Named arguments can be written in another order, so the inserted positional argument could end up after an out-of-order named argument.

```csharp
using System;
using System.Threading;
using System.Threading.Tasks;
public class Sample
{
    public static Task M(TimeProvider provider, CancellationToken token)
        => Task.Delay(cancellationToken: token, delay: TimeSpan.FromSeconds(1));
}
```

The original code compiles, but the fix produced `Task.Delay(cancellationToken: token, provider, delay: TimeSpan.FromSeconds(1))`, which reports CS1739.

## What changed

`UseAnOverloadThatHasTimeProviderFixer`:

- The argument is inserted at the index of the parameter only when every argument written before that index is positional. Otherwise it is added as a named argument (`timeProvider: provider`) at the end of the list, which is valid whatever the order of the existing arguments and keeps them and their evaluation order untouched.
- The candidate invocation is bound with `SemanticModel.GetSpeculativeSymbolInfo(..., SpeculativeBindingOption.BindAsExpression)` before the fix is registered, so the fix is only offered when the new invocation compiles and the new argument is bound to the `TimeProvider` parameter. The positional form is tried first, then the named one; when neither binds, no fix is registered. This also follows the "validate before registering" rule of `AGENTS.md`, which the previous code did not: it registered the fix and computed the result afterwards.

Incidental: the argument list is rebuilt with `ArgumentList.WithArguments` instead of a new `SyntaxFactory.ArgumentList`, so the trivia of the parentheses is preserved.

## Notes for the reviewer

One behavior change beyond the broken case: when the named arguments are written *in* order (`Task.Delay(delay: x, cancellationToken: t)`), the fix used to emit a non-trailing positional argument, which compiles but only with C# 7.2 or later. It now emits a named argument there too.

The same defect exists in `UseAnOverloadThatHasCancellationTokenFixer_Argument` and `UseAnOverloadThatHasMidpointRoundingFixer`, which use the identical insert-at-ordinal logic. They are left out of this PR to keep it scoped to MA0166.

## Tests

8 tests added to `UseAnOverloadThatHasTimeProviderAnalyzerTests`: out-of-order named arguments, named arguments written in order, a named argument after the insertion point, a positional argument that must still shift, an optional-parameter case, extension methods, `params`, and a case where no valid insertion exists (asserting that no fix is applied). The two named-argument tests were confirmed to fail against the previous fixer.

- `dotnet build`: 0 warnings, 0 errors for all five Roslyn versions.
- `UseAnOverloadThatHas*` tests: 97 passed on each of roslyn4.8, 4.14, 5.0, 5.6 and 5.9; 0 failed, 0 skipped.
- Full test suite on roslyn5.9: 4388 passed, 0 failed, 0 skipped.
- `dotnet run --project src/DocumentationGenerator`: exit code 0, no markdown change.
