### PR TITLE
Remove the discarded message argument of MA0080

### DIFF
--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasCancellationTokenAnalyzer.cs
@@ -253,7 +253,7 @@ public sealed class UseAnOverloadThatHasCancellationTokenAnalyzer : DiagnosticAn
                 if (parentMethod is not null && parentMethod.IsOverrideOrInterfaceImplementation())
                     return;
 
-                context.ReportDiagnostic(FlowCancellationTokenInAwaitForEachRule, op.Collection, string.Join(", ", availableCancellationTokens));
+                context.ReportDiagnostic(FlowCancellationTokenInAwaitForEachRule, op.Collection);
             }
         }
 


### PR DESCRIPTION
## What changed

One line in `UseAnOverloadThatHasCancellationTokenAnalyzer.AnalyzeLoop`: MA0080 (`FlowCancellationTokenInAwaitForEachRule`) no longer passes `string.Join(", ", availableCancellationTokens)` as a message argument.

## Why

The argument was already being discarded:

- In that branch `availableCancellationTokens` is always empty (it is the `else` of `if (availableCancellationTokens.Length > 0)`), so the join always produced `""`.
- The rule's `messageFormat` is `"Specify a CancellationToken"` — no `{0}` placeholder — so the argument was formatted into nothing.

## Notes for the reviewer

**This is a cleanup, not a bug fix, and no test changes because nothing observable changes.** The diagnostic ID, severity, location and message text are all identical before and after. If you'd rather not carry a no-op diff, this is a reasonable thing to close.

This started from a report that also suggested passing `CreateProperties(...)` on this branch, for symmetry with `AnalyzeInvocation` and for a hypothetical future MA0080 fixer. I tried that and backed it out, because the properties would carry no information: in the loop case every value is a constant (`ParameterIndex="-1"`, `ParameterName=null`, `IsEnumeratorCancellation="False"`, `CancellationTokens=""`). Worse, the existing fixer's only use of them is `cancellationTokens.Split(',')`, and `"".Split(',')` yields a single empty string — so an MA0080 fixer reading those properties would offer a bogus `Use CancellationToken:  ` action over an empty expression. Such a fixer would have to synthesize `CancellationToken.None` itself and ignore the properties. The asymmetry with `AnalyzeInvocation` looks intentional rather than an oversight: the loop case has nothing meaningful to pass.

## Testing

- `dotnet build src/Meziantou.Analyzer/Meziantou.Analyzer.roslyn5.9.csproj` — succeeded, 0 warnings.
- `UseAnOverloadThatHasCancellationTokenAnalyzerTests` — 64/64 pass on roslyn5.9. The same class passed 64/64 on roslyn4.8, 4.14, 5.0 and 5.6 earlier in the session; the final one-line diff is Roslyn-version independent, and CI covers all five.
- `dotnet run --project src/DocumentationGenerator` — exit 0, no markdown changes (no descriptor or message-format change).