### PR TITLE
Share the argument list logic of the code fixes that add an argument

### DIFF
--- a/src/Meziantou.Analyzer.CodeFixers/Internals/ArgumentListHelper.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Internals/ArgumentListHelper.cs
@@ -1,0 +1,154 @@
+namespace Meziantou.Analyzer.Internals;
+
+/// <summary>
+/// Creates the argument lists of the code fixes that add an argument to an invocation.
+/// </summary>
+internal static class ArgumentListHelper
+{
+    /// <summary>
+    /// Creates a copy of <paramref name="invocationExpression"/> with an additional argument bound to the parameter
+    /// named <paramref name="parameterName"/>, declared at the index <paramref name="parameterIndex"/> of the invoked
+    /// overload, or <see langword="null"/> when the argument cannot be added without changing how the invocation binds.
+    /// </summary>
+    /// <param name="parameterIndex">The index of the parameter in the overload the invocation must be bound to after the fix.</param>
+    /// <param name="parameterName">The name of that parameter.</param>
+    /// <param name="argumentExpression">The expression of the argument to add.</param>
+    /// <param name="isExpectedParameter">Validates the parameter the new argument is bound to.</param>
+    /// <param name="overload">The overload the invocation must be bound to after the fix, when it is known. It is used to rename the existing named arguments when the overload declares the parameters with other names.</param>
+    public static InvocationExpressionSyntax? AddArgument(
+        SemanticModel semanticModel,
+        SyntaxGenerator generator,
+        InvocationExpressionSyntax invocationExpression,
+        int parameterIndex,
+        string parameterName,
+        SyntaxNode argumentExpression,
+        Func<IParameterSymbol, bool> isExpectedParameter,
+        IMethodSymbol? overload = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (parameterIndex < 0)
+            return null;
+
+        var arguments = invocationExpression.ArgumentList.Arguments;
+
+        // A positional argument can only be added at the index of the parameter when all the arguments written before it are positional.
+        // Otherwise, C# does not allow it (CS1738, CS1739, CS8323) or it would be bound to another parameter.
+        if (parameterIndex <= arguments.Count && !arguments.Take(parameterIndex).Any(argument => argument.NameColon is not null))
+        {
+            var positionalArgument = (ArgumentSyntax)generator.Argument(argumentExpression);
+            var candidate = WithArguments(invocationExpression, arguments.Insert(parameterIndex, positionalArgument));
+            if (GetBoundParameter(semanticModel, invocationExpression, candidate, parameterIndex) is { } parameter && isExpectedParameter(parameter))
+                return candidate;
+        }
+
+        // The new parameter shifts the parameters declared after it, so the positional arguments written at their
+        // positions would be bound to other parameters once the argument is added at the end of the list.
+        for (var i = parameterIndex; i < arguments.Count; i++)
+        {
+            if (arguments[i].NameColon is null)
+                return null;
+        }
+
+        var namedArgument = (ArgumentSyntax)generator.Argument(parameterName, RefKind.None, argumentExpression);
+
+        // A named argument added at the end of the list is valid whatever the order of the existing arguments, and keeps their evaluation order
+        var namedCandidate = WithArguments(invocationExpression, arguments.Add(namedArgument));
+        if (GetBoundParameter(semanticModel, invocationExpression, namedCandidate, parameterName) is { } namedParameter && isExpectedParameter(namedParameter))
+            return namedCandidate;
+
+        // The overload can declare the parameters with other names, in which case the existing named arguments must be renamed
+        if (overload is not null && RenameArguments(semanticModel, invocationExpression, parameterIndex, overload, cancellationToken) is { } renamedArguments)
+        {
+            var renamedCandidate = WithArguments(invocationExpression, renamedArguments.Add(namedArgument));
+            if (GetBoundParameter(semanticModel, invocationExpression, renamedCandidate, parameterName) is { } renamedParameter && isExpectedParameter(renamedParameter))
+                return renamedCandidate;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Creates a copy of <paramref name="invocationExpression"/> with the arguments <paramref name="arguments"/>.
+    /// </summary>
+    public static InvocationExpressionSyntax WithArguments(InvocationExpressionSyntax invocationExpression, SeparatedSyntaxList<ArgumentSyntax> arguments)
+    {
+        return invocationExpression.WithArgumentList(invocationExpression.ArgumentList.WithArguments(arguments));
+    }
+
+    /// <summary>
+    /// Gets the method <paramref name="newInvocation"/> would be bound to at the position of <paramref name="invocationExpression"/>,
+    /// so a code fix is only offered when the new invocation compiles and its arguments are bound to the expected parameters.
+    /// </summary>
+    public static IMethodSymbol? GetTargetMethod(SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, InvocationExpressionSyntax newInvocation)
+    {
+        return semanticModel.GetSpeculativeSymbolInfo(invocationExpression.SpanStart, newInvocation, SpeculativeBindingOption.BindAsExpression).Symbol as IMethodSymbol;
+    }
+
+    private static IParameterSymbol? GetBoundParameter(SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, InvocationExpressionSyntax newInvocation, int parameterIndex)
+    {
+        var method = GetTargetMethod(semanticModel, invocationExpression, newInvocation);
+        if (method is null || parameterIndex >= method.Parameters.Length)
+            return null;
+
+        return method.Parameters[parameterIndex];
+    }
+
+    private static IParameterSymbol? GetBoundParameter(SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, InvocationExpressionSyntax newInvocation, string parameterName)
+    {
+        var method = GetTargetMethod(semanticModel, invocationExpression, newInvocation);
+        return method?.Parameters.FirstOrDefault(parameter => string.Equals(parameter.Name, parameterName, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Binds the arguments of <paramref name="invocationExpression"/> to the parameters of <paramref name="overload"/>,
+    /// renaming the named arguments when the overload declares the parameters with other names, or returns
+    /// <see langword="null"/> when the arguments cannot be reused.
+    /// </summary>
+    private static SeparatedSyntaxList<ArgumentSyntax>? RenameArguments(SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, int parameterIndex, IMethodSymbol overload, CancellationToken cancellationToken)
+    {
+        if (semanticModel.GetOperation(invocationExpression, cancellationToken) is not IInvocationOperation invocationOperation)
+            return null;
+
+        var arguments = invocationExpression.ArgumentList.Arguments;
+        var newArguments = arguments;
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            var argument = arguments[i];
+            if (argument.NameColon is null)
+                continue;
+
+            var parameter = GetParameter(invocationOperation, argument);
+            if (parameter is null)
+                return null;
+
+            // The new parameter shifts the parameters declared after it
+            var overloadParameterIndex = parameter.Ordinal < parameterIndex ? parameter.Ordinal : parameter.Ordinal + 1;
+            if (overloadParameterIndex >= overload.Parameters.Length)
+                return null;
+
+            // The overload can declare the parameters in a different order, in which case the arguments cannot be reused
+            var overloadParameter = overload.Parameters[overloadParameterIndex];
+            if (!overloadParameter.Type.IsEqualTo(parameter.Type))
+                return null;
+
+            if (!string.Equals(argument.NameColon.Name.Identifier.ValueText, overloadParameter.Name, StringComparison.Ordinal))
+            {
+                var newArgument = argument.WithNameColon(argument.NameColon.WithName(SyntaxFactory.IdentifierName(overloadParameter.Name)));
+                newArguments = newArguments.Replace(newArguments[i], newArgument);
+            }
+        }
+
+        return newArguments;
+
+        static IParameterSymbol? GetParameter(IInvocationOperation invocationOperation, ArgumentSyntax argument)
+        {
+            foreach (var argumentOperation in invocationOperation.Arguments)
+            {
+                if (argumentOperation.Syntax == argument)
+                    return argumentOperation.Parameter;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasCancellationTokenFixer_Argument.cs
@@ -38,7 +38,16 @@ public sealed class UseAnOverloadThatHasCancellationTokenFixer_Argument : CodeFi
         foreach (var cancellationToken in cancellationTokens.Split(','))
         {
             var cancellationTokenExpression = SyntaxFactory.ParseExpression(cancellationToken);
-            var newInvocation = CreateInvocation(semanticModel, generator, invocationExpression, parameterIndex, parameterName, cancellationTokenExpression, cancellationTokenSymbol);
+            var newInvocation = ArgumentListHelper.AddArgument(
+                semanticModel,
+                generator,
+                invocationExpression,
+                parameterIndex,
+                parameterName,
+                cancellationTokenExpression,
+                parameter => parameter.Type.IsEqualTo(cancellationTokenSymbol),
+                cancellationToken: context.CancellationToken);
+
             if (newInvocation is null)
                 continue;
 
@@ -71,44 +80,6 @@ public sealed class UseAnOverloadThatHasCancellationTokenFixer_Argument : CodeFi
             return null;
 
         return parent.Syntax;
-    }
-
-    private static InvocationExpressionSyntax? CreateInvocation(SemanticModel semanticModel, SyntaxGenerator generator, InvocationExpressionSyntax nodeToFix, int parameterIndex, string parameterName, ExpressionSyntax cancellationTokenExpression, INamedTypeSymbol cancellationTokenSymbol)
-    {
-        var arguments = nodeToFix.ArgumentList.Arguments;
-
-        // A positional argument can only be added at the index of the parameter when all the arguments written before it are positional.
-        // Otherwise, C# does not allow it (CS1738, CS1739, CS8323) or it would be bound to the wrong parameter.
-        if (parameterIndex <= arguments.Count && !arguments.Take(parameterIndex).Any(argument => argument.NameColon is not null))
-        {
-            var positionalArgument = (ArgumentSyntax)generator.Argument(cancellationTokenExpression);
-            var candidate = ReplaceArguments(nodeToFix, arguments.Insert(parameterIndex, positionalArgument));
-            if (GetTargetMethod(semanticModel, nodeToFix, candidate) is { } method && parameterIndex < method.Parameters.Length && method.Parameters[parameterIndex].Type.IsEqualTo(cancellationTokenSymbol))
-                return candidate;
-        }
-
-        // A named argument added at the end of the list is valid whatever the order of the existing arguments
-        var namedArgument = (ArgumentSyntax)generator.Argument(parameterName, RefKind.None, cancellationTokenExpression);
-        var namedCandidate = ReplaceArguments(nodeToFix, arguments.Add(namedArgument));
-        var namedParameter = GetTargetMethod(semanticModel, nodeToFix, namedCandidate)?.Parameters.FirstOrDefault(parameter => string.Equals(parameter.Name, parameterName, StringComparison.Ordinal));
-        if (namedParameter is not null && namedParameter.Type.IsEqualTo(cancellationTokenSymbol))
-            return namedCandidate;
-
-        return null;
-    }
-
-    private static InvocationExpressionSyntax ReplaceArguments(InvocationExpressionSyntax nodeToFix, SeparatedSyntaxList<ArgumentSyntax> arguments)
-    {
-        return nodeToFix.WithArgumentList(nodeToFix.ArgumentList.WithArguments(arguments));
-    }
-
-    /// <summary>
-    /// Gets the method the invocation would be bound to, so the fix is only offered when the new invocation compiles
-    /// and the new argument is bound to the expected parameter.
-    /// </summary>
-    private static IMethodSymbol? GetTargetMethod(SemanticModel semanticModel, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation)
-    {
-        return semanticModel.GetSpeculativeSymbolInfo(nodeToFix.SpanStart, newInvocation, SpeculativeBindingOption.BindAsExpression).Symbol as IMethodSymbol;
     }
 
     private static async Task<Document> FixInvocation(Document document, SyntaxNode nodeToReplace, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasMidpointRoundingFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasMidpointRoundingFixer.cs
@@ -29,9 +29,16 @@ public sealed class UseAnOverloadThatHasMidpointRoundingFixer : CodeFixProvider
         if (midpointRoundingSymbol is null)
             return;
 
-        if (!TryGetFixInfo(semanticModel.Compilation, invocationOperation, invocationExpression, midpointRoundingSymbol, out var fixInfo))
+        var overloadFinder = new OverloadFinder(semanticModel.Compilation);
+        var overload = overloadFinder.FindOverloadWithAdditionalParameterOfType(invocationOperation, new OverloadOptions(IncludeObsoleteMembers: false, AllowOptionalParameters: true), [midpointRoundingSymbol]);
+        if (overload is null)
             return;
 
+        var midpointRoundingParameter = overload.Parameters.FirstOrDefault(parameter => parameter.Type.IsEqualTo(midpointRoundingSymbol));
+        if (midpointRoundingParameter is null)
+            return;
+
+        var generator = SyntaxGenerator.GetGenerator(context.Document);
         foreach (var midpointRoundingMember in midpointRoundingSymbol.GetMembers().OfType<IFieldSymbol>())
         {
             if (midpointRoundingMember is { IsImplicitlyDeclared: true, Name: "value__" })
@@ -41,118 +48,34 @@ public sealed class UseAnOverloadThatHasMidpointRoundingFixer : CodeFixProvider
                 continue;
 
             var midpointRoundingMemberName = midpointRoundingMember.Name;
+            var newInvocation = ArgumentListHelper.AddArgument(
+                semanticModel,
+                generator,
+                invocationExpression,
+                midpointRoundingParameter.Ordinal,
+                midpointRoundingParameter.Name,
+                generator.TypeMemberAccessExpression(midpointRoundingSymbol, midpointRoundingMemberName, addImport: true),
+                parameter => parameter.Type.IsEqualTo(midpointRoundingSymbol),
+                overload,
+                context.CancellationToken);
+
+            if (newInvocation is null)
+                continue;
+
             var title = "Add MidpointRounding." + midpointRoundingMemberName;
             var codeAction = CodeAction.Create(
                 title,
-                ct => AddMidpointRounding(context.Document, invocationExpression, fixInfo, midpointRoundingSymbol, midpointRoundingMemberName, ct),
+                ct => AddMidpointRounding(context.Document, invocationExpression, newInvocation, ct),
                 equivalenceKey: title);
 
             context.RegisterCodeFix(codeAction, context.Diagnostics);
         }
     }
 
-    private static bool TryGetFixInfo(Compilation compilation, IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationExpression, INamedTypeSymbol midpointRoundingSymbol, [NotNullWhen(true)] out MidpointRoundingFixInfo? fixInfo)
-    {
-        fixInfo = null;
-
-        var overloadFinder = new OverloadFinder(compilation);
-        var overload = overloadFinder.FindOverloadWithAdditionalParameterOfType(invocationOperation, new OverloadOptions(IncludeObsoleteMembers: false, AllowOptionalParameters: true), [midpointRoundingSymbol]);
-        if (overload is null)
-            return false;
-
-        var parameterIndex = -1;
-        for (var i = 0; i < overload.Parameters.Length; i++)
-        {
-            if (overload.Parameters[i].Type.IsEqualTo(midpointRoundingSymbol))
-            {
-                parameterIndex = i;
-                break;
-            }
-        }
-
-        if (parameterIndex < 0)
-            return false;
-
-        var parameterName = overload.Parameters[parameterIndex].Name;
-        var arguments = invocationExpression.ArgumentList.Arguments;
-
-        // All the arguments are positional, so they keep their bindings and the new argument can be added at the
-        // position of the parameter. When the position is after the last argument, some optional parameters are
-        // omitted, so the new argument must be named.
-        if (!arguments.Any(argument => argument.NameColon is not null))
-        {
-            fixInfo = new MidpointRoundingFixInfo(invocationExpression.ArgumentList, parameterIndex <= arguments.Count ? parameterIndex : null, parameterName);
-            return true;
-        }
-
-        // Some arguments are named, so they may not be in the parameter order. A positional argument cannot be added
-        // after them, and the parameters of the overload may not have the same names. The new argument is named and
-        // appended, and the existing named arguments are bound to the parameters of the overload.
-        var newArguments = arguments;
-        for (var i = 0; i < arguments.Count; i++)
-        {
-            var argument = arguments[i];
-            var parameter = GetParameter(invocationOperation, argument);
-            if (parameter is null)
-                return false;
-
-            var overloadParameterIndex = parameter.Ordinal < parameterIndex ? parameter.Ordinal : parameter.Ordinal + 1;
-            if (overloadParameterIndex >= overload.Parameters.Length)
-                return false;
-
-            // The overload can declare the parameters in a different order, in which case the arguments cannot be reused
-            var overloadParameter = overload.Parameters[overloadParameterIndex];
-            if (!overloadParameter.Type.IsEqualTo(parameter.Type))
-                return false;
-
-            if (argument.NameColon is null)
-            {
-                // A positional argument binds to the parameter at the same position, so it must come before the new parameter
-                if (i >= parameterIndex)
-                    return false;
-            }
-            else if (!string.Equals(argument.NameColon.Name.Identifier.ValueText, overloadParameter.Name, StringComparison.Ordinal))
-            {
-                var newArgument = argument.WithNameColon(argument.NameColon.WithName(SyntaxFactory.IdentifierName(overloadParameter.Name)));
-                newArguments = newArguments.Replace(newArguments[i], newArgument);
-            }
-        }
-
-        fixInfo = new MidpointRoundingFixInfo(invocationExpression.ArgumentList.WithArguments(newArguments), ArgumentIndex: null, parameterName);
-        return true;
-
-        static IParameterSymbol? GetParameter(IInvocationOperation invocationOperation, ArgumentSyntax argument)
-        {
-            foreach (var argumentOperation in invocationOperation.Arguments)
-            {
-                if (argumentOperation.Syntax == argument)
-                    return argumentOperation.Parameter;
-            }
-
-            return null;
-        }
-    }
-
-    private static async Task<Document> AddMidpointRounding(Document document, InvocationExpressionSyntax invocationExpression, MidpointRoundingFixInfo fixInfo, INamedTypeSymbol midpointRoundingSymbol, string midpointRoundingMember, CancellationToken cancellationToken)
+    private static async Task<Document> AddMidpointRounding(Document document, InvocationExpressionSyntax invocationExpression, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var generator = editor.Generator;
-
-        var midpointRoundingExpression = generator.TypeMemberAccessExpression(midpointRoundingSymbol, midpointRoundingMember, addImport: true);
-
-        var arguments = fixInfo.ArgumentList.Arguments;
-        var newArguments = fixInfo.ArgumentIndex is int argumentIndex
-            ? arguments.Insert(argumentIndex, (ArgumentSyntax)generator.Argument(midpointRoundingExpression))
-            : arguments.Add((ArgumentSyntax)generator.Argument(fixInfo.ParameterName, RefKind.None, midpointRoundingExpression));
-
-        var newInvocation = invocationExpression.WithArgumentList(fixInfo.ArgumentList.WithArguments(newArguments));
-
         editor.ReplaceNode(invocationExpression, newInvocation);
         return editor.GetChangedDocument();
     }
-
-    /// <param name="ArgumentList">The arguments of the invocation, bound to the parameters of the overload.</param>
-    /// <param name="ArgumentIndex">The index at which the positional argument must be added, or <see langword="null"/> when the argument must be named and appended.</param>
-    /// <param name="ParameterName">The name of the <see cref="System.MidpointRounding"/> parameter of the overload.</param>
-    private sealed record MidpointRoundingFixInfo(ArgumentListSyntax ArgumentList, int? ArgumentIndex, string ParameterName);
 }

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasTimeProviderFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseAnOverloadThatHasTimeProviderFixer.cs
@@ -34,7 +34,16 @@ public sealed class UseAnOverloadThatHasTimeProviderFixer : CodeFixProvider
         var generator = SyntaxGenerator.GetGenerator(context.Document);
         foreach (var path in paths.Split(','))
         {
-            var newInvocation = CreateInvocation(semanticModel, generator, invocationExpression, parameterIndex, parameterName, path, timeProviderSymbol);
+            var newInvocation = ArgumentListHelper.AddArgument(
+                semanticModel,
+                generator,
+                invocationExpression,
+                parameterIndex,
+                parameterName,
+                SyntaxFactory.ParseExpression(path),
+                parameter => parameter.Type.IsEqualTo(timeProviderSymbol),
+                cancellationToken: context.CancellationToken);
+
             if (newInvocation is null)
                 continue;
 
@@ -46,45 +55,6 @@ public sealed class UseAnOverloadThatHasTimeProviderFixer : CodeFixProvider
 
             context.RegisterCodeFix(codeAction, context.Diagnostics);
         }
-    }
-
-    private static InvocationExpressionSyntax? CreateInvocation(SemanticModel semanticModel, SyntaxGenerator generator, InvocationExpressionSyntax nodeToFix, int parameterIndex, string parameterName, string timeProviderPath, INamedTypeSymbol timeProviderSymbol)
-    {
-        var timeProviderExpression = SyntaxFactory.ParseExpression(timeProviderPath);
-        var arguments = nodeToFix.ArgumentList.Arguments;
-
-        // A positional argument can only be added at the index of the parameter when all the arguments written before it are positional.
-        // Otherwise, C# does not allow it (CS1738, CS1739, CS8323) or it would be bound to the wrong parameter.
-        if (parameterIndex <= arguments.Count && !arguments.Take(parameterIndex).Any(argument => argument.NameColon is not null))
-        {
-            var positionalArgument = (ArgumentSyntax)generator.Argument(timeProviderExpression);
-            var candidate = ReplaceArguments(nodeToFix, arguments.Insert(parameterIndex, positionalArgument));
-            if (GetTargetMethod(semanticModel, nodeToFix, candidate) is { } method && parameterIndex < method.Parameters.Length && method.Parameters[parameterIndex].Type.IsEqualTo(timeProviderSymbol))
-                return candidate;
-        }
-
-        // A named argument added at the end of the list is valid whatever the order of the existing arguments
-        var namedArgument = (ArgumentSyntax)generator.Argument(parameterName, RefKind.None, timeProviderExpression);
-        var namedCandidate = ReplaceArguments(nodeToFix, arguments.Add(namedArgument));
-        var namedParameter = GetTargetMethod(semanticModel, nodeToFix, namedCandidate)?.Parameters.FirstOrDefault(parameter => string.Equals(parameter.Name, parameterName, StringComparison.Ordinal));
-        if (namedParameter is not null && namedParameter.Type.IsEqualTo(timeProviderSymbol))
-            return namedCandidate;
-
-        return null;
-    }
-
-    private static InvocationExpressionSyntax ReplaceArguments(InvocationExpressionSyntax nodeToFix, SeparatedSyntaxList<ArgumentSyntax> arguments)
-    {
-        return nodeToFix.WithArgumentList(nodeToFix.ArgumentList.WithArguments(arguments));
-    }
-
-    /// <summary>
-    /// Gets the method the invocation would be bound to, so the fix is only offered when the new invocation compiles
-    /// and the new argument is bound to the expected parameter.
-    /// </summary>
-    private static IMethodSymbol? GetTargetMethod(SemanticModel semanticModel, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation)
-    {
-        return semanticModel.GetSpeculativeSymbolInfo(nodeToFix.SpanStart, newInvocation, SpeculativeBindingOption.BindAsExpression).Symbol as IMethodSymbol;
     }
 
     private static async Task<Document> FixInvocation(Document document, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseIFormatProviderFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseIFormatProviderFixer.cs
@@ -58,7 +58,16 @@ public sealed class UseIFormatProviderFixer : CodeFixProvider
 
         bool RegisterCodeFix(string formatProviderExpression, string title)
         {
-            var newInvocation = CreateInvocationWithFormatProvider(semanticModel, generator, invocationExpression, parameterIndex, parameterName, formatProviderExpression, formatProviderSymbol);
+            var newInvocation = ArgumentListHelper.AddArgument(
+                semanticModel,
+                generator,
+                invocationExpression,
+                parameterIndex,
+                parameterName,
+                SyntaxFactory.ParseExpression(formatProviderExpression),
+                parameter => parameter.Type.IsOrInheritsFrom(formatProviderSymbol),
+                cancellationToken: context.CancellationToken);
+
             if (newInvocation is null)
                 return false;
 
@@ -86,30 +95,6 @@ public sealed class UseIFormatProviderFixer : CodeFixProvider
         }
     }
 
-    private static InvocationExpressionSyntax? CreateInvocationWithFormatProvider(SemanticModel semanticModel, SyntaxGenerator generator, InvocationExpressionSyntax invocationExpression, int parameterIndex, string parameterName, string formatProviderExpression, ITypeSymbol formatProviderSymbol)
-    {
-        var arguments = invocationExpression.ArgumentList.Arguments;
-
-        // A positional argument can only be added at the index of the parameter when all the arguments written before it are positional.
-        // Otherwise, C# does not allow it (CS1738, CS1739) or it would be bound to another parameter.
-        if (parameterIndex <= arguments.Count && !arguments.Take(parameterIndex).Any(argument => argument.NameColon is not null))
-        {
-            var positionalArgument = (ArgumentSyntax)generator.Argument(SyntaxFactory.ParseExpression(formatProviderExpression));
-            var candidate = ReplaceArguments(invocationExpression, arguments.Insert(parameterIndex, positionalArgument));
-            if (GetTargetMethod(semanticModel, invocationExpression, candidate) is { } method && parameterIndex < method.Parameters.Length && method.Parameters[parameterIndex].Type.IsOrInheritsFrom(formatProviderSymbol))
-                return candidate;
-        }
-
-        // A named argument added at the end of the list is valid whatever the order of the existing arguments, and keeps their evaluation order
-        var namedArgument = (ArgumentSyntax)generator.Argument(parameterName, RefKind.None, SyntaxFactory.ParseExpression(formatProviderExpression));
-        var namedCandidate = ReplaceArguments(invocationExpression, arguments.Add(namedArgument));
-        var namedParameter = GetTargetMethod(semanticModel, invocationExpression, namedCandidate)?.Parameters.FirstOrDefault(parameter => string.Equals(parameter.Name, parameterName, StringComparison.Ordinal));
-        if (namedParameter is not null && namedParameter.Type.IsOrInheritsFrom(formatProviderSymbol))
-            return namedCandidate;
-
-        return null;
-    }
-
     private static InvocationExpressionSyntax? CreateToStringInvocation(SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, IMethodSymbol overload, ITypeSymbol formatProviderSymbol, string formatProviderExpression)
     {
         var arguments = new List<ArgumentSyntax>(capacity: overload.Parameters.Length);
@@ -132,25 +117,11 @@ public sealed class UseIFormatProviderFixer : CodeFixProvider
             arguments.Add(SyntaxFactory.Argument(expression));
         }
 
-        var candidate = ReplaceArguments(invocationExpression, SyntaxFactory.SeparatedList(arguments));
-        if (GetTargetMethod(semanticModel, invocationExpression, candidate) is { } method && method.Parameters.Any(parameter => parameter.Type.IsOrInheritsFrom(formatProviderSymbol)))
+        var candidate = ArgumentListHelper.WithArguments(invocationExpression, SyntaxFactory.SeparatedList(arguments));
+        if (ArgumentListHelper.GetTargetMethod(semanticModel, invocationExpression, candidate) is { } method && method.Parameters.Any(parameter => parameter.Type.IsOrInheritsFrom(formatProviderSymbol)))
             return candidate;
 
         return null;
-    }
-
-    private static InvocationExpressionSyntax ReplaceArguments(InvocationExpressionSyntax invocationExpression, SeparatedSyntaxList<ArgumentSyntax> arguments)
-    {
-        return invocationExpression.WithArgumentList(invocationExpression.ArgumentList.WithArguments(arguments));
-    }
-
-    /// <summary>
-    /// Gets the method the invocation would be bound to, so the fix is only offered when the new invocation compiles
-    /// and the new argument is bound to the expected parameter.
-    /// </summary>
-    private static IMethodSymbol? GetTargetMethod(SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, InvocationExpressionSyntax newInvocation)
-    {
-        return semanticModel.GetSpeculativeSymbolInfo(invocationExpression.SpanStart, newInvocation, SpeculativeBindingOption.BindAsExpression).Symbol as IMethodSymbol;
     }
 
     private static async Task<Document> FixInvocation(Document document, InvocationExpressionSyntax invocationExpression, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparisonFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/UseStringComparisonFixer.cs
@@ -34,7 +34,16 @@ public sealed class UseStringComparisonFixer : CodeFixProvider
 
         void AddCodeFix(string comparisonMode)
         {
-            var newInvocation = CreateInvocation(semanticModel, generator, invocationExpression, parameter, stringComparisonSymbol, comparisonMode);
+            var newInvocation = ArgumentListHelper.AddArgument(
+                semanticModel,
+                generator,
+                invocationExpression,
+                parameter.Ordinal,
+                parameter.Name,
+                generator.TypeMemberAccessExpression(stringComparisonSymbol, comparisonMode, addImport: true),
+                candidate => candidate.Type.IsEqualTo(stringComparisonSymbol),
+                cancellationToken: context.CancellationToken);
+
             if (newInvocation is null)
                 return;
 
@@ -46,46 +55,6 @@ public sealed class UseStringComparisonFixer : CodeFixProvider
 
             context.RegisterCodeFix(codeAction, context.Diagnostics);
         }
-    }
-
-    private static InvocationExpressionSyntax? CreateInvocation(SemanticModel semanticModel, SyntaxGenerator generator, InvocationExpressionSyntax nodeToFix, IParameterSymbol parameter, INamedTypeSymbol stringComparison, string stringComparisonMode)
-    {
-        var comparisonExpression = generator.TypeMemberAccessExpression(stringComparison, stringComparisonMode, addImport: true);
-        var arguments = nodeToFix.ArgumentList.Arguments;
-        var parameterIndex = parameter.Ordinal;
-
-        // A positional argument can only be added at the index of the parameter when all the arguments written before it are positional.
-        // Otherwise, C# does not allow it (CS1738, CS1739, CS8323) or it would be bound to the wrong parameter.
-        if (parameterIndex <= arguments.Count && !arguments.Take(parameterIndex).Any(argument => argument.NameColon is not null))
-        {
-            var positionalArgument = (ArgumentSyntax)generator.Argument(comparisonExpression);
-            var candidate = ReplaceArguments(nodeToFix, arguments.Insert(parameterIndex, positionalArgument));
-            if (GetTargetMethod(semanticModel, nodeToFix, candidate) is { } method && parameterIndex < method.Parameters.Length && method.Parameters[parameterIndex].Type.IsEqualTo(stringComparison))
-                return candidate;
-        }
-
-        // A named argument added at the end of the list is valid whatever the order of the existing arguments
-        var namedArgument = (ArgumentSyntax)generator.Argument(parameter.Name, RefKind.None, comparisonExpression);
-        var namedCandidate = ReplaceArguments(nodeToFix, arguments.Add(namedArgument));
-        var namedParameter = GetTargetMethod(semanticModel, nodeToFix, namedCandidate)?.Parameters.FirstOrDefault(candidate => string.Equals(candidate.Name, parameter.Name, StringComparison.Ordinal));
-        if (namedParameter is not null && namedParameter.Type.IsEqualTo(stringComparison))
-            return namedCandidate;
-
-        return null;
-    }
-
-    private static InvocationExpressionSyntax ReplaceArguments(InvocationExpressionSyntax nodeToFix, SeparatedSyntaxList<ArgumentSyntax> arguments)
-    {
-        return nodeToFix.WithArgumentList(nodeToFix.ArgumentList.WithArguments(arguments));
-    }
-
-    /// <summary>
-    /// Gets the method the invocation would be bound to, so the fix is only offered when the new invocation compiles
-    /// and the new argument is bound to the StringComparison parameter.
-    /// </summary>
-    private static IMethodSymbol? GetTargetMethod(SemanticModel semanticModel, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation)
-    {
-        return semanticModel.GetSpeculativeSymbolInfo(nodeToFix.SpanStart, newInvocation, SpeculativeBindingOption.BindAsExpression).Symbol as IMethodSymbol;
     }
 
     private static async Task<Document> FixInvocation(Document document, InvocationExpressionSyntax nodeToFix, InvocationExpressionSyntax newInvocation, CancellationToken cancellationToken)


### PR DESCRIPTION
## What

Extracts the duplicated "add an argument to an invocation" logic of five code fixers into `ArgumentListHelper` (`src/Meziantou.Analyzer.CodeFixers/Internals/ArgumentListHelper.cs`), and uses it in MA0001/MA0074, MA0011, MA0040, MA0166 and MA0193.

The five fixers had grown near-identical copies of the algorithm introduced by #1486, #1490, #1499, #1500 and #1501: insert a positional argument at the index of the parameter when all the arguments written before it are positional, otherwise add a named argument at the end of the list, and bind the candidate with the semantic model before registering the fix. Each one also carried its own private `ReplaceArguments` and `GetTargetMethod`.

## API

- `AddArgument(semanticModel, generator, invocation, parameterIndex, parameterName, argumentExpression, isExpectedParameter, overload?, cancellationToken)` returns the new invocation, or `null` when the argument cannot be added without changing how the invocation binds. The parameter the new argument is bound to is validated by the caller's predicate: `IsEqualTo` for MA0001, MA0040, MA0166 and MA0193, `IsOrInheritsFrom` for MA0011.
- `WithArguments` and `GetTargetMethod` are the primitives the fixers were duplicating, exposed for the fixes that build a whole argument list: the `ToString(null, provider)` fix of MA0011 uses them directly.

## Behavior

The helper adds two things to the shared algorithm:

- The renaming of the existing named arguments when the overload declares the parameters with other names, which was previously only implemented by the MA0193 code fix. It is used by the callers that know the overload the invocation must be bound to, so only MA0193 for now.
- The named argument is rejected when a positional argument is written at or after the index of the new parameter, as the new parameter shifts it to another parameter of the overload. This changes nothing for these five rules, whose new argument always has a distinctive type, so such a candidate already failed to bind, but it makes the helper correct for the rules that would add an argument of a common type.

MA0193 is the only rule whose fix changes: it now binds its candidate with the semantic model, which it did not do, so the fix is only offered when the new invocation compiles and the argument is bound to the `MidpointRounding` parameter. The four other fixers are behavior-identical.

## Notes for the reviewer

- No test was added: the change is behavior-preserving and the 236 existing tests of the five rules already cover each branch (named arguments in order and out of order, named argument after the insertion index, omitted optional parameters, overload declaring another parameter name).
- MA0002 (`UseStringComparerFixer`) is the remaining fixer that adds an argument, and it is left as is: it also targets object creations, implicit object creations and collection expressions, and speculative binding cannot resolve a target-typed `new(...)`, so it would need an unvalidated path, which would defeat the purpose of the helper.
- MA0001 and MA0011 could pass `overload` to get the renaming of the named arguments for free, as they both have the symbol at hand. That is a behavior change rather than a refactoring, so it is not part of this PR.

## Validation

- `dotnet build`: all Roslyn versions, no warning
- `dotnet test` on roslyn5.9: 4594 passed
- The 236 tests of the five affected rules on roslyn4.8, roslyn4.14, roslyn5.0, roslyn5.6 and roslyn5.9: passed
- `dotnet run --project src/DocumentationGenerator`: no markdown change