### PR TITLE
Keep the initialization order in the MA0004 code fix

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis.Formatting;
+
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
@@ -123,7 +125,8 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
                     {
                         var newBlock = SyntaxFactory.Block(variablesStatement, newUsingBlock.WithoutLeadingTrivia())
                             .WithLeadingTrivia(usingBlock.GetLeadingTrivia())
-                            .WithTrailingTrivia(usingBlock.GetTrailingTrivia());
+                            .WithTrailingTrivia(usingBlock.GetTrailingTrivia())
+                            .WithAdditionalAnnotations(Formatter.Annotation);
                         editor.ReplaceNode(usingBlock, newBlock);
                     }
 
@@ -205,21 +208,16 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
 
         bool TryInsertVariableStatementBeforeUsing(LocalDeclarationStatementSyntax variableStatement, UsingStatementSyntax usingStatement)
         {
-            var insertionTarget = usingStatement;
-            while (insertionTarget.Parent is UsingStatementSyntax parentUsing &&
-                   parentUsing.Statement == insertionTarget &&
-                   parentUsing.Declaration is null)
+            // The declaration can only be extracted where a statement can be inserted just before the using statement.
+            // Moving it before an enclosing statement would evaluate the initializer before that statement,
+            // so the caller wraps the declaration and the using statement in a block instead.
+            if (usingStatement.Parent is BlockSyntax or SwitchSectionSyntax)
             {
-                insertionTarget = parentUsing;
-            }
-
-            if (insertionTarget.Parent is BlockSyntax or SwitchSectionSyntax)
-            {
-                editor.InsertBefore(insertionTarget, variableStatement);
+                editor.InsertBefore(usingStatement, variableStatement);
                 return true;
             }
 
-            if (insertionTarget.Parent is GlobalStatementSyntax { Parent: CompilationUnitSyntax } globalStatement)
+            if (usingStatement.Parent is GlobalStatementSyntax { Parent: CompilationUnitSyntax } globalStatement)
             {
                 editor.InsertBefore(globalStatement, SyntaxFactory.GlobalStatement(variableStatement));
                 return true;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
@@ -790,15 +790,70 @@ public sealed class UseConfigureAwaitAnalyzerTests
                 async Task Test()
                 {
                     Stream stream = OpenWrite();
-                    var streamWriter = new StreamWriter(stream);
                     await using (stream.ConfigureAwait(false))
-                    await using (streamWriter.ConfigureAwait(false))
                     {
-                        await streamWriter.WriteAsync("test-data").ConfigureAwait(false);
+                        var streamWriter = new StreamWriter(stream);
+                        await using (streamWriter.ConfigureAwait(false))
+                        {
+                            await streamWriter.WriteAsync("test-data").ConfigureAwait(false);
+                        }
                     }
                 }
 
                 Stream OpenWrite() => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task AwaitUsing_UnderUsingWithSideEffect_KeepsEvaluationOrder()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    using (Create("outer"))
+                    await using (var {|MA0004:resource = Create("inner")|})
+                    {
+                    }
+                }
+
+                static Resource Create(string text) => throw null;
+            }
+            class Resource : IDisposable, IAsyncDisposable
+            {
+                public void Dispose() => throw null;
+                public ValueTask DisposeAsync() => throw null;
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    using (Create("outer"))
+                    {
+                        var resource = Create("inner");
+                        await using (resource.ConfigureAwait(false))
+                        {
+                        }
+                    }
+                }
+
+                static Resource Create(string text) => throw null;
+            }
+            class Resource : IDisposable, IAsyncDisposable
+            {
+                public void Dispose() => throw null;
+                public ValueTask DisposeAsync() => throw null;
             }
             """;
 


### PR DESCRIPTION
## Problem

The MA0004 code fix extracts the declaration of an `await using` statement so that `ConfigureAwait` can be appended to the variable:

```csharp
await using (var a = expr) { }
// becomes
var a = expr;
await using (a.ConfigureAwait(false)) { }
```

`TryInsertVariableStatementBeforeUsing` walked up through the enclosing `using (expr)` statements to find a position where a statement could be inserted, then hoisted the declaration above all of them. That moves the initializer ahead of every crossed `using` expression:

```csharp
using (Create("outer"))
await using (var resource = Create("inner")) { }
```

is fixed into

```csharp
var resource = Create("inner");
using (Create("outer"))
await using (resource.ConfigureAwait(false)) { }
```

`Create("inner")` now runs before `Create("outer")`. It also breaks exception safety: if the hoisted initializer throws, the resources acquired by the crossed `using` statements are never disposed, whereas originally they were.

## Change

The helper no longer ascends. It inserts the declaration only when it can go directly before the `using` statement itself (its parent is a block, a switch section, or the global statement list). When the `using` statement is the embedded statement of another statement, the fixer falls back to wrapping the declaration and the `using` statement in a block, which it already did for the other positions where a statement cannot be inserted:

```csharp
using (Create("outer"))
{
    var resource = Create("inner");
    await using (resource.ConfigureAwait(false))
    {
    }
}
```

The generated block now carries `Formatter.Annotation`, so its body is reindented instead of keeping the indentation it had. That fallback path had no test coverage before, so the formatting had gone unnoticed.

## Tests

- New regression test `AwaitUsing_UnderUsingWithSideEffect_KeepsEvaluationOrder`, with a side-effecting expression in the enclosing `using` and in the initializer.
- `AwaitUsing_WithMultipleUsings_ShouldNotThrow` expected the hoisted form, which is exactly the transformation that reorders the acquisition, so it now expects the block form.

MA0004 tests pass on all five Roslyn versions (35 each), and the full Roslyn 5.9 suite passes (4576 tests, 0 failed, 0 skipped). `dotnet run --project src/DocumentationGenerator` produces no markdown change.