### PR TITLE
Do not offer the MA0082 code fix when both operands are NaN

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotNaNInComparisonsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotNaNInComparisonsFixer.cs
@@ -30,6 +30,12 @@ public sealed class DoNotNaNInComparisonsFixer : CodeFixProvider
 
         var leftIsNaN = TryGetNaNType(binaryOperation.LeftOperand, halfTypeSymbol, out _, out var leftSyntax);
         var rightIsNaN = TryGetNaNType(binaryOperation.RightOperand, halfTypeSymbol, out _, out var rightSyntax);
+
+        // NaN == NaN is false and NaN != NaN is true, whereas IsNaN(NaN) is true.
+        // Replacing the comparison would change the behavior of the code, so there is nothing to fix.
+        if (leftIsNaN && rightIsNaN)
+            return;
+
         if (leftIsNaN && leftSyntax is not null && nodeToFix.IsEquivalentTo(leftSyntax))
         {
             RegisterCodeFix(binaryOperation.LeftOperand);

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotNaNInComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotNaNInComparisonsAnalyzerTests.cs
@@ -99,6 +99,28 @@ public sealed class DoNotNaNInComparisonsAnalyzerTests
     }
 
     [Fact]
+    public Task Comparisons_BothOperandsAreNaN_NoCodeFix()
+    {
+        const string Source = """
+            class Test
+            {
+                void A()
+                {
+                    _ = {|MA0082:double.NaN|} == {|MA0082:double.NaN|};
+                    _ = {|MA0082:double.NaN|} != {|MA0082:double.NaN|};
+                    _ = (double){|MA0082:float.NaN|} == {|MA0082:double.NaN|};
+                }
+            }
+            """;
+
+        var test = CreateTest();
+        test.TestCode = Source;
+        test.FixedCode = Source;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Comparisons_CodeFix_Half()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

```csharp
public class Sample
{
    public static object Run() => double.NaN == double.NaN;
}
```

MA0082 reports both `NaN` operands. Applying the offered fix produces `double.IsNaN(double.NaN)`, which changes the result of the expression from `False` to `True`.

The fixer rewrote `x == NaN` into `IsNaN(x)` by picking the *other* operand of the comparison. When both operands are the NaN sentinel, "the other operand" is itself `NaN`, so the rewrite loses the IEEE semantics of the comparison. The `!=` form was equally wrong: `!double.IsNaN(double.NaN)` is `false` while `NaN != NaN` is `true`.

## Change

The fixer now returns before registering any action when both operands are recognized NaN constants. The analyzer still reports both operands — the comparison is still worth flagging — but no behavior-changing fix is offered.

I did not add a "replace the whole comparison with the constant result" alternative: MA0082 is a report-only design rule, and folding the expression to `false`/`true` is a different transformation than the one the fix advertises.

## Notes for the reviewer

The new test sets `FixedCode` in addition to `TestCode`. This is needed: `Microsoft.CodeAnalysis.Testing` skips code fix verification entirely when only `TestCode` is set, so a test written the usual way passes even while the fix is being applied. I verified the new test actually catches the bug by neutralizing the guard and re-running it — it fails with exactly the reported diff (`_ = double.NaN == double.NaN;` → `_ = double.IsNaN(double.NaN);`). Other analyzer tests in this repo likely have the same blind spot.

## Validation

- All 5 `DoNotNaNInComparisonsAnalyzerTests` pass on every Roslyn version (4.8, 4.14, 5.0, 5.6, 5.9).
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.