### PR TITLE
Fix MA0040 inserting the CancellationToken in an invalid argument position

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs
@@ -11,80 +11,110 @@ public sealed class UseAnOverloadThatHasCancellationTokenFixer_Argument : CodeFi
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        if (nodeToFix is null)
+        if (nodeToFix is not InvocationExpressionSyntax invocationExpression)
             return;
 
-        if (nodeToFix.IsKind(SyntaxKind.InvocationExpression))
+        if (!int.TryParse(context.Diagnostics[0].Properties.GetValueOrDefault(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterIndexKey), NumberStyles.None, CultureInfo.InvariantCulture, out var parameterIndex))
+            return;
+
+        if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterNameKey, out var parameterName) || parameterName is null)
+            return;
+
+        if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterIsEnumeratorCancellationKey, out var parameterIsEnumeratorCancellation) || !bool.TryParse(parameterIsEnumeratorCancellation, out var isEnumeratorCancellation))
+            return;
+
+        if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.CancellationTokensKey, out var cancellationTokens) || cancellationTokens is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var cancellationTokenSymbol = semanticModel.Compilation.GetBestTypeByMetadataName("System.Threading.CancellationToken");
+        if (cancellationTokenSymbol is null)
+            return;
+
+        var generator = SyntaxGenerator.GetGenerator(context.Document);
+        foreach (var cancellationToken in cancellationTokens.Split(','))
         {
-            if (!int.TryParse(context.Diagnostics[0].Properties.GetValueOrDefault(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterIndexKey), NumberStyles.None, CultureInfo.InvariantCulture, out var parameterIndex))
-                return;
+            var cancellationTokenExpression = SyntaxFactory.ParseExpression(cancellationToken);
+            var newInvocation = CreateInvocation(semanticModel, generator, invocationExpression, parameterIndex, parameterName, cancellationTokenExpression, cancellationTokenSymbol);
+            if (newInvocation is null)
+                continue;
 
-            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterNameKey, out var parameterName) || parameterName is null)
-                return;
+            var nodeToReplace = isEnumeratorCancellation
+                ? GetRedundantWithCancellation(semanticModel, invocationExpression, cancellationTokenExpression, context.CancellationToken) ?? invocationExpression
+                : invocationExpression;
 
-            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.ParameterIsEnumeratorCancellationKey, out var parameterIsEnumeratorCancellation) || !bool.TryParse(parameterIsEnumeratorCancellation, out var isEnumeratorCancellation))
-                return;
+            var title = "Use CancellationToken:  " + cancellationToken;
+            var codeAction = CodeAction.Create(
+                title,
+                ct => FixInvocation(context.Document, nodeToReplace, newInvocation, ct),
+                equivalenceKey: title);
 
-            if (!context.Diagnostics[0].Properties.TryGetValue(UseAnOverloadThatHasCancellationTokenAnalyzerCommon.CancellationTokensKey, out var cancellationTokens) || cancellationTokens is null)
-                return;
-
-            foreach (var cancellationToken in cancellationTokens.Split(','))
-            {
-                var title = "Use CancellationToken:  " + cancellationToken;
-                var codeAction = CodeAction.Create(
-                    title,
-                    ct => FixInvocation(context.Document, (InvocationExpressionSyntax)nodeToFix, parameterIndex, parameterName, cancellationToken, isEnumeratorCancellation, ct),
-                    equivalenceKey: title);
-
-                context.RegisterCodeFix(codeAction, context.Diagnostics);
-            }
+            context.RegisterCodeFix(codeAction, context.Diagnostics);
         }
     }
 
-    private static async Task<Document> FixInvocation(Document document, InvocationExpressionSyntax nodeToFix, int index, string parameterName, string cancellationTokenText, bool isEnumeratorCancellation, CancellationToken cancellationToken)
+    /// <summary>
+    /// Gets the enclosing <c>WithCancellation</c> invocation that becomes redundant once the token is passed to the method itself.
+    /// </summary>
+    private static SyntaxNode? GetRedundantWithCancellation(SemanticModel semanticModel, InvocationExpressionSyntax nodeToFix, ExpressionSyntax cancellationTokenExpression, CancellationToken cancellationToken)
+    {
+        if (semanticModel.GetOperation(nodeToFix, cancellationToken) is not IInvocationOperation invocation)
+            return null;
+
+        if (invocation.Parent?.Parent is not IInvocationOperation { TargetMethod.Name: "WithCancellation", Arguments: [{ }, { Value: var withCancellationArgument }] } parent)
+            return null;
+
+        if (!withCancellationArgument.Syntax.IsEquivalentTo(cancellationTokenExpression))
+            return null;
+
+        return parent.Syntax;
+    }
+
+    private static InvocationExpressionSyntax? CreateInvocation(SemanticModel semanticModel, SyntaxGenerator generator, InvocationExpressionSyntax nodeToFix, int parameterIndex, string parameterName, ExpressionSyntax cancellationTokenExpression, INamedTypeSymbol cancellationTokenSymbol)
+    {
+        var arguments = nodeToFix.ArgumentList.Arguments;
+
+        // A positional argument can only be added at the index of the parameter when all the arguments written before it are positional.
+        // Otherwise, C# does not allow it (CS1738, CS1739, CS8323) or it would be bound to the wrong parameter.
+        if (parameterIndex <= arguments.Count && !arguments.Take(parameterIndex).Any(argument => argument.NameColon is not null))
+        {
+            var positionalArgument = (ArgumentSyntax)generator.Argument(cancellationTokenExpression);
+            var candidate = ReplaceArguments(nodeToFix, arguments.Insert(parameterIndex, positionalArgument));
+            if (GetTargetMethod(semanticModel, nodeToFix, candidate) is { } method && parameterIndex < method.Parameters.Length && method.Parameters[parameterIndex].Type.IsEqualTo(cancellationTokenSymbol))
+                return candidate;
+        }
+
+        // A named argument added at the end of the list is valid whatever the order of the existing arguments
+        var namedArgument = (ArgumentSyntax)generator.Argument(parameterName, RefKind.None, cancellationTokenExpression);
+        var namedCandidate = ReplaceArguments(nodeToFix, arguments.Add(namedArgument));
+        var namedParameter = GetTargetMethod(semanticModel, nodeToFix, namedCandidate)?.Parameters.FirstOrDefault(parameter => string.Equals(parameter.Name, parameterName, StringComparison.Ordinal));
+        if (namedParameter is not null && namedParameter.Type.IsEqualTo(cancellationTokenSymbol))
+            return namedCandidate;
+
+        return null;
+    }
+
+    private static InvocationExpressionSyntax ReplaceArguments(InvocationExpressionSyntax nodeToFix, SeparatedSyntaxList<ArgumentSyntax> arguments)
+    {
+        return nodeToFix.WithArgumentList(nodeToFix.ArgumentList.WithArguments(arguments));
+    }
+
+    /// <summary>
+    /// Gets the method the invocation would be bound to, so the fix is only offered when the new invocation compiles
+    /// and the new argument is bound to the expected parameter.
+    /// </summary>
+    private static IMethodSymbol? GetTargetMethod(SemanticModel semanticModel, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation)
+    {
+        return semanticModel.GetSpeculativeSymbolInfo(nodeToFix.SpanStart, newInvocation, SpeculativeBindingOption.BindAsExpression).Symbol as IMethodSymbol;
+    }
+
+    private static async Task<Document> FixInvocation(Document document, SyntaxNode nodeToReplace, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var generator = editor.Generator;
-
-        var cancellationTokenExpression = SyntaxFactory.ParseExpression(cancellationTokenText);
-
-        SyntaxNode? parentNode = null;
-        if (isEnumeratorCancellation)
-        {
-            if (editor.SemanticModel.GetOperation(nodeToFix, cancellationToken) is IInvocationOperation invocation)
-            {
-                // Check direct invocation parent
-                if (invocation.Parent?.Parent is IInvocationOperation { TargetMethod.Name: "WithCancellation", Arguments: [{ }, { Value: var withCancellationArgument }] } parent)
-                {
-                    if (withCancellationArgument.Syntax.IsEquivalentTo(cancellationTokenExpression))
-                    {
-                        parentNode = parent.Syntax;
-                    }
-                }
-            }
-        }
-
-        SyntaxNode newInvocation;
-        if (index > nodeToFix.ArgumentList.Arguments.Count)
-        {
-            var newArguments = nodeToFix.ArgumentList.Arguments.Add((ArgumentSyntax)generator.Argument(parameterName, RefKind.None, cancellationTokenExpression));
-            newInvocation = nodeToFix.WithArgumentList(SyntaxFactory.ArgumentList(newArguments));
-        }
-        else
-        {
-            var newArguments = nodeToFix.ArgumentList.Arguments.Insert(index, (ArgumentSyntax)generator.Argument(cancellationTokenExpression));
-            newInvocation = nodeToFix.WithArgumentList(SyntaxFactory.ArgumentList(newArguments));
-        }
-
-        if (parentNode is not null)
-        {
-            editor.ReplaceNode(parentNode, newInvocation);
-        }
-        else
-        {
-            editor.ReplaceNode(nodeToFix, newInvocation);
-        }
-
+        editor.ReplaceNode(nodeToReplace, newInvocation);
         return editor.GetChangedDocument();
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasCancellationTokenAnalyzerTests.cs
@@ -1655,4 +1655,113 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzerTests
 
         return test.RunAsync();
     }
+    [Fact]
+    public Task NamedArguments_OutOfOrder()
+    {
+        var test = CreateArgumentFixTest();
+        test.TestCode = """
+            using System.Threading;
+            class Test
+            {
+                static int M(int x, int y) => x + y;
+                static int M(int x, int y, CancellationToken token) => x + y;
+
+                public static object A(CancellationToken token) => {|MA0040:M(y: 2, x: 1)|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading;
+            class Test
+            {
+                static int M(int x, int y) => x + y;
+                static int M(int x, int y, CancellationToken token) => x + y;
+
+                public static object A(CancellationToken token) => M(y: 2, x: 1, token: token);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task NamedArguments_InOrder()
+    {
+        var test = CreateArgumentFixTest();
+        test.TestCode = """
+            using System.Threading;
+            class Test
+            {
+                static int M(int x, int y) => x + y;
+                static int M(int x, int y, CancellationToken token) => x + y;
+
+                public static object A(CancellationToken token) => {|MA0040:M(x: 1, y: 2)|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading;
+            class Test
+            {
+                static int M(int x, int y) => x + y;
+                static int M(int x, int y, CancellationToken token) => x + y;
+
+                public static object A(CancellationToken token) => M(x: 1, y: 2, token: token);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task NamedArgumentAfterCancellationTokenParameter()
+    {
+        var test = CreateArgumentFixTest();
+        test.TestCode = """
+            using System.Threading;
+            class Test
+            {
+                static int M(int x, int y) => x + y;
+                static int M(int x, CancellationToken token, int y) => x + y;
+
+                public static object A(CancellationToken token) => {|MA0040:M(1, y: 2)|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading;
+            class Test
+            {
+                static int M(int x, int y) => x + y;
+                static int M(int x, CancellationToken token, int y) => x + y;
+
+                public static object A(CancellationToken token) => M(1, token, y: 2);
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task OptionalParameter_WithNamedArgumentBeforeCancellationToken()
+    {
+        var test = CreateArgumentFixTest();
+        test.TestCode = """
+            using System.Threading;
+            class Test
+            {
+                static void M(int a = 0, int b = 0, CancellationToken token = default) => throw null;
+
+                public static void A(CancellationToken token) => {|MA0040:M(b: 1)|};
+            }
+            """;
+        test.FixedCode = """
+            using System.Threading;
+            class Test
+            {
+                static void M(int a = 0, int b = 0, CancellationToken token = default) => throw null;
+
+                public static void A(CancellationToken token) => M(b: 1, token: token);
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## What

The MA0040 code fix inserted the `CancellationToken` argument at the index of the parameter in the *written* argument list. Named arguments need not be written in parameter order, so the inserted positional argument could follow an out-of-order named argument.

```csharp
using System.Threading;
public class Sample
{
    static int M(int x, int y) => x + y;
    static int M(int x, int y, CancellationToken token) => x + y;

    public static object Run(CancellationToken token) => M(y: 2, x: 1);
}
```

The original source compiles. The fix produced `M(y: 2, x: 1, token)`, which fails with **CS8323** — an unnamed argument cannot follow a named argument used out of position. The same mapping could also bind the new argument to the wrong parameter (CS1738, CS1739).

## How

[`UseAnOverloadThatHasCancellationTokenFixer_Argument`](src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs) now follows the same shape as the MA0166 fixer after #1490:

- The token is inserted at the parameter index only when every argument written before that index is positional.
- Otherwise it is added as a named argument at the end of the list, which is valid whatever the order of the existing arguments and keeps their evaluation order.
- Both candidates are bound with `GetSpeculativeSymbolInfo` before the fix is registered, so the fix is only offered when the new invocation compiles and the new argument is bound to a `CancellationToken` parameter. Building the invocation moved into `RegisterCodeFixesAsync` accordingly, per the repository's "validate before registering" rule; `FixInvocation` now only replaces the node.

The `WithCancellation` removal path moved into `GetRedundantWithCancellation` with no behavior change. Arguments are rewritten with `ArgumentList.WithArguments(...)` instead of a fresh `SyntaxFactory.ArgumentList(...)`, which preserves the original parentheses' trivia.

## Notes for the reviewer

The in-order case `M(x: 1, y: 2)` also gets the named form (`M(x: 1, y: 2, token: token)`) rather than a positional append. A positional argument would be legal there, but the guard is on "any preceding named argument", which matches `NamedArguments_InOrder` in the MA0166 tests — I kept the two fixers consistent rather than adding an in-position special case.

No documentation change: `docs/Rules/MA0040.md` does not describe argument placement, and the analogous MA0166 fix touched no docs either. `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.

## Tests

Four tests added to `UseAnOverloadThatHasCancellationTokenAnalyzerTests`: `NamedArguments_OutOfOrder` (the reproduction above), `NamedArguments_InOrder`, `NamedArgumentAfterCancellationTokenParameter` (still gets the positional insert: `M(1, token, y: 2)`), and `OptionalParameter_WithNamedArgumentBeforeCancellationToken`. Both new named-argument tests fail against the previous fixer, which emits `M(y: 2, x: 1, token)`.

- `dotnet build` — succeeded, 0 warnings, 0 errors.
- MA0032/MA0040/MA0166 tests: 81 passing on each of roslyn4.8, 4.14, 5.0, 5.6 and 5.9; 0 failed, 0 skipped.
- Full suite across all five Roslyn versions: 22601 passed, 0 failed, 0 skipped.