### PR TITLE
Report MA0179 when the constant is on the left of the length comparison

### DIFF
--- a/docs/Rules/MA0179.md
+++ b/docs/Rules/MA0179.md
@@ -18,6 +18,7 @@ if (member.GetCustomAttributes<ObsoleteAttribute>().Any()) { }
 if (member.GetCustomAttributes<ObsoleteAttribute>().Count() > 0) { }
 if (member.GetCustomAttributes<ObsoleteAttribute>().Length > 0) { }
 if (member.GetCustomAttributes<ObsoleteAttribute>().Length == 0) { }
+if (0 < member.GetCustomAttributes<ObsoleteAttribute>().Length) { }
 if (member.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: false).Any()) { }
 
 // compliant
@@ -29,6 +30,7 @@ if (Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
 if (Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
 if (Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
 if (!Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
+if (Attribute.IsDefined(member, typeof(ObsoleteAttribute))) { }
 if (Attribute.IsDefined(member, typeof(ObsoleteAttribute), inherit: false)) { }
 
 // compliant - with predicate (not detected)

--- a/src/Meziantou.Analyzer/Rules/UseAttributeIsDefinedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAttributeIsDefinedAnalyzer.cs
@@ -60,11 +60,13 @@ public sealed class UseAttributeIsDefinedAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            if (IsGetCustomAttributesLengthComparison(operation, operation.LeftOperand, operation.RightOperand, out _))
+            if (IsGetCustomAttributesLengthComparison(operation, operation.LeftOperand, operation.RightOperand, lengthIsOnLeft: true, out _) ||
+                IsGetCustomAttributesLengthComparison(operation, operation.RightOperand, operation.LeftOperand, lengthIsOnLeft: false, out _))
             {
                 context.ReportDiagnostic(Rule, operation, "GetCustomAttributes().Length");
             }
-            else if (IsGetCustomAttributesCountComparison(operation, operation.LeftOperand, operation.RightOperand, out _))
+            else if (IsGetCustomAttributesCountComparison(operation, operation.LeftOperand, operation.RightOperand, countIsOnLeft: true, out _) ||
+                     IsGetCustomAttributesCountComparison(operation, operation.RightOperand, operation.LeftOperand, countIsOnLeft: false, out _))
             {
                 context.ReportDiagnostic(Rule, operation, "GetCustomAttributes().Count()");
             }
@@ -123,11 +125,11 @@ public sealed class UseAttributeIsDefinedAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        private bool IsGetCustomAttributesLengthComparison(IBinaryOperation binaryOp, IOperation left, IOperation right, out IInvocationOperation? invocation)
+        private bool IsGetCustomAttributesLengthComparison(IBinaryOperation binaryOp, IOperation lengthOperand, IOperation otherOperand, bool lengthIsOnLeft, out IInvocationOperation? invocation)
         {
             invocation = null;
 
-            if (left is not IPropertyReferenceOperation propertyReference)
+            if (lengthOperand is not IPropertyReferenceOperation propertyReference)
                 return false;
 
             if (propertyReference.Property.Name is not "Length")
@@ -140,11 +142,11 @@ public sealed class UseAttributeIsDefinedAnalyzer : DiagnosticAnalyzer
                 return false;
 
             // Only allow clear-cut patterns that unambiguously check for existence
-            if (right.ConstantValue is not { HasValue: true, Value: int value })
+            if (otherOperand.ConstantValue is not { HasValue: true, Value: int value })
                 return false;
 
             // Validate that the operator + value combination makes sense
-            return IsValidLengthComparisonPattern(binaryOp.OperatorKind, value, lengthIsOnLeft: true);
+            return IsValidLengthComparisonPattern(binaryOp.OperatorKind, value, lengthIsOnLeft);
         }
 
         private static bool IsValidLengthComparisonPattern(BinaryOperatorKind operatorKind, int value, bool lengthIsOnLeft)
@@ -177,11 +179,11 @@ public sealed class UseAttributeIsDefinedAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        private bool IsGetCustomAttributesCountComparison(IBinaryOperation binaryOp, IOperation left, IOperation right, out IInvocationOperation? invocation)
+        private bool IsGetCustomAttributesCountComparison(IBinaryOperation binaryOp, IOperation countOperand, IOperation otherOperand, bool countIsOnLeft, out IInvocationOperation? invocation)
         {
             invocation = null;
 
-            if (left is not IInvocationOperation countInvocation)
+            if (countOperand is not IInvocationOperation countInvocation)
                 return false;
 
             // Check if this is the specific Count<T>(IEnumerable<T>) method
@@ -198,11 +200,11 @@ public sealed class UseAttributeIsDefinedAnalyzer : DiagnosticAnalyzer
                 return false;
 
             // Only allow clear-cut patterns that unambiguously check for existence
-            if (right.ConstantValue is not { HasValue: true, Value: int value })
+            if (otherOperand.ConstantValue is not { HasValue: true, Value: int value })
                 return false;
 
             // Use the same validation as Length (Count and Length have the same semantics)
-            return IsValidLengthComparisonPattern(binaryOp.OperatorKind, value, lengthIsOnLeft: true);
+            return IsValidLengthComparisonPattern(binaryOp.OperatorKind, value, countIsOnLeft);
         }
 
         private bool IsGetCustomAttributeInvocation(IOperation operation, out IInvocationOperation? invocation)

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAttributeIsDefinedAnalyzerTests.cs
@@ -478,6 +478,69 @@ public sealed class UseAttributeIsDefinedAnalyzerTests
         return test.RunAsync();
     }
 
+    [Theory]
+    [InlineData("0 == member.GetCustomAttributes<ObsoleteAttribute>().Count()", "!")]
+    [InlineData("0 != member.GetCustomAttributes<ObsoleteAttribute>().Count()", "")]
+    [InlineData("0 < member.GetCustomAttributes<ObsoleteAttribute>().Count()", "")]
+    [InlineData("1 <= member.GetCustomAttributes<ObsoleteAttribute>().Count()", "")]
+    [InlineData("1 > member.GetCustomAttributes<ObsoleteAttribute>().Count()", "!")]
+    [InlineData("0 >= member.GetCustomAttributes<ObsoleteAttribute>().Count()", "!")]
+    public Task GetCustomAttributes_Count_ConstantOnLeft(string expression, string negation)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {|MA0179:{{expression}}|};
+                }
+            }
+            """;
+        test.FixedCode = $$"""
+            using System;
+            using System.Linq;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {{negation}}Attribute.IsDefined(member, typeof(ObsoleteAttribute));
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Theory]
+    [InlineData("0 > member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length")]
+    [InlineData("1 == member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length")]
+    [InlineData("2 <= member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length")]
+    public Task GetCustomAttributes_Length_ConstantOnLeft_AmbiguousComparison_ShouldNotReport(string expression)
+    {
+        var test = CreateTest();
+        test.TestCode = $$"""
+            using System;
+            using System.Reflection;
+
+            class TestClass
+            {
+                void Test(MemberInfo member)
+                {
+                    _ = {{expression}};
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
     [Fact]
     public Task GetCustomAttributes_Count_WithPredicate_ShouldNotReport()
     {
@@ -662,6 +725,12 @@ public sealed class UseAttributeIsDefinedAnalyzerTests
     [Theory]
     [InlineData("member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length < 1", "!")]
     [InlineData("member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length <= 0", "!")]
+    [InlineData("0 == member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length", "!")]
+    [InlineData("0 != member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length", "")]
+    [InlineData("0 < member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length", "")]
+    [InlineData("1 <= member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length", "")]
+    [InlineData("1 > member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length", "!")]
+    [InlineData("0 >= member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length", "!")]
     public Task GetCustomAttributes_Length_Comparison(string expression, string negation)
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

`UseAttributeIsDefinedAnalyzer` (MA0179) only detected `GetCustomAttributes().Length` / `.Count()` existence checks when the length was the **left** operand. The reversed form was silently missed:

```csharp
member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length > 0  // MA0179 reported
0 < member.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length  // no diagnostic
```

## Why

`IsValidLengthComparisonPattern` takes a `lengthIsOnLeft` flag and carefully implements *both* orientations. But both call sites hard-coded `lengthIsOnLeft: true` and only ever passed `(operation.LeftOperand, operation.RightOperand)` in that order, so the entire `else` block was unreachable dead code.

`IsGetCustomAttributeComparison` (the `== null` variant) already handles both orientations, which makes the asymmetry an oversight rather than a deliberate scope decision — so this fixes it rather than deleting the branch.

## Changes

- `AnalyzeBinary` now tries both operand orders for the `Length` and `Count()` comparisons, passing the orientation through to `IsValidLengthComparisonPattern` instead of hard-coding `true`.
- Renamed the `left`/`right` parameters of the two helpers to `lengthOperand`/`countOperand` and `otherOperand`, since they no longer correspond to syntactic sides.
- Documented the reversed form in `docs/Rules/MA0179.md`.

## Note for reviewers

**The code fixer needed no change.** `ShouldNegateLengthComparison` already implemented both orientations and already searched both operands — it was dead in exactly the same way as the analyzer's `else` block, and simply becomes live now. That is why the diff touches only the analyzer.

## Tests

15 new cases in `UseAttributeIsDefinedAnalyzerTests`, each asserting the diagnostic **and** the fixed code, so the negation direction is verified rather than just detection:

- 6 reversed `Length` forms added to the existing theory: `0 == len` → `!IsDefined`, `0 != len` → `IsDefined`, `0 < len` → `IsDefined`, `1 <= len` → `IsDefined`, `1 > len` → `!IsDefined`, `0 >= len` → `!IsDefined`
- 6 equivalent reversed `Count()` forms
- 3 negative cases confirming ambiguous reversed comparisons stay unreported (`0 > len`, `1 == len`, `2 <= len`)

## Verification

- `dotnet test --max-parallel-test-modules 2` across all five Roslyn versions: **22751 passed, 0 failed**.
- Confirmed the new tests actually ran by checking the test names in the `.trx` output rather than relying on the pass count.
- `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes.
