### PR TITLE
Include the preprocessor trivia in the MA0202 branch comparison

### DIFF
--- a/docs/Rules/MA0202.md
+++ b/docs/Rules/MA0202.md
@@ -11,6 +11,8 @@ The comparison ignores trivia (such as comments and whitespace) when branches co
 
 For comment-only branches, comments are compared textually to avoid false positives when comment content differs.
 
+Nested preprocessor directives (such as a nested `#if` or a `#pragma`) are part of the comparison, so two branches that differ only by a nested directive or by the code of an inactive nested branch are not reported.
+
 ## Non-compliant code
 
 ````csharp

--- a/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalCommon.cs
+++ b/src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalCommon.cs
@@ -74,23 +74,54 @@ internal static class ConditionalCompilationBranchesAreIdenticalCommon
     private static string ComputeBranchSignature(SourceText sourceText, TextSpan span)
     {
         var text = sourceText.ToString(span);
-        var tokens = SyntaxFactory.ParseTokens(text);
         var builder = new StringBuilder();
-        foreach (var token in tokens)
-        {
-            if (token.RawKind == (int)SyntaxKind.EndOfFileToken)
-                continue;
-
-            builder.Append(token.RawKind);
-            builder.Append(':');
-            builder.Append(token.Text);
-            builder.Append(';');
-        }
-
-        if (builder.Length == 0)
+        if (!AppendTokens(builder, text))
             return text.Trim();
 
         return builder.ToString();
+    }
+
+    private static bool AppendTokens(StringBuilder builder, string text)
+    {
+        var hasToken = false;
+        foreach (var token in SyntaxFactory.ParseTokens(text))
+        {
+            // Preprocessor directives are parsed as trivia, so they must be appended explicitly.
+            // Otherwise, two branches containing different nested directives would have the same signature.
+            AppendPreprocessorTrivia(builder, token.LeadingTrivia);
+            if (token.RawKind != (int)SyntaxKind.EndOfFileToken)
+            {
+                hasToken = true;
+                builder.Append(token.RawKind);
+                builder.Append(':');
+                builder.Append(token.Text);
+                builder.Append(';');
+            }
+
+            AppendPreprocessorTrivia(builder, token.TrailingTrivia);
+        }
+
+        return hasToken;
+    }
+
+    private static void AppendPreprocessorTrivia(StringBuilder builder, SyntaxTriviaList triviaList)
+    {
+        foreach (var trivia in triviaList)
+        {
+            if (trivia.IsDirective)
+            {
+                builder.Append('#');
+                builder.Append(trivia.ToString().Trim());
+                builder.Append(';');
+            }
+            else if (trivia.RawKind == (int)SyntaxKind.DisabledTextTrivia)
+            {
+                // The text of an inactive nested branch is not tokenized, so it is tokenized separately
+                builder.Append('~');
+                AppendTokens(builder, trivia.ToString());
+                builder.Append(';');
+            }
+        }
     }
 
     internal sealed class BranchGroup(

--- a/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/ConditionalCompilationBranchesAreIdenticalAnalyzerTests.cs
@@ -143,6 +143,81 @@ public sealed class ConditionalCompilationBranchesAreIdenticalAnalyzerTests
     }
 
     [Fact]
+    public Task NestedDirectives_DifferentConditions()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            #if A
+            #if !B
+            _ = 0;
+            #endif
+            #else
+            #if !C
+            _ = 0;
+            #endif
+            #endif
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task NestedDirectives_SameConditions()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            #if A
+            #if !B
+            _ = 0;
+            #endif
+            {|MA0202:#else|}
+            #if !B
+            _ = 0;
+            #endif
+            #endif
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task NestedDirectives_DifferentInactiveCode()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            #if A
+            _ = 2;
+            #if B
+            _ = 0;
+            #endif
+            #else
+            _ = 2;
+            #if B
+            _ = 1;
+            #endif
+            #endif
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task PragmaDirectiveInSingleBranch()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            #if A
+            #pragma warning disable CA1000
+            _ = 0;
+            #else
+            _ = 0;
+            #endif
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task IfElse_SameCode_PartialExpression()
     {
         var test = CreateTest();


### PR DESCRIPTION
## Why

`MA0202` (*Conditional compilation branches have identical code*) compares the branches of a conditional compilation block by a signature built from `SyntaxFactory.ParseTokens`, appending only the **tokens**. Everything the preprocessor produces is *trivia*, so two things were missing from the comparison:

- the **nested directives** (`#if`, `#elif`, `#else`, `#pragma`, `#nullable`, …), parsed as directive trivia;
- the **code of an inactive nested branch**, which the lexer keeps as `DisabledTextTrivia` instead of tokenizing it.

Two branches differing only by a nested directive, or by the code that directive guards, therefore had the same signature and the second one was reported as a duplicate, although removing it changes the code that is compiled:

```csharp
#if NET8_0
#if !DEBUG
Trace();
#endif
#else          // <- reported as identical to the #if branch
#if !RELEASE
Trace();
#endif
#endif
```

```csharp
#if NET8_0
#pragma warning disable CS0618
Foo();
#else          // <- reported as identical, although the pragma is meaningful
Foo();
#endif
```

## What changed

[`ConditionalCompilationBranchesAreIdenticalCommon.ComputeBranchSignature`](src/Meziantou.Analyzer/Rules/ConditionalCompilationBranchesAreIdenticalCommon.cs) now walks the leading and trailing trivia of each token:

- the text of a **directive trivia** is appended to the signature (trimmed), so a nested `#if`, `#pragma` or `#nullable` is part of the comparison;
- a **disabled text trivia** is tokenized separately, so the code of an inactive nested branch is compared with the same trivia-insensitive signature as active code.

The recursion terminates: the directives of a nested block are lexed as directive trivia rather than as part of the disabled text, so each recursive call parses a strictly shorter text.

## Notes for the reviewer

Two details are easy to miss:

- **The end of file token is no longer skipped entirely** — only its token part is. The directives closing the nested blocks of a branch (its trailing `#endif`) are in the leading trivia of that token, so skipping it with `continue` would drop them.
- **The comment-only fallback is now keyed on "no token was appended"** rather than on "the signature is empty". Keying it on the builder would have regressed comment-only branches containing a directive: two `#region`-wrapped branches with different comments would have produced the same signature and become a new false positive.

Appending every directive means a difference in a `#region` now makes two branches different. That is a false negative rather than a false positive, which is the safe direction for this rule.

## Tests

Four tests added to `ConditionalCompilationBranchesAreIdenticalAnalyzerTests`: different nested conditions, same nested conditions (a guard against over-correcting, it must still be reported), differing inactive nested code, and a `#pragma` in a single branch.

The analyzer change was reverted locally and the tests re-run to check they are real regression coverage: the three "no diagnostic" tests fail on the previous code. With the change, the 17 tests of the rule pass on every supported Roslyn version (4.8, 4.14, 5.0, 5.6, 5.9). `dotnet run --project src/DocumentationGenerator` exits 0.

The shared helper is only used by the MA0202 analyzer and its code fixer, so no other rule is affected. The code fixer works on text spans and needs no change.

Note on the `#if DEBUG` / `#if RELEASE` shape: that one was *not* a false positive, as a branch producing no token already fell back to a raw text comparison. The defect shows up when the nested conditions evaluate to true under the default (empty) preprocessor symbols of `ParseTokens`, which is what the `#if !B` / `#if !C` test reproduces.