### PR TITLE
Fix MA0031 rewriting comparisons against non-constant limits

### DIFF
--- a/docs/Rules/MA0031.md
+++ b/docs/Rules/MA0031.md
@@ -11,3 +11,17 @@ enumerable.Count() > 10;
 // Should be
 enumerable.Skip(10).Any();
 ```
+
+When the value compared with `Count()` is not a constant, it may be negative. `Skip` ignores a negative count, so
+`enumerable.Skip(n).Any()` is not equivalent to `enumerable.Count() > n`. `Take` also ignores a negative count, but the
+comparison is kept, so bounding the count with `Take` is equivalent on the whole range of `int`:
+
+```csharp
+enumerable.Count() > n;
+
+// Should be
+enumerable.Take(n + 1).Count() > n;
+```
+
+The value compared with `Count()` is used twice by this rewrite, so the rule is not reported when evaluating it twice
+could change the behavior of the expression, such as when it is a method call.

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/OptimizeLinqUsageFixer.cs
@@ -149,7 +149,8 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
                 if (!TryGetCountOperationSpan(diagnostic, out var takeCountSpan) || !TryGetOperandOperationSpan(diagnostic, out var takeOperandSpan))
                     return;
 
-                context.RegisterCodeFix(CodeAction.Create(title, ct => UseTakeAndCount(context.Document, takeCountSpan, takeOperandSpan, ct), equivalenceKey: title), context.Diagnostics);
+                var takePlusOne = diagnostic.Properties.ContainsKey(OptimizeLinqUsageAnalyzerCommon.TakePlusOneKey);
+                context.RegisterCodeFix(CodeAction.Create(title, ct => UseTakeAndCount(context.Document, takeCountSpan, takeOperandSpan, takePlusOne, ct), equivalenceKey: title), context.Diagnostics);
                 break;
 
             case OptimizeLinqUsageData.UseSkipAndAny:
@@ -261,7 +262,7 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
-    private static async Task<Document> UseTakeAndCount(Document document, TextSpan countOperationSpan, TextSpan operandOperationSpan, CancellationToken cancellationToken)
+    private static async Task<Document> UseTakeAndCount(Document document, TextSpan countOperationSpan, TextSpan operandOperationSpan, bool takePlusOne, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var countNode = root?.FindNode(countOperationSpan, getInnermostNodeForTie: true);
@@ -288,11 +289,15 @@ public sealed class OptimizeLinqUsageFixer : CodeFixProvider
         SyntaxNode takeArgument;
         if (operandOperation.ConstantValue.Value is int value)
         {
-            takeArgument = generator.LiteralExpression(value + 1);
+            takeArgument = generator.LiteralExpression(takePlusOne ? value + 1 : value);
+        }
+        else if (takePlusOne)
+        {
+            takeArgument = generator.AddExpression(operandOperation.Syntax, generator.LiteralExpression(1));
         }
         else
         {
-            takeArgument = generator.AddExpression(operandOperation.Syntax, generator.LiteralExpression(1));
+            takeArgument = operandOperation.Syntax;
         }
 
         newExpression = generator.InvocationExpression(

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzer.cs
@@ -615,7 +615,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                             if (!HasTake(operation, ExtensionMethodOwnerTypes))
                             {
                                 message = string.Create(CultureInfo.InvariantCulture, $"Replace 'Count() == {value}' with 'Take({value + 1}).Count() == {value}'");
-                                properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount);
+                                properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount)
+                                    .Add(OptimizeLinqUsageAnalyzerCommon.TakePlusOneKey, value: "");
                             }
                         }
 
@@ -640,7 +641,8 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                             if (!HasTake(operation, ExtensionMethodOwnerTypes))
                             {
                                 message = string.Create(CultureInfo.InvariantCulture, $"Replace 'Count() != {value}' with 'Take({value + 1}).Count() != {value}'");
-                                properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount);
+                                properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount)
+                                    .Add(OptimizeLinqUsageAnalyzerCommon.TakePlusOneKey, value: "");
                             }
                         }
 
@@ -737,54 +739,50 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
                         break;
                 }
             }
-            else
+            else if (!HasTake(operation, ExtensionMethodOwnerTypes) && CanBeEvaluatedTwice(otherOperand))
             {
+                // The value of the operand is unknown, so it may be negative. Rewriting to 'Skip(n).Any()' is not
+                // valid in that case: 'Skip' ignores a negative count, whereas comparing a count, which is never
+                // negative, with a negative value yields a constant result. Keeping the comparison and bounding the
+                // count with 'Take' is valid on the whole range of 'int', as 'Take(n).Count()' is
+                // 'Min(Count(), Max(n, 0))'. The operand is duplicated by the fix, hence the check that it can be
+                // evaluated twice.
                 switch (opKind)
                 {
                     case BinaryOperatorKind.Equals:
-                        // expr.Count() == 1
-                        if (!HasTake(operation, ExtensionMethodOwnerTypes))
-                        {
-                            message = "Replace 'Count() == n' with 'Take(n + 1).Count() == n'";
-                            properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount);
-                        }
-
+                        // expr.Count() == n
+                        message = "Replace 'Count() == n' with 'Take(n + 1).Count() == n'";
+                        properties = CreateTakeAndCountProperties(takePlusOne: true);
                         break;
 
                     case BinaryOperatorKind.NotEquals:
-                        // expr.Count() != 1
-                        if (!HasTake(operation, ExtensionMethodOwnerTypes))
-                        {
-                            message = "Replace 'Count() != n' with 'Take(n + 1).Count() != n'";
-                            properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount);
-                        }
-
+                        // expr.Count() != n
+                        message = "Replace 'Count() != n' with 'Take(n + 1).Count() != n'";
+                        properties = CreateTakeAndCountProperties(takePlusOne: true);
                         break;
 
                     case BinaryOperatorKind.LessThan:
-                        // expr.Count() < 10
-                        message = "Replace 'Count() < n' with 'Skip(n - 1).Any() == false'";
-                        properties = CreateProperties(OptimizeLinqUsageData.UseSkipAndNotAny)
-                            .Add(OptimizeLinqUsageAnalyzerCommon.SkipMinusOneKey, value: "");
+                        // expr.Count() < n
+                        message = "Replace 'Count() < n' with 'Take(n).Count() < n'";
+                        properties = CreateTakeAndCountProperties(takePlusOne: false);
                         break;
 
                     case BinaryOperatorKind.LessThanOrEqual:
-                        // expr.Count() <= 10
-                        message = "Replace 'Count() <= n' with 'Skip(n).Any() == false'";
-                        properties = CreateProperties(OptimizeLinqUsageData.UseSkipAndNotAny);
+                        // expr.Count() <= n
+                        message = "Replace 'Count() <= n' with 'Take(n + 1).Count() <= n'";
+                        properties = CreateTakeAndCountProperties(takePlusOne: true);
                         break;
 
                     case BinaryOperatorKind.GreaterThan:
-                        // expr.Count() > 1
-                        message = "Replace 'Count() > n' with 'Skip(n).Any()'";
-                        properties = CreateProperties(OptimizeLinqUsageData.UseSkipAndAny);
+                        // expr.Count() > n
+                        message = "Replace 'Count() > n' with 'Take(n + 1).Count() > n'";
+                        properties = CreateTakeAndCountProperties(takePlusOne: true);
                         break;
 
                     case BinaryOperatorKind.GreaterThanOrEqual:
-                        // expr.Count() >= 2
-                        message = "Replace 'Count() >= n' with 'Skip(n - 1).Any()'";
-                        properties = CreateProperties(OptimizeLinqUsageData.UseSkipAndAny)
-                            .Add(OptimizeLinqUsageAnalyzerCommon.SkipMinusOneKey, value: "");
+                        // expr.Count() >= n
+                        message = "Replace 'Count() >= n' with 'Take(n).Count() >= n'";
+                        properties = CreateTakeAndCountProperties(takePlusOne: false);
                         break;
                 }
             }
@@ -837,6 +835,25 @@ public sealed class OptimizeLinqUsageAnalyzer : DiagnosticAnalyzer
 
                 return op.TargetMethod.Name == nameof(Enumerable.Take) && extensionMethodOwnerTypes.Contains(op.TargetMethod.ContainingType, SymbolEqualityComparer.Default);
             }
+
+            static ImmutableDictionary<string, string?> CreateTakeAndCountProperties(bool takePlusOne)
+            {
+                var properties = CreateProperties(OptimizeLinqUsageData.UseTakeAndCount);
+                return takePlusOne ? properties.Add(OptimizeLinqUsageAnalyzerCommon.TakePlusOneKey, value: "") : properties;
+            }
+
+            // The fix keeps the operand in the comparison and also uses it as the argument of 'Take', so it must be
+            // possible to evaluate it twice without changing the behavior of the expression.
+            static bool CanBeEvaluatedTwice(IOperation operation) => operation switch
+            {
+                _ when operation.ConstantValue.HasValue => true,
+                ILiteralOperation or IParameterReferenceOperation or ILocalReferenceOperation or IInstanceReferenceOperation => true,
+                IFieldReferenceOperation fieldReference => fieldReference.Instance is null || CanBeEvaluatedTwice(fieldReference.Instance),
+                IConversionOperation conversion => conversion.OperatorMethod is null && CanBeEvaluatedTwice(conversion.Operand),
+                IUnaryOperation unary => unary.OperatorMethod is null && CanBeEvaluatedTwice(unary.Operand),
+                IBinaryOperation binary => binary.OperatorMethod is null && CanBeEvaluatedTwice(binary.LeftOperand) && CanBeEvaluatedTwice(binary.RightOperand),
+                _ => false,
+            };
         }
 
         private static void UseCastInsteadOfSelect(OperationAnalysisContext context, IInvocationOperation operation)

--- a/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzerCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeLinqUsageAnalyzerCommon.cs
@@ -14,4 +14,5 @@ internal static class OptimizeLinqUsageAnalyzerCommon
     internal const string OperandOperationStartKey = "OperandOperationStart";
     internal const string OperandOperationLengthKey = "OperandOperationLength";
     internal const string SkipMinusOneKey = "SkipMinusOne";
+    internal const string TakePlusOneKey = "TakePlusOne";
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/OptimizeLinqUsageAnalyzerTests.cs
@@ -724,6 +724,12 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     [InlineData("Count() != 10", "Take(11).Count() != 10", "Replace 'Count() != 10' with 'Take(11).Count() != 10'")]
     [InlineData("Count() != n", "Take(n + 1).Count() != n", "Replace 'Count() != n' with 'Take(n + 1).Count() != n'")]
     [InlineData("Count(x => x > 1) != n", "Where(x => x > 1).Take(n + 1).Count() != n", "Replace 'Count() != n' with 'Take(n + 1).Count() != n'")]
+    [InlineData("Count() == n", "Take(n + 1).Count() == n", "Replace 'Count() == n' with 'Take(n + 1).Count() == n'")]
+    [InlineData("Count() < n", "Take(n).Count() < n", "Replace 'Count() < n' with 'Take(n).Count() < n'")]
+    [InlineData("Count() <= n", "Take(n + 1).Count() <= n", "Replace 'Count() <= n' with 'Take(n + 1).Count() <= n'")]
+    [InlineData("Count() > n", "Take(n + 1).Count() > n", "Replace 'Count() > n' with 'Take(n + 1).Count() > n'")]
+    [InlineData("Count() >= n", "Take(n).Count() >= n", "Replace 'Count() >= n' with 'Take(n).Count() >= n'")]
+    [InlineData("Count(x => true) <= n", "Where(x => true).Take(n + 1).Count() <= n", "Replace 'Count() <= n' with 'Take(n + 1).Count() <= n'")]
     public Task Count_TakeAndCount(string text, string fix, string expectedMessage)
     {
         var test = new CodeFixTest();
@@ -761,9 +767,7 @@ public sealed class OptimizeLinqUsageAnalyzerTests
     [Theory]
     [InlineData("Count() > 1", "Skip(1).Any()", "Replace 'Count() > 1' with 'Skip(1).Any()'")]
     [InlineData("Count() > 2", "Skip(2).Any()", "Replace 'Count() > 2' with 'Skip(2).Any()'")]
-    [InlineData("Count() > n", "Skip(n).Any()", "Replace 'Count() > n' with 'Skip(n).Any()'")]
     [InlineData("Count() >= 2", "Skip(1).Any()", "Replace 'Count() >= 2' with 'Skip(1).Any()'")]
-    [InlineData("Count() >= n", "Skip(n - 1).Any()", "Replace 'Count() >= n' with 'Skip(n - 1).Any()'")]
     public Task Count_SkipAndAny(string text, string fix, string expectedMessage)
     {
         var test = new CodeFixTest();
@@ -773,8 +777,7 @@ public sealed class OptimizeLinqUsageAnalyzerTests
             {
                 public Test()
                 {
-                    int n = 10;
-                    var enumerable = Enumerable.Empty<int>();
+                        var enumerable = Enumerable.Empty<int>();
                     _ = {|#0:enumerable.{{text}}|};
                 }
             }
@@ -787,8 +790,7 @@ public sealed class OptimizeLinqUsageAnalyzerTests
             {
                 public Test()
                 {
-                    int n = 10;
-                    var enumerable = Enumerable.Empty<int>();
+                        var enumerable = Enumerable.Empty<int>();
                     _ = enumerable.{{fix}};
                 }
             }
@@ -800,11 +802,8 @@ public sealed class OptimizeLinqUsageAnalyzerTests
 
     [Theory]
     [InlineData("Count() < 2", "Skip(1).Any()", "Replace 'Count() < 2' with 'Skip(1).Any() == false'")]
-    [InlineData("Count() < n", "Skip(n - 1).Any()", "Replace 'Count() < n' with 'Skip(n - 1).Any() == false'")]
     [InlineData("Count() <= 1", "Skip(1).Any()", "Replace 'Count() <= 1' with 'Skip(1).Any() == false'")]
     [InlineData("Count() <= 2", "Skip(2).Any()", "Replace 'Count() <= 2' with 'Skip(2).Any() == false'")]
-    [InlineData("Count() <= n", "Skip(n).Any()", "Replace 'Count() <= n' with 'Skip(n).Any() == false'")]
-    [InlineData("Count(x => true) <= n", "Where(x => true).Skip(n).Any()", "Replace 'Count() <= n' with 'Skip(n).Any() == false'")]
     public Task Count_NotSkipAndAny(string text, string fix, string expectedMessage)
     {
         var test = new CodeFixTest();
@@ -814,8 +813,7 @@ public sealed class OptimizeLinqUsageAnalyzerTests
             {
                 public Test()
                 {
-                    int n = 10;
-                    var enumerable = Enumerable.Empty<int>();
+                        var enumerable = Enumerable.Empty<int>();
                     _ = {|#0:enumerable.{{text}}|};
                 }
             }
@@ -828,10 +826,42 @@ public sealed class OptimizeLinqUsageAnalyzerTests
             {
                 public Test()
                 {
-                    int n = 10;
-                    var enumerable = Enumerable.Empty<int>();
+                        var enumerable = Enumerable.Empty<int>();
                     _ = !enumerable.{{fix}};
                 }
+            }
+
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("Count() == GetLimit()")]
+    [InlineData("Count() != GetLimit()")]
+    [InlineData("Count() < GetLimit()")]
+    [InlineData("Count() <= GetLimit()")]
+    [InlineData("Count() > GetLimit()")]
+    [InlineData("Count() >= GetLimit()")]
+    [InlineData("Take(10).Count() < n")]
+    [InlineData("Take(10).Count() <= n")]
+    [InlineData("Take(10).Count() > n")]
+    [InlineData("Take(10).Count() >= n")]
+    public Task Count_NonConstantOperand_NotReported(string text)
+    {
+        var test = new CodeFixTest();
+        test.TestCode = $$"""
+            using System.Linq;
+            class Test
+            {
+                public Test()
+                {
+                    int n = 10;
+                    var enumerable = System.Linq.Enumerable.Empty<int>();
+                    _ = enumerable.{{text}};
+                }
+
+                static int GetLimit() => 10;
             }
 
             """;


### PR DESCRIPTION
## Problem

When the value compared with `Count()` is not a constant, it may be negative. `Skip` ignores a negative count, whereas comparing a count — which is never negative — with a negative value yields a constant result. The four relational rewrites were therefore not equivalent to the original expression:

| Comparison | Old rewrite | Diverges when |
|---|---|---|
| `Count() < n` | `!Skip(n - 1).Any()` | `n <= 0` and the sequence is empty; **any** count when `n` is `int.MinValue` |
| `Count() <= n` | `!Skip(n).Any()` | `n < 0` and the sequence is empty |
| `Count() > n` | `Skip(n).Any()` | `n < 0` and the sequence is empty |
| `Count() >= n` | `Skip(n - 1).Any()` | `n <= 0` and the sequence is empty; **any** count when `n` is `int.MinValue` |

For instance:

```csharp
int limit = -1;
_ = Enumerable.Empty<int>().Count() > limit;     // true
_ = Enumerable.Empty<int>().Skip(limit).Any();   // false
```

`<` and `>=` are also wrong for any count when `n` is `int.MinValue`, as `n - 1` underflows to `int.MaxValue`.

## Fix

No `Skip`/`Any` form can be correct here: for a negative `n` the result must be constant, whereas `Skip(k).Any()` always depends on the sequence.

Non-constant values now use the bounded `Count()` form already used for `==` and `!=`. It keeps the comparison and is equivalent on the whole range of `int`, since `Take(n).Count()` is `Min(Count(), Max(n, 0))`:

- `Count() < n` → `Take(n).Count() < n`
- `Count() <= n` → `Take(n + 1).Count() <= n`
- `Count() > n` → `Take(n + 1).Count() > n`
- `Count() >= n` → `Take(n).Count() >= n`

Constant values are unchanged: a negative constant still reports that the expression is always true or always false, and a non-negative one still uses `Skip`.

A `TakePlusOne` diagnostic property tells the fixer whether to emit `n` or `n + 1`, mirroring the existing `SkipMinusOne` property.

## Notes for the reviewer

- **The value is now used twice by the rewrite**, so the rule is no longer reported when the operand cannot be evaluated twice (`CanBeEvaluatedTwice`, modeled on the existing `IsSideEffectFree` of `UseHasFlagMethodCommon`). This also fixes the pre-existing `==`/`!=` rewrites, which duplicated a method call such as in `Count() == GetLimit()` → `Take(GetLimit() + 1).Count() == GetLimit()`.
- **Trade-off:** that check is conservative, so property operands such as `other.Count` or `arr.Length` are no longer reported, as a getter may have side effects. This loses some coverage the `Skip` rewrite had.
- **Pre-existing edge case, unchanged:** in a `checked` context the generated `n + 1` throws when `n` is `int.MaxValue`, whereas the original expression does not. The old `n - 1` had the mirror problem, so the risk is not new, but it now applies to four more operators.

## Validation

- An exhaustive equivalence check over counts `{0, 1, 2, 3, 5}` × values `{int.MinValue, int.MinValue + 1, -3..6, int.MaxValue - 1, int.MaxValue}` reproduced every divergence of the table above for the old rewrites and reported none for the new ones.
- The six operators with a non-constant value moved to the `Take`-based theory, and a new `Count_NonConstantOperand_NotReported` theory covers method-call operands and sources that already have a `Take`.
- Full test suite passes on all five Roslyn versions — 5.9: 4391, 5.6: 4358, 5.0: 4334, 4.14: 4305, 4.8: 4274, all 0 failed and 0 skipped.
- `dotnet run --project src/DocumentationGenerator` exits 0 after the `docs/Rules/MA0031.md` update.
