### PR TITLE
Do not report MA0214 when the function cannot be made async

### DIFF
--- a/docs/Rules/MA0214.md
+++ b/docs/Rules/MA0214.md
@@ -15,6 +15,12 @@ async Task<int> Sample() => await GetValueAsync(); // compliant
 
 The rule reports methods, local functions, and lambdas whose **every** `return` statement returns an awaitable task (or whose expression body does). It is not reported when a return value cannot be awaited (`return null;`, `return default;`), nor inside `try`/`using`/`lock`/`fixed` blocks. When several `return` statements are present they are all rewritten to use `await`.
 
+The rule is not reported when the `async` modifier cannot be added to the function, such as when it has a `ref`, `out`, `in`, `ref readonly`, pointer or `ref struct` parameter, when it is an instance method of a `ref struct`, or when it is annotated with `[MethodImpl(MethodImplOptions.Synchronized)]`:
+
+````c#
+Task<int> Sample(ref int value) => GetValueAsync(); // compliant, an async method cannot have a 'ref' parameter
+````
+
 Functions that only return already-completed tasks, such as the ones implementing an asynchronous interface synchronously, are not reported as awaiting those tasks brings no benefit:
 
 ````c#

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAwaitInsteadOfReturningTaskFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAwaitInsteadOfReturningTaskFixer.cs
@@ -14,29 +14,41 @@ public sealed class UseAwaitInsteadOfReturningTaskFixer : CodeFixProvider
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        if (nodeToFix is not ExpressionSyntax)
+        if (nodeToFix is not ExpressionSyntax value)
             return;
 
-        if (nodeToFix.FirstAncestorOrSelf<SyntaxNode>(IsFunction) is null)
+        var function = value.FirstAncestorOrSelf<SyntaxNode>(IsFunction);
+        if (function is null)
+            return;
+
+        if (GetBody(function) is (null, null))
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        // The fix adds the 'async' modifier, which the signature of the function must support
+        if (GetFunctionSymbol(semanticModel, function, context.CancellationToken) is not { } method || !UseAwaitInsteadOfReturningTaskCommon.CanBeMadeAsync(method, semanticModel.Compilation))
             return;
 
         const string Title = "Use await";
         context.RegisterCodeFix(
-            CodeAction.Create(Title, ct => FixAsync(context.Document, nodeToFix, ct), equivalenceKey: Title),
+            CodeAction.Create(Title, ct => FixAsync(context.Document, value, function, ct), equivalenceKey: Title),
             context.Diagnostics);
     }
 
-    private static async Task<Document> FixAsync(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static IMethodSymbol? GetFunctionSymbol(SemanticModel semanticModel, SyntaxNode function, CancellationToken cancellationToken)
+    {
+        return function is MethodDeclarationSyntax or LocalFunctionStatementSyntax
+            ? semanticModel.GetDeclaredSymbol(function, cancellationToken) as IMethodSymbol
+            : semanticModel.GetSymbolInfo(function, cancellationToken).Symbol as IMethodSymbol;
+    }
+
+    private static async Task<Document> FixAsync(Document document, ExpressionSyntax value, SyntaxNode function, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         var semanticModel = editor.SemanticModel;
-
-        if (nodeToFix is not ExpressionSyntax value)
-            return document;
-
-        var function = value.FirstAncestorOrSelf<SyntaxNode>(IsFunction);
-        if (function is null)
-            return document;
 
         var isGeneric = IsGenericTaskLike(semanticModel.Compilation, semanticModel.GetTypeInfo(value, cancellationToken).ConvertedType);
 

--- a/src/Meziantou.Analyzer/Rules/UseAwaitInsteadOfReturningTaskAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAwaitInsteadOfReturningTaskAnalyzer.cs
@@ -56,9 +56,9 @@ public sealed class UseAwaitInsteadOfReturningTaskAnalyzer : DiagnosticAnalyzer
         if (method.IsAsync)
             return;
 
-        // Only members that support the 'async' keyword can be reported. Property/event accessors, operators,
-        // constructors, etc. cannot be async even though they may return an awaitable type.
-        if (method.MethodKind is not (MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation or MethodKind.LocalFunction or MethodKind.LambdaMethod or MethodKind.AnonymousFunction))
+        // The 'async' modifier must be addable to the function, which excludes the members that do not support it
+        // (property accessors, operators, constructors, ...) and the signatures that forbid it (ref parameters, ...)
+        if (!UseAwaitInsteadOfReturningTaskCommon.CanBeMadeAsync(method, context.Compilation))
             return;
 
         // The function must return an awaitable type that can be used with the 'async' keyword

--- a/src/Meziantou.Analyzer/Rules/UseAwaitInsteadOfReturningTaskCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAwaitInsteadOfReturningTaskCommon.cs
@@ -1,0 +1,100 @@
+using System.Runtime.CompilerServices;
+
+namespace Meziantou.Analyzer.Rules;
+
+internal static class UseAwaitInsteadOfReturningTaskCommon
+{
+    /// <summary>
+    /// Determines whether the <see langword="async"/> modifier can be added to the function without breaking the compilation.
+    /// </summary>
+    internal static bool CanBeMadeAsync(IMethodSymbol method, Compilation compilation)
+    {
+        // Only members that support the 'async' keyword can be reported. Property/event accessors, operators,
+        // constructors, etc. cannot be async even though they may return an awaitable type.
+        if (method.MethodKind is not (MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation or MethodKind.LocalFunction or MethodKind.LambdaMethod or MethodKind.AnonymousFunction))
+            return false;
+
+        // 'async' cannot be combined with a by-reference return type (CS1073)
+        if (method.ReturnsByRef || method.ReturnsByRefReadonly)
+            return false;
+
+        // An instance of a ref struct cannot be preserved across an 'await' boundary, so the instance methods
+        // of a ref struct cannot be async (CS4007). Local functions and lambdas already cannot capture the
+        // 'this' of a ref struct, so only the members themselves are excluded.
+        if (method.MethodKind is (MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation) && !method.IsStatic && method.ContainingType is { IsRefLikeType: true })
+            return false;
+
+        // 'MethodImplOptions.Synchronized' cannot be applied to an async method (CS4015)
+        if (IsSynchronized(method, compilation))
+            return false;
+
+        foreach (var parameter in method.Parameters)
+        {
+            // Async methods cannot have ref, in or out parameters (CS1988)
+            if (parameter.RefKind is not RefKind.None)
+                return false;
+
+            // Async methods cannot have pointer type parameters (CS4005)
+            if (parameter.Type is IPointerTypeSymbol or IFunctionPointerTypeSymbol)
+                return false;
+
+            // Parameters of a ref struct type cannot be declared in async methods (CS4012)
+            if (IsRefLikeOrAllowsRefLike(parameter.Type))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsRefLikeOrAllowsRefLike(ITypeSymbol type)
+    {
+        if (type.IsRefLikeType)
+            return true;
+
+#if ROSLYN_4_14_OR_GREATER
+        if (type is ITypeParameterSymbol { AllowsRefLikeType: true })
+            return true;
+#endif
+
+        return false;
+    }
+
+    private static bool IsSynchronized(IMethodSymbol method, Compilation compilation)
+    {
+        var methodImplAttributeSymbol = compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.MethodImplAttribute");
+        if (methodImplAttributeSymbol is null)
+            return false;
+
+        foreach (var attribute in method.GetAttributes())
+        {
+            if (!attribute.AttributeClass.IsEqualTo(methodImplAttributeSymbol))
+                continue;
+
+            foreach (var argument in attribute.ConstructorArguments)
+            {
+                if (HasSynchronizedFlag(argument))
+                    return true;
+            }
+
+            foreach (var argument in attribute.NamedArguments)
+            {
+                if (HasSynchronizedFlag(argument.Value))
+                    return true;
+            }
+        }
+
+        return false;
+
+        static bool HasSynchronizedFlag(TypedConstant constant)
+        {
+            var value = constant.Value switch
+            {
+                short shortValue => shortValue,
+                int intValue => intValue,
+                _ => 0,
+            };
+
+            return (value & (int)MethodImplOptions.Synchronized) is not 0;
+        }
+    }
+}

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAwaitInsteadOfReturningTaskAnalyzerTests.cs
@@ -10,6 +10,14 @@ public sealed class UseAwaitInsteadOfReturningTaskAnalyzerTests
 {
     private static CodeFixTest CreateTest() => new();
 
+    private static CodeFixTest CreateUnsafeTest()
+    {
+        var test = CreateTest();
+        test.SolutionTransforms.Add(static (solution, projectId) =>
+            solution.WithProjectCompilationOptions(projectId, ((CSharpCompilationOptions)solution.GetProject(projectId)!.CompilationOptions!).WithAllowUnsafe(true)));
+        return test;
+    }
+
     [Fact]
     public void Rule_IsDisabledByDefault()
     {
@@ -995,6 +1003,292 @@ public sealed class UseAwaitInsteadOfReturningTaskAnalyzerTests
             {
                 static Task CompletedTask => throw null;
                 async Task A() => await CompletedTask;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefParameter_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                static Task<int> A(ref int value) => Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OutParameter_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                static Task<int> A(out int value)
+                {
+                    value = 0;
+                    return Inner();
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task InParameter_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                static Task<int> A(in int value) => Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefReadonlyParameter_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                static Task<int> A(ref readonly int value) => Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefParameter_LocalFunction_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                void A()
+                {
+                    _ = (Del)Local;
+                    static Task<int> Local(ref int value) => Inner();
+                }
+
+                delegate Task<int> Del(ref int value);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefParameter_Lambda_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                void A()
+                {
+                    Del d = (ref int value) => Inner();
+                }
+
+                delegate Task<int> Del(ref int value);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PointerParameter_NoDiagnostic()
+    {
+        var test = CreateUnsafeTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                static unsafe Task<int> A(int* value) => Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FunctionPointerParameter_NoDiagnostic()
+    {
+        var test = CreateUnsafeTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                static unsafe Task<int> A(delegate*<void> value) => Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefStructParameter_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                static Task<int> A(Span<int> value) => Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+#if CSHARP13_OR_GREATER
+    [Fact]
+    public Task AllowsRefStructTypeParameter_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+                static Task<int> A<T>(T value) where T : allows ref struct => Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+#endif
+
+    [Fact]
+    public Task RefStructInstanceMethod_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            ref struct Test
+            {
+                int _field;
+                static Task<int> Inner() => throw null;
+                Task<int> A() => Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefStructStaticMethod_Diagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            ref struct Test
+            {
+                int _field;
+                static Task<int> Inner() => throw null;
+                static Task<int> A() => {|MA0214:Inner()|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading.Tasks;
+            ref struct Test
+            {
+                int _field;
+                static Task<int> Inner() => throw null;
+                static async Task<int> A() => await Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RefReturn_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> _field;
+                static ref Task<int> A() => ref _field;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MethodImplSynchronized_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Runtime.CompilerServices;
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+
+                [MethodImpl(MethodImplOptions.Synchronized)]
+                static Task<int> A() => Inner();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MethodImplAggressiveInlining_Diagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Runtime.CompilerServices;
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static Task<int> A() => {|MA0214:Inner()|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Runtime.CompilerServices;
+            using System.Threading.Tasks;
+            class Test
+            {
+                static Task<int> Inner() => throw null;
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static async Task<int> A() => await Inner();
             }
             """;
 


### PR DESCRIPTION
## What

MA0214 (*Use 'await' instead of returning the task*) validated the kind of the member and its return type, but never whether the signature allows the `async` modifier. The code fix then added `async` unconditionally, producing code that does not compile:

```csharp
// Before: reported, and the fix produced code that fails with CS1988
public static Task Run(ref int value) => Task.Delay(value);
```

## Why

The rule is disabled by default, but when enabled its fix silently broke the build. Adding `async` is only valid for a subset of signatures, and neither the analyzer nor the fixer checked for it.

## How

A new shared `UseAwaitInsteadOfReturningTaskCommon.CanBeMadeAsync(IMethodSymbol, Compilation)` is picked up by both the analyzer and the code fixer through the existing `Rules\*Common.cs` wildcard. It absorbs the previous `MethodKind` check and adds the restrictions the compiler enforces — each one verified against the compiler rather than assumed:

| Restriction | Error |
|---|---|
| `ref` / `out` / `in` / `ref readonly` parameters | CS1988 (the reported bug) |
| pointer and function pointer parameters | CS4005 |
| `ref struct` parameters, incl. type parameters with `allows ref struct` | CS4012 |
| instance methods of a `ref struct` | CS4007 |
| `[MethodImpl(MethodImplOptions.Synchronized)]` | CS4015 |
| by-reference return types | CS1073 |

The fixer also now resolves the enclosing function's symbol and validates it — plus that a body exists — **before** calling `RegisterCodeFix`, following the repository's fixer guidance, instead of returning an unchanged document after the fix has already been offered to the user.

## Notes for the reviewer

Two deliberate judgment calls:

- **The `ref struct` instance-method exclusion is conservative.** The compiler only rejects those whose `this` actually needs preserving (an empty `ref struct` compiles), but distinguishing that is not worth the complexity for an opt-in rule: the cost is a missed suggestion, not broken code.
- **`ITypeParameterSymbol.AllowsRefLikeType` does not exist before Roslyn 4.14**, so that single branch sits behind `#if ROSLYN_4_14_OR_GREATER`. `allows ref struct` is C# 13 and cannot be written against Roslyn 4.8 anyway; its test is guarded with `#if CSHARP13_OR_GREATER`.

## Tests

15 tests added to `UseAwaitInsteadOfReturningTaskAnalyzerTests`: 13 negative, plus a `ref struct` **static** method and a `[MethodImpl(AggressiveInlining)]` method that still report and fix, so the new checks are not over-broad. Each negative test was confirmed to fail without the fix by neutering the checks and re-running — all 13 failed, the positive ones stayed green.

- MA0214 class passes on all five Roslyn versions (53 on 4.8 with the C# 13 test compiled out, 54 on 4.14 / 5.0 / 5.6 / 5.9).
- Full suite on Roslyn 5.9: 4394 passed, 0 failed. The full suite was not re-run on the other four versions, only the MA0214 class.
- `dotnet build` clean; `dotnet run --project src/DocumentationGenerator` exits 0 after the hand-written addition to `docs/Rules/MA0214.md`.
