### PR TITLE
Report MA0224/MA0225 when an earlier assignment configures another instance

### DIFF
--- a/docs/Rules/MA0224.md
+++ b/docs/Rules/MA0224.md
@@ -33,7 +33,7 @@ Note that the option only rejects the `null` values that are present in the payl
 
 The rule does not report anything when the target framework does not support the option.
 
-The rule only reports the creation of a `JsonSerializerOptions`, and considers the option configured when it is set in the object initializer, or on the local the creation is assigned to in the same method. It does not report the options that are configured without being created, such as the ones of `ConfigureHttpJsonOptions` or `AddJsonOptions` in an ASP.NET Core application, and it does not report the copy constructor, as the copied instance can be configured somewhere else.
+The rule only reports the creation of a `JsonSerializerOptions`, and considers the option configured when it is set in the object initializer, or on the local the creation is assigned to, by a statement that runs after the creation and before another instance is assigned to that local. It does not report the options that are configured without being created, such as the ones of `ConfigureHttpJsonOptions` or `AddJsonOptions` in an ASP.NET Core application, and it does not report the copy constructor, as the copied instance can be configured somewhere else.
 
 The option can also be enabled for the whole application with the `System.Text.Json.Serialization.RespectNullableAnnotationsDefault` feature switch, which this rule does not detect:
 

--- a/docs/Rules/MA0225.md
+++ b/docs/Rules/MA0225.md
@@ -33,7 +33,7 @@ record Person(int Id);
 
 The rule does not report anything when the target framework does not support the option.
 
-The rule only reports the creation of a `JsonSerializerOptions`, and considers the option configured when it is set in the object initializer, or on the local the creation is assigned to in the same method. It does not report the options that are configured without being created, such as the ones of `ConfigureHttpJsonOptions` or `AddJsonOptions` in an ASP.NET Core application, and it does not report the copy constructor, as the copied instance can be configured somewhere else.
+The rule only reports the creation of a `JsonSerializerOptions`, and considers the option configured when it is set in the object initializer, or on the local the creation is assigned to, by a statement that runs after the creation and before another instance is assigned to that local. It does not report the options that are configured without being created, such as the ones of `ConfigureHttpJsonOptions` or `AddJsonOptions` in an ASP.NET Core application, and it does not report the copy constructor, as the copied instance can be configured somewhere else.
 
 The option can also be enabled for the whole application with the `System.Text.Json.Serialization.RespectRequiredConstructorParametersDefault` feature switch, which this rule does not detect:
 

--- a/src/Meziantou.Analyzer/Rules/JsonSerializerOptionsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/JsonSerializerOptionsAnalyzer.cs
@@ -134,30 +134,63 @@ public sealed class JsonSerializerOptionsAnalyzer : DiagnosticAnalyzer
         /// <summary>
         /// Indicates whether the created instance is stored in a local that a following statement configures,
         /// such as <c>var options = new JsonSerializerOptions(); options.RespectNullableAnnotations = true;</c>.
+        /// Only the statements that run before another instance is assigned to the local are considered, as the
+        /// following ones configure that other instance.
         /// </summary>
         private static bool IsSetOnLocal(IObjectCreationOperation operation, string propertyName)
         {
             if (GetAssignedLocal(operation) is not { } local)
                 return false;
 
-            IOperation root = operation;
-            while (root.Parent is not null)
+            foreach (var statement in GetFollowingStatements(operation))
             {
-                root = root.Parent;
-            }
-
-            foreach (var descendant in root.Descendants())
-            {
-                if (descendant is ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Instance: ILocalReferenceOperation localReference } property }
-                    && IsProperty(property, propertyName)
-                    && local.IsEqualTo(localReference.Local))
+                foreach (var descendant in statement.DescendantsAndSelf())
                 {
-                    return true;
+                    if (descendant is ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Instance: ILocalReferenceOperation localReference } property }
+                        && IsProperty(property, propertyName)
+                        && local.IsEqualTo(localReference.Local))
+                    {
+                        return true;
+                    }
+
+                    if (IsAssignedTo(descendant, local))
+                        return false;
                 }
             }
 
             return false;
         }
+
+        /// <summary>
+        /// Gets the statements that run after the statement containing the operation, in the order they run.
+        /// </summary>
+        private static IEnumerable<IOperation> GetFollowingStatements(IOperation operation)
+        {
+            for (var current = operation; current.Parent is { } parent; current = parent)
+            {
+                var statements = parent switch
+                {
+                    IBlockOperation block => block.Operations,
+                    ISwitchCaseOperation switchCase => switchCase.Body,
+                    _ => ImmutableArray<IOperation>.Empty,
+                };
+
+                for (var i = statements.IndexOf(current) + 1; i < statements.Length; i++)
+                {
+                    yield return statements[i];
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether the operation assigns another value to the local.
+        /// </summary>
+        private static bool IsAssignedTo(IOperation operation, ILocalSymbol local) => operation switch
+        {
+            IAssignmentOperation { Target: ILocalReferenceOperation localReference } => local.IsEqualTo(localReference.Local),
+            IArgumentOperation { Parameter.RefKind: RefKind.Ref or RefKind.Out, Value: ILocalReferenceOperation localReference } => local.IsEqualTo(localReference.Local),
+            _ => false,
+        };
 
         private static bool IsProperty(IPropertyReferenceOperation operation, string propertyName)
             => string.Equals(operation.Property.Name, propertyName, StringComparison.Ordinal);

--- a/tests/Meziantou.Analyzer.Test/Rules/JsonSerializerOptionsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/JsonSerializerOptionsAnalyzerTests.cs
@@ -143,6 +143,112 @@ public sealed class JsonSerializerOptionsAnalyzerTests
     }
 
     [Fact]
+    public Task OptionsSetOnTheLocalBeforeItIsAssignedANewInstance()
+    {
+        // The first statement configures the first instance, not the one created afterwards
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                void A()
+                {
+                    var options = {|MA0225:new JsonSerializerOptions()|};
+                    options.RespectNullableAnnotations = true;
+                    options = {|MA0224:{|MA0225:new JsonSerializerOptions()|}|};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionsSetOnTheLocalAfterItIsAssignedANewInstance()
+    {
+        // The last statements configure the last instance, not the one created before
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                void A()
+                {
+                    var options = {|MA0224:{|MA0225:new JsonSerializerOptions()|}|};
+                    options = new JsonSerializerOptions();
+                    options.RespectNullableAnnotations = true;
+                    options.RespectRequiredConstructorParameters = true;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionsSetOnTheLocalInAnEnclosingBlock()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                void A(bool condition)
+                {
+                    JsonSerializerOptions options;
+                    if (condition)
+                    {
+                        options = new JsonSerializerOptions();
+                    }
+                    else
+                    {
+                        options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+                    }
+
+                    options.RespectNullableAnnotations = true;
+                    options.RespectRequiredConstructorParameters = true;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionsSetOnTheLocalInTheSameSwitchSection()
+    {
+        var test = new AnalyzerTest();
+        test.TestCode = """
+            using System.Text.Json;
+
+            class Sample
+            {
+                void A(int value)
+                {
+                    JsonSerializerOptions options;
+                    switch (value)
+                    {
+                        case 0:
+                            options = new JsonSerializerOptions();
+                            options.RespectNullableAnnotations = true;
+                            options.RespectRequiredConstructorParameters = true;
+                            break;
+
+                        default:
+                            options = {|MA0224:{|MA0225:new JsonSerializerOptions()|}|};
+                            break;
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task OptionsSetOnAnotherLocal()
     {
         var test = new AnalyzerTest();


### PR DESCRIPTION
## What

`IsSetOnLocal` in `JsonSerializerOptionsAnalyzer` walked to the top of the operation tree and accepted **any** `local.Property = …` assignment found in it, without considering program order or reassignment of the local. An assignment that ran *before* a creation — and therefore configured a different instance — suppressed the diagnostic on that creation:

```csharp
var options = new JsonSerializerOptions();
options.RespectNullableAnnotations = true;
options = new JsonSerializerOptions(); // MA0225 only: MA0224 was missed
```

The mirror case was wrong too: configuration that follows a replacement creation suppressed the diagnostic on the earlier, unconfigured instance.

The scan now starts at the statements that run *after* the creation and stops as soon as another value is assigned to the local:

- `GetFollowingStatements` yields the siblings after the statement containing the creation, then continues in each enclosing block. It also handles switch sections, whose bodies are an `ImmutableArray<IOperation>` rather than an `IBlockOperation`, so a creation configured later in the same `case` is still recognized. Walking up the enclosing blocks keeps the case where the creation is nested in an `if`/`switch` and the configuration is done afterwards in the outer block.
- `IsAssignedTo` ends the scan on a reassignment of the local: a simple or compound assignment, or passing it as `ref`/`out`.

## Tests

Four tests added to `JsonSerializerOptionsAnalyzerTests`:

- `OptionsSetOnTheLocalBeforeItIsAssignedANewInstance` — the reported case; both rules are now reported on the replacement creation.
- `OptionsSetOnTheLocalAfterItIsAssignedANewInstance` — the mirror case; the first creation is reported instead of being suppressed by configuration that belongs to the second instance.
- `OptionsSetOnTheLocalInAnEnclosingBlock` and `OptionsSetOnTheLocalInTheSameSwitchSection` — guard the block walking, which the previous whole-tree scan covered implicitly.

Both new cases were confirmed failing against the analyzer before the fix.

## Docs

The behavior sentence of `MA0224.md` and `MA0225.md` now states that the configuration must run after the creation and before another instance is assigned to the local.

## Notes for the reviewer

- The change is conservative in the direction of reporting: a creation inside a loop body configured by a statement placed *before* it in that body is now reported. That shape looks unlikely enough not to warrant a control flow graph.
- Crossing a lambda or local function boundary while walking up the enclosing blocks is kept as before, so configuration done inside a lambda declared after the creation still counts.
- Verified: the solution builds with 0 warnings, `JsonSerializerOptionsAnalyzerTests` passes on all five Roslyn versions (26 tests each), the full roslyn5.9 suite passes (4579/4579), and `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes.
