### PR TITLE
Do not report MA0031 when the Take bound is not a valid int

### DIFF
--- a/docs/Rules/MA0031.md
+++ b/docs/Rules/MA0031.md
@@ -11,3 +11,8 @@ enumerable.Count() > 10;
 // Should be
 enumerable.Skip(10).Any();
 ```
+
+`Count() == n` and `Count() != n` are replaced with `Take(n + 1).Count()`, so they are not reported when `n + 1` cannot be computed:
+
+- `n` is the constant `int.MaxValue`, as `Take(int.MaxValue + 1)` cannot be expressed (and `Take(int.MaxValue)` would never stop the enumeration earlier)
+- `n` is not a constant and the expression is in a `checked` context, as `n + 1` would throw an `OverflowException` when `n` is `int.MaxValue`

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
@@ -149,6 +149,9 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
                 if (!TryGetCountOperationSpan(diagnostic, out var takeCountSpan) || !TryGetOperandOperationSpan(diagnostic, out var takeOperandSpan))
                     return;
 
+                if (!await CanUseTakeAndCountAsync(context.Document, takeCountSpan, takeOperandSpan, context.CancellationToken).ConfigureAwait(false))
+                    return;
+
                 context.RegisterCodeFix(CodeAction.Create(title, ct => UseTakeAndCount(context.Document, takeCountSpan, takeOperandSpan, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
@@ -169,6 +172,25 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
                 context.RegisterCodeFix(CodeAction.Create(title, ct => UseOrderInsteadOfOrderBy(context.Document, nodeToFix, ct), equivalenceKey: title), context.Diagnostics);
                 break;
         }
+    }
+
+    private static async Task<bool> CanUseTakeAndCountAsync(Document document, TextSpan countOperationSpan, TextSpan operandOperationSpan, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var countNode = root?.FindNode(countOperationSpan, getInnermostNodeForTie: true);
+        var operandNode = root?.FindNode(operandOperationSpan, getInnermostNodeForTie: true);
+        if (countNode is null || operandNode is null)
+            return false;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return false;
+
+        var operandOperation = semanticModel.GetOperation(operandNode, cancellationToken);
+        if (operandOperation is null)
+            return false;
+
+        return OptimizeLinqUsageAnalyzerCommon.CanUseTakeAndCount(operandOperation, countNode, semanticModel.Compilation);
     }
 
     private static bool TryGetFirstOperationSpan(Diagnostic diagnostic, out TextSpan span)

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -612,7 +612,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                         else
                         {
                             // expr.Count() == 1
-                            if (!HasTake(operation, ExtensionMethodOwnerTypes))
+                            // 'Take(value + 1)' must not overflow, so 'int.MaxValue' is not reported
+                            if (!HasTake(operation, ExtensionMethodOwnerTypes) && OptimizeLinqUsageAnalyzerCommon.CanUseTakeAndCount(otherOperand, operation.Syntax, context.Compilation))
                             {
                                 message = string.Create(CultureInfo.InvariantCulture, $"Replace 'Count() == {value}' with 'Take({value + 1}).Count() == {value}'");
                                 properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount);
@@ -637,7 +638,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                         else
                         {
                             // expr.Count() != 1
-                            if (!HasTake(operation, ExtensionMethodOwnerTypes))
+                            // 'Take(value + 1)' must not overflow, so 'int.MaxValue' is not reported
+                            if (!HasTake(operation, ExtensionMethodOwnerTypes) && OptimizeLinqUsageAnalyzerCommon.CanUseTakeAndCount(otherOperand, operation.Syntax, context.Compilation))
                             {
                                 message = string.Create(CultureInfo.InvariantCulture, $"Replace 'Count() != {value}' with 'Take({value + 1}).Count() != {value}'");
                                 properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount);
@@ -743,7 +745,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                 {
                     case BinaryOperatorKind.Equals:
                         // expr.Count() == 1
-                        if (!HasTake(operation, ExtensionMethodOwnerTypes))
+                        // 'Take(n + 1)' must not throw, so nothing is reported in a checked context where 'n' may be 'int.MaxValue'
+                        if (!HasTake(operation, ExtensionMethodOwnerTypes) && OptimizeLinqUsageAnalyzerCommon.CanUseTakeAndCount(otherOperand, operation.Syntax, context.Compilation))
                         {
                             message = "Replace 'Count() == n' with 'Take(n + 1).Count() == n'";
                             properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount);
@@ -753,7 +756,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
 
                     case BinaryOperatorKind.NotEquals:
                         // expr.Count() != 1
-                        if (!HasTake(operation, ExtensionMethodOwnerTypes))
+                        // 'Take(n + 1)' must not throw, so nothing is reported in a checked context where 'n' may be 'int.MaxValue'
+                        if (!HasTake(operation, ExtensionMethodOwnerTypes) && OptimizeLinqUsageAnalyzerCommon.CanUseTakeAndCount(otherOperand, operation.Syntax, context.Compilation))
                         {
                             message = "Replace 'Count() != n' with 'Take(n + 1).Count() != n'";
                             properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount);

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzerCommon.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis.CSharp;
+
 namespace Meziantou.Analyzer.Rules;
 
 internal static class OptimizeLinqUsageAnalyzerCommon
@@ -14,4 +16,40 @@ internal static class OptimizeLinqUsageAnalyzerCommon
     internal const string OperandOperationStartKey = "OperandOperationStart";
     internal const string OperandOperationLengthKey = "OperandOperationLength";
     internal const string SkipMinusOneKey = "SkipMinusOne";
+
+    /// <summary>
+    /// Indicates if comparing <c>Count()</c> with <paramref name="operand"/> can be replaced by
+    /// <c>Take(operand + 1).Count()</c>, which requires <c>operand + 1</c> to be a valid <see cref="int"/>.
+    /// </summary>
+    /// <param name="operand">The operand compared with the result of <c>Count()</c>.</param>
+    /// <param name="takeLocation">The node replaced by the <c>Take</c> invocation, which determines the overflow checking context of <c>operand + 1</c>.</param>
+    /// <param name="compilation">The compilation containing <paramref name="takeLocation"/>.</param>
+    internal static bool CanUseTakeAndCount(IOperation operand, SyntaxNode takeLocation, Compilation compilation)
+    {
+        if (operand.ConstantValue.Value is int value)
+        {
+            // 'int.MaxValue + 1' overflows, and 'Take(int.MaxValue)' would never stop the enumeration earlier anyway
+            return value != int.MaxValue;
+        }
+
+        // 'operand + 1' throws an OverflowException when the operand is 'int.MaxValue' in a checked context
+        return !IsInCheckedContext(takeLocation, compilation);
+    }
+
+    private static bool IsInCheckedContext(SyntaxNode node, Compilation compilation)
+    {
+        foreach (var ancestor in node.Ancestors())
+        {
+            switch (ancestor.Kind())
+            {
+                case SyntaxKind.CheckedExpression or SyntaxKind.CheckedStatement:
+                    return true;
+
+                case SyntaxKind.UncheckedExpression or SyntaxKind.UncheckedStatement:
+                    return false;
+            }
+        }
+
+        return compilation.Options.CheckOverflow;
+    }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
@@ -722,6 +722,7 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     [Theory]
     [InlineData("Count() == 1", "Take(2).Count() == 1", "Replace 'Count() == 1' with 'Take(2).Count() == 1'")]
     [InlineData("Count() != 10", "Take(11).Count() != 10", "Replace 'Count() != 10' with 'Take(11).Count() != 10'")]
+    [InlineData("Count() == int.MaxValue - 1", "Take(int.MaxValue).Count() == int.MaxValue - 1", "Replace 'Count() == 2147483646' with 'Take(2147483647).Count() == 2147483646'")]
     [InlineData("Count() != n", "Take(n + 1).Count() != n", "Replace 'Count() != n' with 'Take(n + 1).Count() != n'")]
     [InlineData("Count(x => x > 1) != n", "Where(x => x > 1).Take(n + 1).Count() != n", "Replace 'Count() != n' with 'Take(n + 1).Count() != n'")]
     public Task Count_TakeAndCount(string text, string fix, string expectedMessage)
@@ -764,6 +765,8 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     [InlineData("Count() > n", "Skip(n).Any()", "Replace 'Count() > n' with 'Skip(n).Any()'")]
     [InlineData("Count() >= 2", "Skip(1).Any()", "Replace 'Count() >= 2' with 'Skip(1).Any()'")]
     [InlineData("Count() >= n", "Skip(n - 1).Any()", "Replace 'Count() >= n' with 'Skip(n - 1).Any()'")]
+    [InlineData("Count() > int.MaxValue", "Skip(int.MaxValue).Any()", "Replace 'Count() > 2147483647' with 'Skip(2147483647).Any()'")]
+    [InlineData("Count() >= int.MaxValue", "Skip(2147483646).Any()", "Replace 'Count() >= 2147483647' with 'Skip(2147483646).Any()'")]
     public Task Count_SkipAndAny(string text, string fix, string expectedMessage)
     {
         var test = new CodeFixTest();
@@ -805,6 +808,8 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     [InlineData("Count() <= 2", "Skip(2).Any()", "Replace 'Count() <= 2' with 'Skip(2).Any() == false'")]
     [InlineData("Count() <= n", "Skip(n).Any()", "Replace 'Count() <= n' with 'Skip(n).Any() == false'")]
     [InlineData("Count(x => true) <= n", "Where(x => true).Skip(n).Any()", "Replace 'Count() <= n' with 'Skip(n).Any() == false'")]
+    [InlineData("Count() < int.MaxValue", "Skip(2147483646).Any()", "Replace 'Count() < 2147483647' with 'Skip(2147483646).Any() == false'")]
+    [InlineData("Count() <= int.MaxValue", "Skip(int.MaxValue).Any()", "Replace 'Count() <= 2147483647' with 'Skip(2147483647).Any() == false'")]
     public Task Count_NotSkipAndAny(string text, string fix, string expectedMessage)
     {
         var test = new CodeFixTest();
@@ -841,6 +846,8 @@ public sealed class OptimizeLinqUsageAnalyzerTests
 
     [Theory]
     [InlineData("Take(10).Count() == 1")]
+    [InlineData("Count() == int.MaxValue")]
+    [InlineData("Count() == 2147483647")]
     public Task Count_Equals(string text)
     {
         var test = new CodeFixTest();
@@ -862,6 +869,7 @@ public sealed class OptimizeLinqUsageAnalyzerTests
 
     [Theory]
     [InlineData("Take(1).Count() != n")]
+    [InlineData("Count() != int.MaxValue")]
     public Task Count_NotEquals(string text)
     {
         var test = new CodeFixTest();
@@ -874,6 +882,97 @@ public sealed class OptimizeLinqUsageAnalyzerTests
                     int n = 10;
                     var enumerable = System.Linq.Enumerable.Empty<int>();
                     _ = enumerable.{{text}};
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Count_TakeAndCount_CheckedContext()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    int n = 10;
+                    var enumerable = System.Linq.Enumerable.Empty<int>();
+                    checked
+                    {
+                        _ = enumerable.Count() == n;
+                    }
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Count_TakeAndCount_CheckOverflowCompilationOption()
+    {
+        var test = new CodeFixTest();
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var compilationOptions = (CSharpCompilationOptions)solution.GetProject(projectId)!.CompilationOptions!;
+            return solution.WithProjectCompilationOptions(projectId, compilationOptions.WithOverflowChecks(true));
+        });
+        test.TestCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    int n = 10;
+                    var enumerable = System.Linq.Enumerable.Empty<int>();
+                    _ = enumerable.Count() == n;
+                }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Count_TakeAndCount_UncheckedContextInsideCheckedContext()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    int n = 10;
+                    var enumerable = System.Linq.Enumerable.Empty<int>();
+                    checked
+                    {
+                        _ = unchecked({|#0:enumerable.Count() == n|});
+                    }
+                }
+            }
+
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0031", DiagnosticSeverity.Info).WithLocation(0).WithMessage("Replace 'Count() == n' with 'Take(n + 1).Count() == n'"));
+        test.FixedCode = """
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    int n = 10;
+                    var enumerable = System.Linq.Enumerable.Empty<int>();
+                    checked
+                    {
+                        _ = unchecked(enumerable.Take(n + 1).Count() == n);
+                    }
                 }
             }
 


### PR DESCRIPTION
## What

MA0031 replaces `Count() == n` and `Count() != n` with `Take(n + 1).Count()`. Both the diagnostic message and the code fix computed `n + 1` without checking that the result is representable:

```csharp
Enumerable.Range(0, int.MaxValue).Count() == int.MaxValue // true
// the code fix produced:
Enumerable.Range(0, int.MaxValue).Take(int.MinValue).Count() == int.MaxValue // false
```

`value + 1` wrapped to `int.MinValue`, and `Take` with a negative count yields an empty sequence, so the rewritten count was `0`. Both versions compile, and the runtime gets the count of a `Range` without enumerating billions of elements, so the wrong result is observable.

## How

A new `OptimizeLinqUsageAnalyzerCommon.CanUseTakeAndCount` (shared by the analyzer and the code fixer) decides whether the `Take(n + 1)` rewrite can be offered. Two cases are now excluded:

- **`n` is the constant `int.MaxValue`** — `Take(int.MaxValue + 1)` cannot be expressed, and `Take(int.MaxValue)` would never stop the enumeration earlier, so there is no beneficial rewrite to suggest. The diagnostic is not reported, which also keeps the message from printing the overflowed bound.
- **`n` is not a constant and the expression is in a checked context** — `n + 1` would throw an `OverflowException` when `n` is `int.MaxValue`, for any sequence, turning a comparison that returns `false` into an exception. The context is detected from the enclosing `checked`/`unchecked` expressions and statements, falling back to the `CheckOverflow` compilation option. The node used for that lookup is the `Count()` invocation, i.e. where the generated `+` lands, so `Count() == unchecked(n)` is classified by the context of the comparison and not by the one of the operand.

The analyzer applies the check at its four `UseTakeAndCount` sites, and the fixer validates the same condition before registering the fix, per the validate-before-register rule in `AGENTS.md`.

## Notes for reviewers

- Non-constant thresholds in unchecked code still get `Take(n + 1)`. A wrong result there needs both `n == int.MaxValue` and a sequence of 2³¹−1 elements, and there is no single-pass equivalent of the comparison without the `+ 1`, so suppressing every non-constant `Count() == n` diagnostic would have cost more than it bought. Happy to change that call.
- Boundary tests were added for `== int.MaxValue - 1`, which rewrites to `Take(int.MaxValue)` — the largest valid bound — and for the four inequality operators at `int.MaxValue`. The `Skip` path is safe at that boundary: the constant branches already exclude the values for which `value - 1` could underflow.
- Separately, and not touched here: for **non-constant** operands the inequality rewrites are wrong for negative thresholds, because `Enumerable.Skip` yields everything for a non-positive count. `Count() > n` with `n = -1` on an empty sequence is `true`, while `Skip(-1).Any()` is `false`. That is a pre-existing defect of a different code path, so it is left for its own change.

## Testing

- `OptimizeLinqUsageAnalyzerTests` passes on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9: **164 passed, 0 failed, 0 skipped** on each version (155 before, 9 new cases).
- `dotnet run --project src/DocumentationGenerator` exits 0 with no pending markdown changes.
- The full test suite was not run.