### PR TITLE
Detect the ConfigureAwait of the async enumerable in the MA0004 foreach analysis

### DIFF
--- a/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseConfigureAwaitAnalyzer.cs
@@ -38,7 +38,6 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
     {
         private INamedTypeSymbol? ConfiguredAsyncDisposableSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredAsyncDisposable");
 
-        private INamedTypeSymbol? IAsyncEnumerableSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Collections.Generic.IAsyncEnumerable`1");
         private INamedTypeSymbol? ConfiguredCancelableAsyncEnumerableSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1");
         private INamedTypeSymbol? ConfiguredTaskAwaitableSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredTaskAwaitable");
         private INamedTypeSymbol? ConfiguredTaskAwaitableOfTSymbol { get; } = compilation.GetBestTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1");
@@ -85,8 +84,6 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
         public bool IsConfiguredAsyncDisposable(ITypeSymbol type) => type.IsEqualTo(ConfiguredAsyncDisposableSymbol);
 
         public bool IsConfiguredCancelableAsyncEnumerable(ITypeSymbol type) => type.OriginalDefinition.IsEqualTo(ConfiguredCancelableAsyncEnumerableSymbol);
-
-        public bool IsAsyncEnumerable(ITypeSymbol? type) => type.IsEqualTo(IAsyncEnumerableSymbol);
 
         public bool IsConfiguredTaskAwaitable(SemanticModel semanticModel, AwaitExpressionSyntax awaitSyntax, CancellationToken cancellationToken)
         {
@@ -139,8 +136,8 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
 
             if (analyzerContext.IsConfiguredCancelableAsyncEnumerable(collectionType))
             {
-                // Enumerable().WithCancellation(ct) or Enumerable().ConfigureAwait(false)
-                if (HasConfigureAwait(operation.Collection) && HasPartOfTypeIAsyncEnumerable(operation.Collection))
+                // Enumerable().ConfigureAwait(false) or Enumerable().ConfigureAwait(false).WithCancellation(ct)
+                if (HasConfigureAwaitOnAsyncEnumerable(operation.Collection))
                     return;
 
                 // Check if it's a variable reference that is already configured
@@ -159,31 +156,20 @@ public sealed class UseConfigureAwaitAnalyzer : DiagnosticAnalyzer
                 context.ReportDiagnostic(Rule, data, operation.Collection);
             }
 
-            static bool HasConfigureAwait(IOperation operation)
+            bool HasConfigureAwaitOnAsyncEnumerable(IOperation operation)
             {
-                if (operation is IInvocationOperation invocation)
+                // Only the ConfigureAwait calls returning a ConfiguredCancelableAsyncEnumerable<T> configure the
+                // enumeration. For instance, the ConfigureAwait of "await GetEnumerableAsync().ConfigureAwait(false)"
+                // configures the task, not the async enumerable the task returns.
+                if (operation is IInvocationOperation { TargetMethod.Name: "ConfigureAwait", Type: { } returnType } &&
+                    analyzerContext.IsConfiguredCancelableAsyncEnumerable(returnType))
                 {
-                    if (invocation.TargetMethod.Name == "ConfigureAwait")
-                        return true;
-                }
-
-                foreach (var child in operation.GetChildOperations())
-                {
-                    if (HasConfigureAwait(child))
-                        return true;
-                }
-
-                return false;
-            }
-
-            bool HasPartOfTypeIAsyncEnumerable(IOperation operation)
-            {
-                if (analyzerContext.IsAsyncEnumerable(operation.Type))
                     return true;
+                }
 
                 foreach (var child in operation.GetChildOperations())
                 {
-                    if (HasConfigureAwait(child))
+                    if (HasConfigureAwaitOnAsyncEnumerable(child))
                         return true;
                 }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseConfigureAwaitAnalyzerTests.cs
@@ -220,6 +220,127 @@ public sealed class UseConfigureAwaitAnalyzerTests
     }
 
     [Fact]
+    public Task MissingConfigureAwait_AwaitForeach_WithConfigureAwaitOnConcreteType()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Threading;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    await foreach(var item in Enumerable().ConfigureAwait(false))
+                    {
+                    }
+                }
+
+                static AsyncEnumerable Enumerable() => throw null;
+            }
+
+            class AsyncEnumerable : IAsyncEnumerable<int>
+            {
+                public IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default) => throw null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MissingConfigureAwait_AwaitForeach_WithCancellationAndConfigureAwait()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Threading;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    IAsyncEnumerable<int> Enumerable() => throw null;
+
+                    CancellationToken ct = default;
+                    await foreach(var item in Enumerable().WithCancellation(ct).ConfigureAwait(false))
+                    {
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MissingConfigureAwait_AwaitForeach_ConfigureAwaitThenWithCancellation()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Threading;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    IAsyncEnumerable<int> Enumerable() => throw null;
+
+                    CancellationToken ct = default;
+                    await foreach(var item in Enumerable().ConfigureAwait(false).WithCancellation(ct))
+                    {
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task MissingConfigureAwait_AwaitForeach_ConfigureAwaitOnTaskOnly_ShouldReportError()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Collections.Generic;
+            using System.Runtime.CompilerServices;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    Task<ConfiguredCancelableAsyncEnumerable<int>> Enumerable() => throw null;
+
+                    // The ConfigureAwait call configures the Task, not the async enumerable
+                    await foreach(var item in {|MA0004:await Enumerable().ConfigureAwait(false)|})
+                    {
+                    }
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Collections.Generic;
+            using System.Runtime.CompilerServices;
+            using System.Threading.Tasks;
+            class ClassTest
+            {
+                async Task Test()
+                {
+                    Task<ConfiguredCancelableAsyncEnumerable<int>> Enumerable() => throw null;
+
+                    // The ConfigureAwait call configures the Task, not the async enumerable
+                    await foreach(var item in (await Enumerable().ConfigureAwait(false)).ConfigureAwait(false))
+                    {
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task MissingConfigureAwait_AwaitDispose_ShouldReportError()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

When the collection of an `await foreach` is a `ConfiguredCancelableAsyncEnumerable<T>`, `UseConfigureAwaitAnalyzer` skipped it when both `HasConfigureAwait(collection)` and `HasPartOfTypeIAsyncEnumerable(collection)` returned `true`. Both helpers were broken, and the guard only worked by accident.

`HasPartOfTypeIAsyncEnumerable` had two independent defects:

1. **The recursion went to the wrong helper.** It called `HasConfigureAwait(child)` instead of itself, so it actually answered "does a child contain a `ConfigureAwait` call?". The `&&` degenerated into `HasConfigureAwait(x) && HasConfigureAwait(x)` plus a top-level type test.

2. **The type test could never match.** `IsAsyncEnumerable` compared a constructed type against the open generic definition with `SymbolEqualityComparer.Default`, so `IAsyncEnumerable<int>` was never equal to `IAsyncEnumerable<T>`. The first line of the method was dead code. Every neighbouring helper (`IsConfiguredCancelableAsyncEnumerable`, …) does use `OriginalDefinition`.

Nothing was mis-reported today only because Roslyn wraps the collection of an `await foreach` in an implicit `IConversionOperation`, which puts the `ConfigureAwait` invocation among the children of the operation. If that node shape ever changed, the guard would start returning `false` and MA0004 would fire on code that already has `.ConfigureAwait(false)`.

## Why the obvious fix does not work

Repairing the two helpers in place (fix the recursion, add `OriginalDefinition`) **makes the code fix loop**. For:

```csharp
Task<ConfiguredCancelableAsyncEnumerable<int>> Enumerable() => throw null;
await foreach (var item in await Enumerable().ConfigureAwait(false)) { }
```

the guard correctly returns `false` and MA0004 fires — but appending `.ConfigureAwait(false)` does not add an `IAsyncEnumerable` part to the expression, so the diagnostic is reported again on the fixed code. The code-fix test failed with:

```
+  await foreach(var item in (await Enumerable().ConfigureAwait(false)).ConfigureAwait(false).ConfigureAwait(false))
```

"Is there an `IAsyncEnumerable` somewhere in this tree" is not a property the code fix can establish, so it is not a usable guard.

## What this does instead

Both helpers were groping at the same question: *does this chain contain a `ConfigureAwait` that configures the **enumeration** rather than a task?* The return type answers it directly — `ConfigureAwait` returns a `ConfiguredCancelableAsyncEnumerable<T>` on an async enumerable and a `ConfiguredTaskAwaitable` on a task. One recursive predicate replaces both helpers, and it is idempotent by construction, so the code fix converges.

`IsAsyncEnumerable` and `IAsyncEnumerableSymbol` become unused and are removed.

## Behavior

| Expression | Reports | Change |
|---|---|---|
| `Enumerable().ConfigureAwait(false)` | no | — |
| `Enumerable().WithCancellation(ct)` | yes | — |
| `Enumerable().WithCancellation(ct).ConfigureAwait(false)` | no | — |
| `Enumerable().ConfigureAwait(false).WithCancellation(ct)` | no | — |
| `await taskOfConfigured.ConfigureAwait(false)` | **yes** | was: no |

**For reviewers:** the last row is the one user-visible change. Only the task is configured there, so the configuration of the enumerable is unknown — which is exactly what the `&& HasPartOfTypeIAsyncEnumerable` clause was written to catch. It is locked in by `MissingConfigureAwait_AwaitForeach_ConfigureAwaitOnTaskOnly_ShouldReportError`; that test is the single place to flip it if you would rather stay silent. Returning `Task<ConfiguredCancelableAsyncEnumerable<T>>` from a method is close to nonexistent in practice, since it is a compiler-support struct.

Also checked: the `OriginalDefinition` change alone does **not** matter for a concrete type such as `class MyEnum : IAsyncEnumerable<int>`, because Roslyn inserts a conversion node to `IAsyncEnumerable<int>` for the reduced extension call. A test covers that case anyway.

## Tests

Three tests added to `UseConfigureAwaitAnalyzerTests`:

- `MissingConfigureAwait_AwaitForeach_WithConfigureAwaitOnConcreteType` — a class implementing `IAsyncEnumerable<T>`
- `MissingConfigureAwait_AwaitForeach_WithCancellationAndConfigureAwait` — `.WithCancellation(ct).ConfigureAwait(false)`
- `MissingConfigureAwait_AwaitForeach_ConfigureAwaitThenWithCancellation` — `.ConfigureAwait(false).WithCancellation(ct)`, the reverse order
- `MissingConfigureAwait_AwaitForeach_ConfigureAwaitOnTaskOnly_ShouldReportError` — the behavior change above, with its code fix

## Verification

- `dotnet build` — 0 warnings, 0 errors
- MA0004 suite (41 tests) passes on roslyn4.8, 4.14, 5.0, 5.6 and 5.9
- Full suite on roslyn5.9 — 4598 passed, 0 failed
- Reverting the analyzer to its previous state and re-running makes 1 of the 41 fail, so the new tests do catch the original defect
- `dotnet run --project src/DocumentationGenerator` — exit 0, no markdown changes