### PR TITLE
Preserve argument binding in the MA0074 code fix

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparisonFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparisonFixer.cs
@@ -13,10 +13,7 @@ public sealed class UseStringComparisonFixer : CodeFixProvider
         // In case the ArrayCreationExpressionSyntax is wrapped in an ArgumentSyntax or some other node with the same span,
         // get the innermost node for ties.
         var nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-        if (nodeToFix is null)
-            return;
-
-        if (nodeToFix is not InvocationExpressionSyntax)
+        if (nodeToFix is not InvocationExpressionSyntax invocationExpression)
             return;
 
         var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
@@ -27,64 +24,87 @@ public sealed class UseStringComparisonFixer : CodeFixProvider
         if (stringComparisonSymbol is null)
             return;
 
+        var parameter = FindStringComparisonParameter(semanticModel, invocationExpression, stringComparisonSymbol, context.CancellationToken);
+        if (parameter is null)
+            return;
+
+        var generator = SyntaxGenerator.GetGenerator(context.Document);
         AddCodeFix(nameof(StringComparison.Ordinal));
         AddCodeFix(nameof(StringComparison.OrdinalIgnoreCase));
 
         void AddCodeFix(string comparisonMode)
         {
+            var newInvocation = CreateInvocation(semanticModel, generator, invocationExpression, parameter, stringComparisonSymbol, comparisonMode);
+            if (newInvocation is null)
+                return;
+
             var title = "Add StringComparison." + comparisonMode;
             var codeAction = CodeAction.Create(
                 title,
-                ct => AddStringComparison(context.Document, nodeToFix, comparisonMode, stringComparisonSymbol, ct),
+                ct => FixInvocation(context.Document, invocationExpression, newInvocation, ct),
                 equivalenceKey: title);
 
             context.RegisterCodeFix(codeAction, context.Diagnostics);
         }
     }
 
-    private static async Task<Document> AddStringComparison(Document document, SyntaxNode nodeToFix, string stringComparisonMode, INamedTypeSymbol stringComparison, CancellationToken cancellationToken)
+    private static InvocationExpressionSyntax? CreateInvocation(SemanticModel semanticModel, SyntaxGenerator generator, InvocationExpressionSyntax nodeToFix, IParameterSymbol parameter, INamedTypeSymbol stringComparison, string stringComparisonMode)
+    {
+        var comparisonExpression = generator.TypeMemberAccessExpression(stringComparison, stringComparisonMode, addImport: true);
+        var arguments = nodeToFix.ArgumentList.Arguments;
+        var parameterIndex = parameter.Ordinal;
+
+        // A positional argument can only be added at the index of the parameter when all the arguments written before it are positional.
+        // Otherwise, C# does not allow it (CS1738, CS1739, CS8323) or it would be bound to the wrong parameter.
+        if (parameterIndex <= arguments.Count && !arguments.Take(parameterIndex).Any(argument => argument.NameColon is not null))
+        {
+            var positionalArgument = (ArgumentSyntax)generator.Argument(comparisonExpression);
+            var candidate = ReplaceArguments(nodeToFix, arguments.Insert(parameterIndex, positionalArgument));
+            if (GetTargetMethod(semanticModel, nodeToFix, candidate) is { } method && parameterIndex < method.Parameters.Length && method.Parameters[parameterIndex].Type.IsEqualTo(stringComparison))
+                return candidate;
+        }
+
+        // A named argument added at the end of the list is valid whatever the order of the existing arguments
+        var namedArgument = (ArgumentSyntax)generator.Argument(parameter.Name, RefKind.None, comparisonExpression);
+        var namedCandidate = ReplaceArguments(nodeToFix, arguments.Add(namedArgument));
+        var namedParameter = GetTargetMethod(semanticModel, nodeToFix, namedCandidate)?.Parameters.FirstOrDefault(candidate => string.Equals(candidate.Name, parameter.Name, StringComparison.Ordinal));
+        if (namedParameter is not null && namedParameter.Type.IsEqualTo(stringComparison))
+            return namedCandidate;
+
+        return null;
+    }
+
+    private static InvocationExpressionSyntax ReplaceArguments(InvocationExpressionSyntax nodeToFix, SeparatedSyntaxList<ArgumentSyntax> arguments)
+    {
+        return nodeToFix.WithArgumentList(nodeToFix.ArgumentList.WithArguments(arguments));
+    }
+
+    /// <summary>
+    /// Gets the method the invocation would be bound to, so the fix is only offered when the new invocation compiles
+    /// and the new argument is bound to the StringComparison parameter.
+    /// </summary>
+    private static IMethodSymbol? GetTargetMethod(SemanticModel semanticModel, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation)
+    {
+        return semanticModel.GetSpeculativeSymbolInfo(nodeToFix.SpanStart, newInvocation, SpeculativeBindingOption.BindAsExpression).Symbol as IMethodSymbol;
+    }
+
+    private static async Task<Document> FixInvocation(Document document, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var semanticModel = editor.SemanticModel;
-        var generator = editor.Generator;
-
-        var invocationExpression = (InvocationExpressionSyntax)nodeToFix;
-
-        var newArgument = (ArgumentSyntax)generator.Argument(
-            generator.TypeMemberAccessExpression(stringComparison, stringComparisonMode, addImport: true));
-
-        var insertionIndex = FindStringComparisonParameterIndex(semanticModel, invocationExpression, stringComparison, cancellationToken);
-        SyntaxNode newInvocation;
-        if (insertionIndex >= 0 && insertionIndex < invocationExpression.ArgumentList.Arguments.Count)
-        {
-            var newArgList = invocationExpression.ArgumentList.Arguments.Insert(insertionIndex, newArgument);
-            newInvocation = invocationExpression.WithArgumentList(invocationExpression.ArgumentList.WithArguments(newArgList));
-        }
-        else
-        {
-            newInvocation = invocationExpression.AddArgumentListArguments(newArgument);
-        }
-
-        editor.ReplaceNode(invocationExpression, newInvocation);
+        editor.ReplaceNode(nodeToFix, newInvocation);
         return editor.GetChangedDocument();
     }
 
-    private static int FindStringComparisonParameterIndex(SemanticModel semanticModel, SyntaxNode node, INamedTypeSymbol stringComparison, CancellationToken cancellationToken)
+    private static IParameterSymbol? FindStringComparisonParameter(SemanticModel semanticModel, SyntaxNode node, INamedTypeSymbol stringComparison, CancellationToken cancellationToken)
     {
         if (semanticModel.GetOperation(node, cancellationToken) is not IInvocationOperation operation)
-            return -1;
+            return null;
 
         var overloadFinder = new OverloadFinder(semanticModel.Compilation);
         var overload = overloadFinder.FindOverloadWithAdditionalParameterOfType(operation, options: default, [stringComparison]);
         if (overload is null)
-            return -1;
+            return null;
 
-        for (var i = 0; i < overload.Parameters.Length; i++)
-        {
-            if (overload.Parameters[i].Type.IsEqualTo(stringComparison))
-                return i;
-        }
-
-        return -1;
+        return overload.Parameters.FirstOrDefault(parameter => parameter.Type.IsEqualTo(stringComparison));
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseStringComparisonAnalyzerTests.cs
@@ -634,4 +634,132 @@ public sealed class UseStringComparisonAnalyzerTests
 
         return test.RunAsync();
     }
+
+    [Fact]
+    public Task IndexOf_ReorderedNamedArguments_ShouldAddNamedArgument()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = {|MA0074:"abc".IndexOf(startIndex: 0, value: "a")|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = "abc".IndexOf(startIndex: 0, value: "a", comparisonType: System.StringComparison.Ordinal);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task IndexOf_NamedArgumentsInOrder_ShouldAddNamedArgument()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = {|MA0074:"abc".IndexOf(value: "a", startIndex: 0)|};
+                }
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    _ = "abc".IndexOf(value: "a", startIndex: 0, comparisonType: System.StringComparison.Ordinal);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringComparisonParameterIsNotLast_ShouldInsertArgumentAtParameterIndex()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    {|MA0074:Sample.Method("x", "y")|};
+                }
+            }
+
+            static class Sample
+            {
+                public static void Method(string a, string b) => throw null;
+                public static void Method(string a, System.StringComparison comparisonType, string b) => throw null;
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    Sample.Method("x", System.StringComparison.Ordinal, "y");
+                }
+            }
+
+            static class Sample
+            {
+                public static void Method(string a, string b) => throw null;
+                public static void Method(string a, System.StringComparison comparisonType, string b) => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StringComparisonParameterIsNotLast_ReorderedNamedArguments_ShouldAddNamedArgument()
+    {
+        var test = new CodeFixTest();
+        test.TestCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    {|MA0074:Sample.Method(b: "y", a: "x")|};
+                }
+            }
+
+            static class Sample
+            {
+                public static void Method(string a, string b) => throw null;
+                public static void Method(string a, System.StringComparison comparisonType, string b) => throw null;
+            }
+            """;
+        test.FixedCode = """
+            class TypeName
+            {
+                public void Test()
+                {
+                    Sample.Method(b: "y", a: "x", comparisonType: System.StringComparison.Ordinal);
+                }
+            }
+
+            static class Sample
+            {
+                public static void Method(string a, string b) => throw null;
+                public static void Method(string a, System.StringComparison comparisonType, string b) => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
 }


### PR DESCRIPTION
## Problem

The MA0074 / MA0001 code fix added the `StringComparison` argument at the index of the parameter in the **written** argument list, and appended it positionally when that index was out of range. Named arguments can be written in another order, so the added positional argument could follow an out-of-order named argument — which does not compile (CS1738, CS1739, CS8323) — or could be bound to another parameter.

```csharp
public class Sample
{
    public static object Run() => "abc".IndexOf(startIndex: 0, value: "a");
}
```

The original compiles. Applying the Ordinal fix produced:

```csharp
"abc".IndexOf(startIndex: 0, value: "a", System.StringComparison.Ordinal)
```

which reports CS8323, because a positional argument cannot follow out-of-order named arguments.

## Fix

`UseStringComparisonFixer` now follows the same pattern as the recent MA0166 fix in `UseAnOverloadThatHasTimeProviderFixer`:

- The argument is only inserted at the index of the parameter when all the arguments written before it are positional.
- Otherwise, it is added as a named argument at the end of the list, which is valid whatever the order of the existing arguments and keeps their evaluation order.
- The candidate invocation is bound with the semantic model (`GetSpeculativeSymbolInfo`) before the fix is registered, so the fix is only offered when the new invocation compiles and the new argument is bound to the `StringComparison` parameter.
- The overload lookup moved from the code action to `RegisterCodeFixesAsync`, so no fix is registered when none can be produced (repository guidance: validate before registering).

The example above is now fixed to:

```csharp
"abc".IndexOf(startIndex: 0, value: "a", comparisonType: System.StringComparison.Ordinal)
```

## Notes for reviewers

- Only the code fix changed; the analyzer and the rule documentation are unchanged, so `dotnet run --project src/DocumentationGenerator` reports no markdown change.
- Invocations whose arguments are all positional keep the existing behavior: the argument is inserted at the parameter index, including when that parameter is not the last one.
- Named arguments written in their natural order now also get a named `StringComparison` argument rather than a positional one. Both are valid; the named form is used because it stays valid whatever the argument order.

## Tests

Four tests added to `UseStringComparisonAnalyzerTests`:

- reordered named arguments (the reported case),
- named arguments written in order,
- a `StringComparison` parameter that is not the last one, with positional arguments (mid-list insertion still works),
- the same overload with reordered named arguments.

## Validation

- `dotnet build` — succeeded, 0 warnings.
- MA0074 tests: 30/30 pass on roslyn4.8, roslyn4.14, roslyn5.0, roslyn5.6 and roslyn5.9.
- Full roslyn5.9 suite: 4579/4579 pass.
- `dotnet run --project src/DocumentationGenerator` — exit code 0, no markdown change.