### PR TITLE
Fix MA0018 reporting one diagnostic per event accessor

### DIFF
--- a/src/Meziantou.Analyzer/Rules/DoNotDeclareStaticMembersOnGenericTypes.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotDeclareStaticMembersOnGenericTypes.cs
@@ -36,8 +36,8 @@ public sealed class DoNotDeclareStaticMembersOnGenericTypes : DiagnosticAnalyzer
                 if (member.IsAbstract || member.IsVirtual)
                     continue;
 
-                // skip properties
-                if (member is IMethodSymbol method && (method.MethodKind == MethodKind.PropertyGet || method.MethodKind == MethodKind.PropertySet))
+                // The accessors are reported through the property or event they belong to
+                if (member is IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet or MethodKind.EventAdd or MethodKind.EventRemove })
                     continue;
 
                 // skip operators

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotDeclareStaticMembersOnGenericTypesTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotDeclareStaticMembersOnGenericTypesTests.cs
@@ -86,6 +86,38 @@ public sealed class DoNotDeclareStaticMembersOnGenericTypesTests
     }
 
     [Fact]
+    public Task StaticMembers_Event()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public class Test<T>
+            {
+                public static event System.EventHandler {|MA0018:MyEvent|};
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task StaticMembers_EventWithExplicitAccessors()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public class Test<T>
+            {
+                public static event System.EventHandler {|MA0018:MyEvent|}
+                {
+                    add => throw null;
+                    remove => throw null;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task StaticMembers_Operator()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What changed

`DoNotDeclareStaticMembersOnGenericTypes` (MA0018) skipped `PropertyGet` and `PropertySet` accessors so that a static property is reported once, through its `IPropertySymbol`. The event accessor kinds were missing from that filter, so `MethodKind.EventAdd` and `MethodKind.EventRemove` are now skipped too. The comment, which said "skip properties" while the code skips accessors, was corrected.

## Why

For a static event, `GetMembers()` returns the `IEventSymbol` **and** its `add_` / `remove_` accessors, all three public and static, so all three were reported:

```csharp
public class Sample<T>
{
    public static event EventHandler MyEvent;
}
```

produced three identical diagnostics at the same location:

```
/0/Test0.cs(4,38): info MA0018: Do not declare static members on generic types
/0/Test0.cs(4,38): info MA0018: Do not declare static members on generic types
/0/Test0.cs(4,38): info MA0018: Do not declare static members on generic types
```

With explicitly written `add` / `remove` accessors the three diagnostics land on three different spans, so the IDE does not even deduplicate them.

## Notes for reviewers

- Using `member.IsImplicitlyDeclared` instead would not be enough: accessors written explicitly are not implicit.
- The compiler-generated backing field of a field-like event is private, so `IsVisibleOutsideOfAssembly()` already excluded it — it never contributed a diagnostic.
- Two tests were added to `DoNotDeclareStaticMembersOnGenericTypesTests`: a field-like static event and one with explicit `add` / `remove` accessors (the case with distinct spans). Temporarily reverting the analyzer change makes exactly those two fail, so they do pin the defect.
- All 11 tests in the class pass on roslyn4.8, 4.14, 5.0, 5.6 and 5.9.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes. `docs/Rules/MA0018.md` needs no update: the documented behavior is unchanged, this only removes duplicates.