### PR TITLE
Remove the unreachable string.Join branch of MA0089

### DIFF
--- a/src/Meziantou.Analyzer/Rules/OptimizeStartsWithAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/OptimizeStartsWithAnalyzer.cs
@@ -267,17 +267,6 @@ public sealed class OptimizeStartsWithAnalyzer : DiagnosticAnalyzer
                             }
                         }
                     }
-                    else if (operation.Arguments.Length == 4)
-                    {
-                        if (Join_Char_StringArray_Int32_Int32 is not null)
-                        {
-                            if (operation.Arguments[0].Value is { Type.SpecialType: SpecialType.System_String, ConstantValue: { HasValue: true, Value: string { Length: 1 } } })
-                            {
-                                context.ReportDiagnostic(Rule, operation.Arguments[0].Value);
-                                return;
-                            }
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
## What changed

Deleted the `else if (operation.Arguments.Length == 4)` block from the `string.Join` handling in `OptimizeStartsWithAnalyzer` (MA0089).

## Why

That branch was the `else` of `if (operation.Arguments.Length > 1)`, so `Arguments.Length == 4` could never be true there — it was dead code. Its body was also a duplicate of the `case 4:` arm of the `switch` just above it: the same `Join_Char_StringArray_Int32_Int32` null guard, the same single-char constant check on `Arguments[0]`, and the same reported location. Having the `Join(string, string[], int, int)` overload appear to be handled in two places under different conditions is misleading to read.

No behavior change: the reported diagnostics are identical.

## Notes for the reviewer

The `Arguments.Length > 1` guard is kept. Every `string.Join` overload has at least two parameters, so it is always true in practice, but it also guards the `Arguments[0]` and `Parameters[1]` accesses that happen before the `switch`; dropping it would mean restructuring those for no behavioral gain.

## Verification

- `dotnet build src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.9.csproj` — succeeded, 0 warnings.
- `dotnet test --filter "FullyQualifiedName~OptimizeStartsWithAnalyzerTests"` on `roslyn5.9` and `roslyn4.8` — 106/106 passed on each. The surviving `case 4:` path is covered by existing tests: `Join_Report` asserts `string.Join(",", new string[0], 0, 1)` reports, and `Join_NoReport` asserts the `"ab"` and `','` variants of the same shape do not.
- `dotnet run --project src/DocumentationGenerator` — exit code 0, no markdown changes.