### PR TITLE
Report MA0068 on the parameter and property placements of NotNullIfNotNull

### DIFF
--- a/docs/Rules/MA0068.md
+++ b/docs/Rules/MA0068.md
@@ -3,13 +3,30 @@
 Source: [NullableAttributeUsageAnalyzer.cs](https://github.com/meziantou/Meziantou.Analyzer/blob/main/src/Meziantou.Analyzer/Rules/NullableAttributeUsageAnalyzer.cs)
 <!-- sources -->
 
+`NotNullIfNotNullAttribute` can be applied to a return value, a parameter, or a property. In all cases, its argument must be the name of a parameter of the member it is applied to. For a property, the name can also be the `value` parameter of the setter, and for an indexer, one of its parameters.
+
 ````csharp
 class Test
 {
     [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("unknown")] // non-compliant, "unknown" is not a parameter of the method
-    public void A(string a) { }
+    public string? A(string? a) => a;
 
-    [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("a")] // compliant, "a" is not a parameter of the method
-    public void A(string a) { }
+    [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("a")] // compliant, "a" is a parameter of the method
+    public string? B(string? a) => a;
+
+    public void C(string? a, [System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("unknown")] out string? b) // non-compliant, "unknown" is not a parameter of the method
+        => b = a;
+
+    public void D(string? a, [System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("a")] out string? b) // compliant, "a" is a parameter of the method
+        => b = a;
+
+    [System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("unknown")] // non-compliant, "unknown" is not a parameter of the property
+    public string? E { get; set; }
+
+    [System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("value")] // compliant, "value" is the parameter of the setter
+    public string? F { get; set; }
+
+    [System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("key")] // compliant, "key" is a parameter of the indexer
+    public string? this[string? key] => key;
 }
 ````

--- a/src/Meziantou.Analyzer/Rules/NullableAttributeUsageAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/NullableAttributeUsageAnalyzer.cs
@@ -27,37 +27,76 @@ public sealed class NullableAttributeUsageAnalyzer : DiagnosticAnalyzer
                 return;
 
             ctx.RegisterSymbolAction(symbolContext => AnalyzeMethod(symbolContext, type), SymbolKind.Method);
+            ctx.RegisterSymbolAction(symbolContext => AnalyzeProperty(symbolContext, type), SymbolKind.Property);
         });
     }
 
     private static void AnalyzeMethod(SymbolAnalysisContext context, INamedTypeSymbol notNullIfNotNullAttributeTypeSymbol)
     {
         var method = (IMethodSymbol)context.Symbol;
-        foreach (var attribute in method.GetReturnTypeAttributes())
+        AnalyzeAttributes(context, notNullIfNotNullAttributeTypeSymbol, method.GetReturnTypeAttributes(), method, method);
+
+        // The parameters of the accessors of an indexer duplicate the parameters of the indexer
+        if (method.AssociatedSymbol is IPropertySymbol)
+            return;
+
+        foreach (var parameter in method.Parameters)
+        {
+            AnalyzeAttributes(context, notNullIfNotNullAttributeTypeSymbol, parameter.GetAttributes(), parameter, method);
+        }
+    }
+
+    private static void AnalyzeProperty(SymbolAnalysisContext context, INamedTypeSymbol notNullIfNotNullAttributeTypeSymbol)
+    {
+        var property = (IPropertySymbol)context.Symbol;
+        AnalyzeAttributes(context, notNullIfNotNullAttributeTypeSymbol, property.GetAttributes(), property, property);
+        foreach (var parameter in property.Parameters)
+        {
+            AnalyzeAttributes(context, notNullIfNotNullAttributeTypeSymbol, parameter.GetAttributes(), parameter, property);
+        }
+    }
+
+    private static void AnalyzeAttributes(SymbolAnalysisContext context, INamedTypeSymbol notNullIfNotNullAttributeTypeSymbol, ImmutableArray<AttributeData> attributes, ISymbol symbolToReport, ISymbol declaringSymbol)
+    {
+        foreach (var attribute in attributes)
         {
             if (!attribute.AttributeClass.IsEqualTo(notNullIfNotNullAttributeTypeSymbol))
                 continue;
 
-            if (attribute.ConstructorArguments.Length == 1 && attribute.ConstructorArguments[0].Value is string parameterName)
+            if (attribute.ConstructorArguments is [{ Value: string parameterName }] && !ParameterExists(declaringSymbol, parameterName))
             {
-                var parameterExists = method.Parameters.Any(p => p.Name == parameterName)
-#if CSHARP14_OR_GREATER
-                    || method.ContainingType?.ExtensionParameter?.Name == parameterName
-#endif
-                    ;
-                if (!parameterExists)
+                var location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation();
+                if (location is not null)
                 {
-                    var location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation();
-                    if (location != null)
-                    {
-                        context.ReportDiagnostic(Rule, location, parameterName);
-                    }
-                    else
-                    {
-                        context.ReportDiagnostic(Rule, method, parameterName);
-                    }
+                    context.ReportDiagnostic(Rule, location, parameterName);
+                }
+                else
+                {
+                    context.ReportDiagnostic(Rule, symbolToReport, parameterName);
                 }
             }
         }
+    }
+
+    private static bool ParameterExists(ISymbol declaringSymbol, string parameterName)
+    {
+        // For a property, the name can also be the value parameter of the setter
+        var parameters = declaringSymbol switch
+        {
+            IMethodSymbol method => method.Parameters,
+            IPropertySymbol { SetMethod: { } setMethod } => setMethod.Parameters,
+            IPropertySymbol property => property.Parameters,
+            _ => ImmutableArray<IParameterSymbol>.Empty,
+        };
+
+        if (parameters.Any(p => p.Name == parameterName))
+            return true;
+
+#if CSHARP14_OR_GREATER
+        if (declaringSymbol.ContainingType?.ExtensionParameter?.Name == parameterName)
+            return true;
+#endif
+
+        return false;
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/NullableAttributeUsageAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/NullableAttributeUsageAnalyzerTests.cs
@@ -59,6 +59,155 @@ public sealed class NullableAttributeUsageAnalyzerTests
         return test.RunAsync();
     }
 
+    [Fact]
+    public Task Parameter_ParameterDoesNotExist()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Test
+            {
+                public void A(string? a, [{|MA0068:NotNullIfNotNull("unknown")|}] out string? b) => b = a;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Parameter_ParameterExists()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Test
+            {
+                public void A(string? a, [NotNullIfNotNull(nameof(a))] out string? b) => b = a;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Property_ParameterDoesNotExist()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Test
+            {
+                [{|MA0068:NotNullIfNotNull("unknown")|}]
+                public string? A => null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Property_ValueParameterOfTheSetter()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Test
+            {
+                [NotNullIfNotNull("value")]
+                public string? A { get; set; }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Property_ValueParameterOfAGetOnlyProperty()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Test
+            {
+                [{|MA0068:NotNullIfNotNull("value")|}]
+                public string? A => null;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Indexer_ParameterExists()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Test
+            {
+                [NotNullIfNotNull(nameof(key))]
+                public string? this[string? key] => key;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Indexer_ParameterDoesNotExist()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Test
+            {
+                [{|MA0068:NotNullIfNotNull("unknown")|}]
+                public string? this[string? key] => key;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task IndexerParameter_ParameterDoesNotExist()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Test
+            {
+                public string? this[[{|MA0068:NotNullIfNotNull("unknown")|}] string? key] => key;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PropertyAccessor_ParameterDoesNotExist()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Test
+            {
+                public string? A { [return: {|MA0068:NotNullIfNotNull("unknown")|}] get => null; }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
 #if CSHARP14_OR_GREATER
     [Fact]
     public Task ExtensionBlock_ParameterExists_NoDiagnostic()
@@ -93,6 +242,65 @@ public sealed class NullableAttributeUsageAnalyzerTests
                 {
                     [return: {|MA0068:NotNullIfNotNull("unknown")|}]
                     public object? DoSomething() => obj;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExtensionBlock_Property_ParameterExists_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            static class Extensions
+            {
+                extension(object? obj)
+                {
+                    [NotNullIfNotNull(nameof(obj))]
+                    public object? Value => obj;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExtensionBlock_Property_ParameterDoesNotExist_Diagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            static class Extensions
+            {
+                extension(object? obj)
+                {
+                    [{|MA0068:NotNullIfNotNull("unknown")|}]
+                    public object? Value => obj;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ExtensionBlock_Parameter_ParameterExists_NoDiagnostic()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Diagnostics.CodeAnalysis;
+
+            static class Extensions
+            {
+                extension(object? obj)
+                {
+                    public void DoSomething([NotNullIfNotNull(nameof(obj))] out object? result) => result = obj;
                 }
             }
             """;


### PR DESCRIPTION
## What

`MA0068` (invalid parameter name for nullable attribute) only inspected `GetReturnTypeAttributes()`, so it only validated the `[return: NotNullIfNotNull("...")]` placement. `NotNullIfNotNullAttribute` is declared with `AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue`, and the same typo was silently ignored on an `out`/`ref` parameter and on a property:

```csharp
public class Sample
{
    // no diagnostic before this change, although "doesNotExist" is not a parameter
    public void M(string? a, [NotNullIfNotNull("doesNotExist")] out string? b) => b = a;

    [return: NotNullIfNotNull("doesNotExist")] // MA0068
    public string? N(string? a) => a;
}
```

## How

- A `SymbolKind.Property` symbol action is registered next to the existing `SymbolKind.Method` one, and the attribute loop is shared by the four placements: the return type attributes of a method, the attributes of each of its parameters, the attributes of a property, and the attributes of each parameter of an indexer.
- The parameters are analyzed from their declaring method or indexer rather than being registered directly: `SymbolKind.Parameter` is not a symbol kind the Roslyn analyzer driver raises symbol actions for (it only raises them for namespaces, types, methods, fields, properties and events), so `RegisterSymbolAction(..., SymbolKind.Parameter)` would never run.
- The candidate names come from the declaring symbol: the parameters of the method for a method; for a property, the parameters of the setter when there is one — the parameters of the indexer plus the implicit `value` parameter, which is how the compiler binds the name for the set accessor — and the parameters of the indexer otherwise. The extension parameter keeps being a candidate in both cases, under the existing `CSHARP14_OR_GREATER` guard.
- The parameters of the accessors of an indexer are skipped (`AssociatedSymbol is IPropertySymbol`). An attribute written on an indexer parameter surfaces both on the parameter of the indexer and on the parameter of the accessor, which reported the attribute twice; this was confirmed with a test before adding the guard. The return type attributes of an accessor are still analyzed, so `[return: NotNullIfNotNull(...)]` on a `get` accessor is reported.

## Notes for the reviewer

- A property with no setter and no parameters has no candidate name, so any name is reported. `[NotNullIfNotNull("value")]` is therefore compliant on `{ get; set; }` and reported on a get-only property.
- The sample of [`docs/Rules/MA0068.md`](docs/Rules/MA0068.md) was also incorrect: its compliant case was commented as `"a" is **not** a parameter of the method`, and both methods were named `A`. It now shows the parameter, property and indexer placements, and states the `value`/indexer rule.

## Tests

9 cases added to `NullableAttributeUsageAnalyzerTests` (out parameter valid and invalid, property invalid, `value` on a settable property and on a get-only one, indexer name valid and invalid, indexer parameter attribute, accessor `[return:]`), plus 3 extension block cases for the property and parameter placements.

`dotnet build` succeeds with no warning, the `MA0068` tests pass on every Roslyn version (11 on 4.8 and 4.14, 16 on 5.0, 5.6 and 5.9), and the full 5.9 suite passes (4606 tests). `dotnet run --project src/DocumentationGenerator` exits 0 with no further change.