### PR TITLE
Preserve the variable scope in the MA0004 code fix

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseConfigureAwaitFixer.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis.Formatting;
+
 namespace Meziantou.Analyzer.Rules;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
@@ -115,7 +117,7 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
                         .WithDeclaration(null)
                         .WithExpression(AppendConfigureAwait(SyntaxFactory.IdentifierName(usingBlock.Declaration.Variables[0].Identifier)));
 
-                    if (TryInsertVariableStatementBeforeUsing(variablesStatement.WithLeadingTrivia(usingBlock.GetLeadingTrivia()), usingBlock))
+                    if (TryInsertVariableStatementBeforeUsing(variablesStatement.WithLeadingTrivia(usingBlock.GetLeadingTrivia()), usingBlock, usingBlock.Declaration.Variables[0].Identifier.ValueText))
                     {
                         editor.ReplaceNode(usingBlock, newUsingBlock);
                     }
@@ -123,7 +125,8 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
                     {
                         var newBlock = SyntaxFactory.Block(variablesStatement, newUsingBlock.WithoutLeadingTrivia())
                             .WithLeadingTrivia(usingBlock.GetLeadingTrivia())
-                            .WithTrailingTrivia(usingBlock.GetTrailingTrivia());
+                            .WithTrailingTrivia(usingBlock.GetTrailingTrivia())
+                            .WithAdditionalAnnotations(Formatter.Annotation);
                         editor.ReplaceNode(usingBlock, newBlock);
                     }
 
@@ -203,7 +206,7 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
 
         return context.Document;
 
-        bool TryInsertVariableStatementBeforeUsing(LocalDeclarationStatementSyntax variableStatement, UsingStatementSyntax usingStatement)
+        bool TryInsertVariableStatementBeforeUsing(LocalDeclarationStatementSyntax variableStatement, UsingStatementSyntax usingStatement, string variableName)
         {
             var insertionTarget = usingStatement;
             while (insertionTarget.Parent is UsingStatementSyntax parentUsing &&
@@ -212,6 +215,11 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
             {
                 insertionTarget = parentUsing;
             }
+
+            // Moving the declaration out of the using statement widens the scope of the variable.
+            // When the name is already used elsewhere, keep the original scope by wrapping the statements in a block.
+            if (IsNameUsedOutsideOfUsingStatement(insertionTarget, usingStatement, variableName))
+                return false;
 
             if (insertionTarget.Parent is BlockSyntax or SwitchSectionSyntax)
             {
@@ -223,6 +231,22 @@ public sealed class UseConfigureAwaitFixer : CodeFixProvider
             {
                 editor.InsertBefore(globalStatement, SyntaxFactory.GlobalStatement(variableStatement));
                 return true;
+            }
+
+            return false;
+        }
+
+        static bool IsNameUsedOutsideOfUsingStatement(SyntaxNode insertionTarget, UsingStatementSyntax usingStatement, string variableName)
+        {
+            // The variable is moved to the declaration space of the enclosing function, so the name must not be used anywhere in it
+            var scope = insertionTarget.FirstAncestorOrSelf<SyntaxNode>(node => node is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax or CompilationUnitSyntax);
+            if (scope is null)
+                return true;
+
+            foreach (var token in scope.DescendantTokens())
+            {
+                if (token.IsKind(SyntaxKind.IdentifierToken) && string.Equals(token.ValueText, variableName, StringComparison.Ordinal) && !usingStatement.Span.Contains(token.Span))
+                    return true;
             }
 
             return false;

--- a/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
@@ -378,6 +378,113 @@ public sealed class UseConfigureAwaitAnalyzerTests
     }
 
     [Fact]
+    public Task MissingConfigureAwait_AwaitDispose_Block_SameVariableNameInSiblingUsing_ShouldReportError()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    await using (var {|MA0004:a = new AsyncDisposable()|})
+                    {
+                    }
+                    await using (var {|MA0004:a = new AsyncDisposable()|})
+                    {
+                    }
+                }
+            }
+            class AsyncDisposable : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => throw null;
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    {
+                        var a = new AsyncDisposable();
+                        await using (a.ConfigureAwait(false))
+                        {
+                        }
+                    }
+                    {
+                        var a = new AsyncDisposable();
+                        await using (a.ConfigureAwait(false))
+                        {
+                        }
+                    }
+                }
+            }
+            class AsyncDisposable : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MissingConfigureAwait_AwaitDispose_Block_SameVariableNameInSiblingScope_ShouldReportError()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    await using (var {|MA0004:a = new AsyncDisposable()|})
+                    {
+                    }
+                    {
+                        var a = 0;
+                        _ = a;
+                    }
+                }
+            }
+            class AsyncDisposable : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => throw null;
+            }
+            """;
+        test.FixedCode = """
+            using System;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    {
+                        var a = new AsyncDisposable();
+                        await using (a.ConfigureAwait(false))
+                        {
+                        }
+                    }
+                    {
+                        var a = 0;
+                        _ = a;
+                    }
+                }
+            }
+            class AsyncDisposable : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task MissingConfigureAwait_AwaitDispose_BlockWithoutVariable()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Problem

The MA0004 code fix on `await using (var a = expr)` moves the declaration before the `using` statement:

```csharp
var a = new AsyncDisposable();
await using (a.ConfigureAwait(false)) { }
```

`a` was scoped to the `using` statement; after the fix it is scoped to the whole enclosing block. When the name is used elsewhere in the function, the fixed code no longer compiles.

With two consecutive `await using` statements declaring the same name, the fix emitted two `var a` declarations in the same block (CS0128):

```csharp
await using (var a = new AsyncDisposable()) { }
await using (var a = new AsyncDisposable()) { }
```

Applying the fix to only the first one gives CS0136 instead, since the hoisted local is then in scope for the second declaration.

## Change

`TryInsertVariableStatementBeforeUsing` now refuses to hoist the declaration when the variable name is used anywhere else in the enclosing function (any identifier token outside the `using` statement's own span). The existing fallback then wraps the declaration and the `using` statement in a block, which preserves the original scope exactly:

```csharp
{
    var a = new AsyncDisposable();
    await using (a.ConfigureAwait(false))
    {
    }
}
```

The check is deliberately conservative — a matching identifier token anywhere in the function triggers the block form. It covers the CS0128/CS0136 cases (a conflicting declaration before, after, or in a sibling or nested scope) as well as the subtler case where the hoisted local would shadow a field referenced after the `using` statement and change what that reference binds to. Over-triggering only produces the block form, which is always correct.

The block fallback is also annotated with `Formatter.Annotation`: without it the fallback emitted misindented code, with `await using` indented but its body left at the original level.

## Notes for reviewers

- Non-conflicting names keep the previous, nicer hoisted output. The existing tests, including the chained `await using (stream) await using (var streamWriter = ...)` case that inserts the declaration above the outermost `using` of the chain, are unchanged and still pass.
- The `await using var a = expr;` path is untouched: there the variable is already scoped to the enclosing block, so the fix does not widen anything.

## Tests

Two regression tests in `UseConfigureAwaitAnalyzerTests`: consecutive `await using` declarations reusing a name, and a name reused in a sibling nested block.

- MA0004 test class: 36 tests pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9.
- Full suite on Roslyn 5.9: 4577 passed, 0 failed, 0 skipped.
- `dotnet run --project src/DocumentationGenerator` exits 0, no markdown changes.