### PR TITLE
Preserve argument binding in the MA0108 code fix

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/SimplifyCallerArgumentExpressionFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/SimplifyCallerArgumentExpressionFixer.cs
@@ -13,18 +13,87 @@ public sealed class SimplifyCallerArgumentExpressionFixer : CodeFixProvider
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: false);
-        if (nodeToFix is null or not ArgumentSyntax)
+        if (root?.FindNode(context.Span, getInnermostNodeForTie: false) is not ArgumentSyntax nodeToFix)
+            return;
+
+        if (nodeToFix.Parent is not ArgumentListSyntax argumentList)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        // Removing the argument shifts the following positional arguments, so they must be named to keep binding to the same parameters
+        if (GetArgumentsToName(semanticModel, argumentList, nodeToFix, context.CancellationToken) is not { } argumentsToName)
             return;
 
         var title = "Remove argument";
-        context.RegisterCodeFix(CodeAction.Create(title, ct => RemoveArgument(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
+        context.RegisterCodeFix(CodeAction.Create(title, ct => RemoveArgument(context.Document, nodeToFix, argumentsToName, ct), equivalenceKey: title), context.Diagnostics);
     }
 
-    private static async Task<Document> RemoveArgument(Document document, SyntaxNode nodeToFix, CancellationToken cancellationToken)
+    private static List<(ArgumentSyntax Argument, string ParameterName)>? GetArgumentsToName(SemanticModel semanticModel, ArgumentListSyntax argumentList, ArgumentSyntax argumentToRemove, CancellationToken cancellationToken)
+    {
+        var arguments = argumentList.Arguments;
+        var index = arguments.IndexOf(argumentToRemove);
+        if (index < 0)
+            return null;
+
+        var result = new List<(ArgumentSyntax, string)>();
+        Dictionary<SyntaxNode, string>? parameterNames = null;
+        for (var i = index + 1; i < arguments.Count; i++)
+        {
+            var argument = arguments[i];
+            if (argument.NameColon is not null)
+                continue;
+
+            parameterNames ??= GetParameterNames(semanticModel, argumentList, cancellationToken);
+            if (parameterNames is null || !parameterNames.TryGetValue(argument, out var parameterName))
+                return null;
+
+            result.Add((argument, parameterName));
+        }
+
+        return result;
+    }
+
+    private static Dictionary<SyntaxNode, string>? GetParameterNames(SemanticModel semanticModel, ArgumentListSyntax argumentList, CancellationToken cancellationToken)
+    {
+        if (argumentList.Parent is null)
+            return null;
+
+        if (semanticModel.GetOperation(argumentList.Parent, cancellationToken) is not IInvocationOperation invocation)
+            return null;
+
+        var result = new Dictionary<SyntaxNode, string>();
+        foreach (var argument in invocation.Arguments)
+        {
+            // Only the arguments written by the user can be named. In particular, the arguments of a
+            // params parameter in its expanded form cannot be converted to a named argument.
+            if (argument.ArgumentKind is not ArgumentKind.Explicit || argument.Parameter is null)
+                continue;
+
+            result[argument.Syntax] = argument.Parameter.Name;
+        }
+
+        return result;
+    }
+
+    private static async Task<Document> RemoveArgument(Document document, ArgumentSyntax argumentToRemove, List<(ArgumentSyntax Argument, string ParameterName)> argumentsToName, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        editor.RemoveNode(nodeToFix, SyntaxRemoveOptions.KeepNoTrivia);
+        foreach (var (argument, parameterName) in argumentsToName)
+        {
+            editor.ReplaceNode(argument, argument.WithNameColon(SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(CreateIdentifier(parameterName)))));
+        }
+
+        editor.RemoveNode(argumentToRemove, SyntaxRemoveOptions.KeepNoTrivia);
         return editor.GetChangedDocument();
+    }
+
+    private static SyntaxToken CreateIdentifier(string parameterName)
+    {
+        return SyntaxFacts.GetKeywordKind(parameterName) is SyntaxKind.None
+            ? SyntaxFactory.Identifier(parameterName)
+            : SyntaxFactory.VerbatimIdentifier(leading: default, text: parameterName, valueText: parameterName, trailing: default);
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/SimplifyCallerArgumentExpressionAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/SimplifyCallerArgumentExpressionAnalyzerTests.cs
@@ -91,7 +91,135 @@ public class SimplifyCallerArgumentExpressionAnalyzerTests
 
                 void A(string value)
                 {
-                    NotNull(value, "extra");
+                    NotNull(value, extra: "extra");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReportDiagnostic_FollowedByPositionalArgument()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Runtime.CompilerServices;
+            class Sample
+            {
+                void NotNull(object? target, [CallerArgumentExpression("target")] string? parameterName = null, string extra = null) { }
+
+                void A(string value)
+                {
+                    NotNull(value, {|MA0108:"value"|}, "extra");
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Runtime.CompilerServices;
+            class Sample
+            {
+                void NotNull(object? target, [CallerArgumentExpression("target")] string? parameterName = null, string extra = null) { }
+
+                void A(string value)
+                {
+                    NotNull(value, extra: "extra");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReportDiagnostic_FollowedByNamedArgument()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Runtime.CompilerServices;
+            class Sample
+            {
+                void NotNull(object? target, [CallerArgumentExpression("target")] string? parameterName = null, string extra = null) { }
+
+                void A(string value)
+                {
+                    NotNull(value, {|MA0108:"value"|}, extra: "extra");
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Runtime.CompilerServices;
+            class Sample
+            {
+                void NotNull(object? target, [CallerArgumentExpression("target")] string? parameterName = null, string extra = null) { }
+
+                void A(string value)
+                {
+                    NotNull(value, extra: "extra");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReportDiagnostic_FollowedByPositionalArgument_ParameterNameIsKeyword()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Runtime.CompilerServices;
+            class Sample
+            {
+                void NotNull(object? target, [CallerArgumentExpression("target")] string? parameterName = null, string @class = null) { }
+
+                void A(string value)
+                {
+                    NotNull(value, {|MA0108:"value"|}, "extra");
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Runtime.CompilerServices;
+            class Sample
+            {
+                void NotNull(object? target, [CallerArgumentExpression("target")] string? parameterName = null, string @class = null) { }
+
+                void A(string value)
+                {
+                    NotNull(value, @class: "extra");
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReportDiagnostic_FollowedByExpandedParamsArguments_NoCodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Runtime.CompilerServices;
+            class Sample
+            {
+                void NotNull(object? target, [CallerArgumentExpression("target")] string? parameterName = null, params int[] values) { }
+
+                void A(string value)
+                {
+                    NotNull(value, {|MA0108:"value"|}, 1, 2);
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Runtime.CompilerServices;
+            class Sample
+            {
+                void NotNull(object? target, [CallerArgumentExpression("target")] string? parameterName = null, params int[] values) { }
+
+                void A(string value)
+                {
+                    NotNull(value, {|MA0108:"value"|}, 1, 2);
                 }
             }
             """;


### PR DESCRIPTION
## What

The MA0108 code fix removed the redundant `CallerArgumentExpression` argument without preserving how the *following* positional arguments bound to parameters. Every argument after the removed one shifted one parameter to the left, so the fixed code still compiled but called the method with different values.

## Why

```csharp
static string Describe(int value,
    [CallerArgumentExpression("value")] string expression = null,
    string suffix = "default") => expression + ":" + suffix;

Describe(value, "value", "custom"); // MA0108 on "value"
```

The fix produced `Describe(value, "custom")`, where `"custom"` binds to `expression` instead of `suffix`. Verified by running both versions:

```
original           : value:custom
old fix output     : custom:default   <- behavior changed
new fix output     : value:custom     <- preserved
```

## How

`RegisterCodeFixesAsync` now resolves the invocation's `IInvocationOperation` and looks up the bound parameter of each positional argument that follows the one being removed:

- Positional followers are converted to named arguments (`extra: "extra"`) in the same `DocumentEditor` pass as the removal.
- Followers that are already named are left untouched.
- When a follower cannot be named, the fix is **not registered at all**, per the "validate before registering" rule in `AGENTS.md`. This happens for the arguments of a `params` parameter in its expanded form, which have `ArgumentKind.ParamArray` rather than `Explicit`. The diagnostic is still reported; only the automatic fix is withheld.

Parameter names that are reserved keywords are emitted as verbatim identifiers (`@class:`), since `IParameterSymbol.Name` does not include the `@`.

The analyzer itself is unchanged, so no documentation update was needed (`dotnet run --project src/DocumentationGenerator` reports no markdown change).

## Note for reviewers

The existing `ReportDiagnostic_NamedParameter` test was encoding this bug: it asserted that `NotNull(value, parameterName: "value", "extra")` is fixed to `NotNull(value, "extra")`, where `"extra"` then binds to `parameterName`. Its expectation is updated to `NotNull(value, extra: "extra")`.

## Tests

New cases in `SimplifyCallerArgumentExpressionAnalyzerTests`: followed by a positional argument, followed by a named argument, a keyword parameter name, and expanded `params` arguments (no fix offered).

- `SimplifyCallerArgumentExpressionAnalyzerTests`: 9/9 passing on roslyn4.8, 4.14, 5.0, 5.6 and 5.9
- Full suite: 4384 passed on roslyn5.9, 4267 passed on roslyn4.8, 0 failures, 0 skips
- `dotnet build` (all projects): 0 warnings, 0 errors