### PR TITLE
Report MA0070 on every declaration that can be obsolete

### DIFF
--- a/docs/Rules/MA0070.md
+++ b/docs/Rules/MA0070.md
@@ -1,7 +1,9 @@
-# MA0070 - Obsolete attributes should include explanations
+﻿# MA0070 - Obsolete attributes should include explanations
 <!-- sources -->
 Source: [ObsoleteAttributesShouldIncludeExplanationsAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/ObsoleteAttributesShouldIncludeExplanationsAnalyzer.cs)
 <!-- sources -->
+
+The rule applies to every declaration `ObsoleteAttribute` can be applied to: types (classes, structs, interfaces, enums, delegates), constructors, methods, properties, indexers, fields, events and enum members.
 
 ````csharp
 [Obsolete] // non-compliant
@@ -9,4 +11,24 @@ void A() {}
 
 [Obsolete("reason")] // compliant
 void B() {}
+
+[Obsolete] // non-compliant
+class Sample
+{
+    [Obsolete] // non-compliant
+    public int Property { get; set; }
+
+    [Obsolete] // non-compliant
+    public int Field;
+
+    [Obsolete] // non-compliant
+    public event EventHandler Event;
+}
+
+[Obsolete("reason")] // compliant
+enum Values
+{
+    [Obsolete("reason")] // compliant
+    A,
+}
 ````

--- a/src/Meziantou.Analyzer/Rules/ObsoleteAttributesShouldIncludeExplanationsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/ObsoleteAttributesShouldIncludeExplanationsAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿namespace Meziantou.Analyzer.Rules;
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Meziantou.Analyzer.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ObsoleteAttributesShouldIncludeExplanationsAnalyzer : DiagnosticAnalyzer
@@ -26,14 +28,31 @@ public sealed class ObsoleteAttributesShouldIncludeExplanationsAnalyzer : Diagno
             if (type is null)
                 return;
 
-            ctx.RegisterSymbolAction(symbolContext => AnalyzeMethod(symbolContext, type), SymbolKind.Method);
+            // ObsoleteAttribute is valid on classes, structs, enums, interfaces, delegates, constructors,
+            // methods, properties, indexers, fields and events, so all those symbol kinds must be analyzed.
+            ctx.RegisterSymbolAction(
+                symbolContext => AnalyzeSymbol(symbolContext, type),
+                SymbolKind.NamedType,
+                SymbolKind.Method,
+                SymbolKind.Property,
+                SymbolKind.Field,
+                SymbolKind.Event);
         });
     }
 
-    private static void AnalyzeMethod(SymbolAnalysisContext context, INamedTypeSymbol obsoleteAttributeTypeSymbol)
+    private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol obsoleteAttributeTypeSymbol)
     {
-        var method = (IMethodSymbol)context.Symbol;
-        foreach (var attribute in method.GetAttributes())
+        var symbol = context.Symbol;
+
+        // Synthesized symbols such as the backing field of an auto-property cannot carry an attribute of their own
+        if (symbol.IsImplicitlyDeclared)
+            return;
+
+        // All the symbols of "[Obsolete] int a, b;" share the same attribute, so only report it once
+        if (IsSecondaryVariableDeclarator(symbol, context.CancellationToken))
+            return;
+
+        foreach (var attribute in symbol.GetAttributes())
         {
             if (!attribute.AttributeClass.IsEqualTo(obsoleteAttributeTypeSymbol))
                 continue;
@@ -41,15 +60,33 @@ public sealed class ObsoleteAttributesShouldIncludeExplanationsAnalyzer : Diagno
             if (attribute.ConstructorArguments.Length == 0)
             {
                 var location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation();
-                if (location != null)
+                if (location is not null)
                 {
                     context.ReportDiagnostic(Rule, location);
                 }
                 else
                 {
-                    context.ReportDiagnostic(Rule, method);
+                    context.ReportDiagnostic(Rule, symbol);
                 }
             }
         }
+    }
+
+    private static bool IsSecondaryVariableDeclarator(ISymbol symbol, CancellationToken cancellationToken)
+    {
+        if (symbol.Kind is not (SymbolKind.Field or SymbolKind.Event))
+            return false;
+
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax(cancellationToken) is VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax declaration } declarator
+                && declaration.Variables.Count > 1
+                && declaration.Variables[0] != declarator)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/ObsoleteAttributesShouldIncludeExplanationsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ObsoleteAttributesShouldIncludeExplanationsAnalyzerTests.cs
@@ -1,4 +1,4 @@
-using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
+﻿using AnalyzerTest = Meziantou.Analyzer.Test.Harness.CSharpAnalyzerTest<
     Meziantou.Analyzer.Rules.ObsoleteAttributesShouldIncludeExplanationsAnalyzer>;
 
 namespace Meziantou.Analyzer.Test.Rules;
@@ -30,6 +30,294 @@ public sealed class ObsoleteAttributesShouldIncludeExplanationsAnalyzerTests
             class Test
             {
                 [{|MA0070:System.Obsolete()|}]
+                public void A() { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Class_HasMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [System.Obsolete("message")]
+            class Test
+            {
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Class_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [{|MA0070:System.Obsolete|}]
+            class Test
+            {
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Interface_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [{|MA0070:System.Obsolete|}]
+            interface ITest
+            {
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Struct_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [{|MA0070:System.Obsolete|}]
+            struct Test
+            {
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Delegate_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [{|MA0070:System.Obsolete|}]
+            delegate void Test();
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Enum_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [{|MA0070:System.Obsolete|}]
+            enum Test
+            {
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task EnumMember_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            enum Test
+            {
+                [{|MA0070:System.Obsolete|}]
+                A,
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Constructor_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [{|MA0070:System.Obsolete|}]
+                public Test() { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Property_HasMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [System.Obsolete("message")]
+                public int A { get; set; }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Property_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [{|MA0070:System.Obsolete|}]
+                public int A { get; set; }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PropertyAccessor_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                public int A
+                {
+                    [{|MA0070:System.Obsolete|}]
+                    get => 0;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Indexer_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [{|MA0070:System.Obsolete|}]
+                public int this[int index] => 0;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Field_HasMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [System.Obsolete("message")]
+                public int A;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Field_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [{|MA0070:System.Obsolete|}]
+                public int A;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Field_MultipleDeclarators_HasNoMessage_ReportsOnce()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [{|MA0070:System.Obsolete|}]
+                public int A, B;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Event_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [{|MA0070:System.Obsolete|}]
+                public event System.EventHandler A;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Event_MultipleDeclarators_HasNoMessage_ReportsOnce()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [{|MA0070:System.Obsolete|}]
+                public event System.EventHandler A, B;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Record_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            [{|MA0070:System.Obsolete|}]
+            record Test(int A);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RecordProperty_HasNoMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            record Test([property: {|MA0070:System.Obsolete|}] int A);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task HasOnlyNamedArgument()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                [{|MA0070:System.Obsolete(DiagnosticId = "ID1")|}]
                 public void A() { }
             }
             """;


### PR DESCRIPTION
## What

`MA0070` (*Obsolete attributes should include explanations*) only registered `SymbolKind.Method`, so `[Obsolete]` without an explanation was silently ignored on every other declaration:

```csharp
[Obsolete]                      // was not reported
public class Sample
{
    [Obsolete]                  // was not reported
    public int Prop { get; set; }

    [Obsolete]                  // was not reported
    public int Field;

    [Obsolete]                  // reported
    public void M() { }
}
```

Property and event accessors *are* `SymbolKind.Method`, but `[Obsolete]` on a property is stored on the `IPropertySymbol` rather than on `get_`/`set_`, so the accessor registration did not cover properties either.

`AnalyzeMethod` became `AnalyzeSymbol` working on `ISymbol`, and the registration now covers `NamedType`, `Method`, `Property`, `Field` and `Event`.

## Why those five kinds

They cover every target `ObsoleteAttribute` actually allows — class, struct, enum, interface, delegate, constructor, method, property, indexer, field, event — with enum members falling under `Field` and indexers under `Property`.

Worth flagging for review: `ObsoleteAttribute` is **not** `AttributeTargets.All`, so **parameters and assemblies are deliberately excluded**. The compiler already reports `CS0592` for `[Obsolete]` on a parameter or an assembly, so registering `SymbolKind.Parameter` or analyzing assembly attributes would only produce MA0070 on code that does not compile. I confirmed this with throwaway tests before dropping them.

## Two guards that are needed

- **`IsImplicitlyDeclared`** — synthesized symbols cannot carry an attribute of their own; the guard keeps them from re-reporting the attribute of the symbol they are generated from.
- **`IsSecondaryVariableDeclarator`** — `[Obsolete] public int A, B;` produces two field symbols sharing a single `AttributeData`, which reported the same diagnostic twice at the same span. The attribute is now reported once, on the first declarator. The same applies to field-like events (`event EventHandler A, B;`), which use the same `VariableDeclarationSyntax`.

## On using `OperationKind.Attribute` instead

I prototyped an `IAttributeOperation` version (green on all five Roslyn versions, 71 lines vs 92) and did not ship it. Two assumptions did not survive testing:

- Attribute operations are produced **per symbol, not per syntax**, so the multi-declarator duplicate is *not* solved by them — `IsSecondaryVariableDeclarator` is required either way.
- Local functions and lambdas (`[Obsolete] void Local() {}`, `[Obsolete] () => {}`) compile fine but are missed by **both** approaches. Pre-existing gap, unchanged here.

It would drop the `IsImplicitlyDeclared` guard and be immune to the too-narrow-`SymbolKind`-list mistake this PR fixes, which is a genuine point in its favour. Against it: registering any operation action makes the driver build and walk full operation trees, method bodies included, for every symbol with executable code — cost `symbol.GetAttributes()` does not incur, and cost that lands on anyone running MA0070 on its own or in the IDE. Since `ObsoleteAttribute`'s targets are fixed by the framework and now fully enumerated, I judged the robustness win theoretical and the cost real. Happy to swap if you prefer the operation form.

## Tests

19 new tests in the existing test file (22 total), covering class, interface, struct, enum, enum member, delegate, constructor, property, property accessor, indexer, field, event, both multi-declarator cases, records (type-targeted and `[property:]`-targeted), and `[Obsolete(DiagnosticId = "ID1")]` — a named argument with no constructor argument still reports, which the new test pins down.

- `dotnet build` (whole solution): succeeded, 0 warnings
- MA0070 tests on roslyn4.8, 4.14, 5.0, 5.6 and 5.9: **22/22 on each**
- Full suite on roslyn5.9: **4614/4614**
- `dotnet run --project src/DocumentationGenerator`: exit 0, no markdown changes

## Docs

`docs/Rules/MA0070.md` now lists the covered declarations and shows type, property, field, event and enum-member examples. No change to `docs/comparison-with-other-analyzers.md`: MA0070 was already listed as equivalent to CA1041, and the broader coverage makes that equivalence accurate rather than aspirational.