### PR TITLE
Fix the MA0166 message saying "available tokens"

### DIFF
--- a/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseAnOverloadThatHasTimeProviderAnalyzer.cs
@@ -19,7 +19,7 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
     private static readonly DiagnosticDescriptor UseAnOverloadThatHasTimeProviderWhenAvailable = new(
         RuleIdentifiers.UseAnOverloadThatHasTimeProviderWhenAvailable,
         title: "Forward the TimeProvider to methods that take one",
-        messageFormat: "Use an overload with a TimeProvider, available tokens: {0}",
+        messageFormat: "Use an overload with a TimeProvider, available time providers: {0}",
         RuleCategories.Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
@@ -87,11 +87,11 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
 
             return false;
 
-            static bool IsArgumentImplicitlyDeclared(IInvocationOperation invocationOperation, INamedTypeSymbol cancellationTokenSymbol, [NotNullWhen(true)] out AdditionalParameterInfo? parameterInfo)
+            static bool IsArgumentImplicitlyDeclared(IInvocationOperation invocationOperation, INamedTypeSymbol timeProviderSymbol, [NotNullWhen(true)] out AdditionalParameterInfo? parameterInfo)
             {
                 foreach (var arg in invocationOperation.Arguments)
                 {
-                    if (arg.ArgumentKind is ArgumentKind.DefaultValue && arg.Parameter is not null && arg.Parameter.Type.IsEqualTo(cancellationTokenSymbol))
+                    if (arg.ArgumentKind is ArgumentKind.DefaultValue && arg.Parameter is not null && arg.Parameter.Type.IsEqualTo(timeProviderSymbol))
                     {
                         parameterInfo = new AdditionalParameterInfo(invocationOperation.TargetMethod.Parameters.IndexOf(arg.Parameter), arg.Parameter.Name);
                         return true;
@@ -112,10 +112,10 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
             if (!HasAnOverloadWithTimeProvider(operation, out var parameterInfo))
                 return;
 
-            var availableCancellationTokens = FindTimeProviders(operation, context.CancellationToken);
-            if (availableCancellationTokens.Length > 0)
+            var availableTimeProviders = FindTimeProviders(operation, context.CancellationToken);
+            if (availableTimeProviders.Length > 0)
             {
-                context.ReportDiagnostic(UseAnOverloadThatHasTimeProviderWhenAvailable, CreateProperties(availableCancellationTokens, parameterInfo), operation, string.Join(", ", availableCancellationTokens));
+                context.ReportDiagnostic(UseAnOverloadThatHasTimeProviderWhenAvailable, CreateProperties(availableTimeProviders, parameterInfo), operation, string.Join(", ", availableTimeProviders));
             }
             else
             {
@@ -123,16 +123,16 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
                 if (parentMethod is not null && parentMethod.IsOverrideOrInterfaceImplementation())
                     return;
 
-                context.ReportDiagnostic(UseAnOverloadThatHasTimeProviderRule, CreateProperties(availableCancellationTokens, parameterInfo), operation);
+                context.ReportDiagnostic(UseAnOverloadThatHasTimeProviderRule, CreateProperties(availableTimeProviders, parameterInfo), operation);
             }
         }
 
-        private static ImmutableDictionary<string, string?> CreateProperties(string[] cancellationTokens, AdditionalParameterInfo parameterInfo)
+        private static ImmutableDictionary<string, string?> CreateProperties(string[] timeProviders, AdditionalParameterInfo parameterInfo)
         {
             return ImmutableDictionary.Create<string, string?>(StringComparer.Ordinal)
                 .Add(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterIndexKey, parameterInfo.ParameterIndex.ToString(CultureInfo.InvariantCulture))
                 .Add(UseAnOverloadThatHasTimeProviderAnalyzerCommon.ParameterNameKey, parameterInfo.Name)
-                .Add(UseAnOverloadThatHasTimeProviderAnalyzerCommon.PathsKey, string.Join(',', cancellationTokens));
+                .Add(UseAnOverloadThatHasTimeProviderAnalyzerCommon.PathsKey, string.Join(',', timeProviders));
         }
 
         private List<ISymbol[]>? GetMembers(ITypeSymbol symbol, int maxDepth)
@@ -144,7 +144,9 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzer : DiagnosticAnalyze
                 if (maxDepth < 0)
                     return null;
 
-                // quickly skips some basic types that are known to not contain TimeProvider
+                // Quickly skips the types that Roslyn marks as special (System.Object, the primitives, System.String, the collection
+                // interfaces, ...) as none of them can contain a TimeProvider. The upper bound is the highest SpecialType value defined by
+                // the oldest supported Roslyn version; special types added by newer versions are simply not skipped.
                 if ((int)symbol.SpecialType is >= 1 and <= 45)
                     return null;
 

--- a/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseAnOverloadThatHasTimeProviderAnalyzerTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.UseAnOverloadThatHasTimeProviderAnalyzer,
     Meziantou.Analyzer.Rules.UseAnOverloadThatHasTimeProviderFixer>;
@@ -426,6 +427,39 @@ public sealed class UseAnOverloadThatHasTimeProviderAnalyzerTests
                 static void B(System.TimeProvider foo) => {|MA0166:"".A(0)|};
             }
             """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReportsTheAvailableTimeProvidersInTheMessage()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            class Test
+            {
+                void A(System.TimeProvider timeProvider)
+                {
+                    {|#0:Delay()|};
+                }
+
+                static void Delay() { }
+                static void Delay(System.TimeProvider timeProvider) { }
+            }
+            """;
+        test.FixedCode = """
+            class Test
+            {
+                void A(System.TimeProvider timeProvider)
+                {
+                    Delay(timeProvider);
+                }
+
+                static void Delay() { }
+                static void Delay(System.TimeProvider timeProvider) { }
+            }
+            """;
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("MA0166", DiagnosticSeverity.Info).WithLocation(0).WithMessage("Use an overload with a TimeProvider, available time providers: timeProvider"));
 
         return test.RunAsync();
     }


### PR DESCRIPTION
## What

`MA0166` (*Forward the TimeProvider to methods that take one*) formats the list of `TimeProvider` expressions available in the scope into its message, but called them *tokens*:

```
MA0166: Use an overload with a TimeProvider, available tokens: this.timeProvider
```

The file was derived from `UseAnOverloadThatHasCancellationTokenAnalyzer` and the wording was never updated. It is confusing next to `MA0032`/`MA0040`, where the same wording really is about `CancellationToken`.

The message is now:

```
MA0166: Use an overload with a TimeProvider, available time providers: this.timeProvider
```

## Also in this change

The same copy-paste left several identifiers talking about cancellation tokens; they are renamed to match what they actually hold:

- `availableCancellationTokens` → `availableTimeProviders`
- `CreateProperties(string[] cancellationTokens, …)` → `timeProviders`
- `IsArgumentImplicitlyDeclared(…, INamedTypeSymbol cancellationTokenSymbol, …)` → `timeProviderSymbol` (the argument passed at the call site is already `TimeProviderSymbol`)

The comment above the `(int)symbol.SpecialType is >= 1 and <= 45` fast path is expanded to say what the range means. Checking the Roslyn packages confirms the enum grew past 45 (`System_Runtime_CompilerServices_InlineArrayAttribute` and `System_Runtime_CompilerServices_AsyncHelpers` exist in 5.9 but not in 4.8), so the bound covers every special type of the oldest supported Roslyn version and the newer ones are simply not skipped — a missed fast path, not a correctness issue. The bound itself is left unchanged, as widening it is a behaviour change beyond this fix.

No behaviour other than the message text changes: the diagnostic properties consumed by the code fix (`ParameterIndexKey`, `ParameterNameKey`, `PathsKey`) are untouched.

## Tests

No test asserted on the MA0166 message, so `ReportsTheAvailableTimeProvidersInTheMessage` is added to pin the wording, mirroring the equivalent MA0040 test.

- `UseAnOverloadThatHasTimeProviderAnalyzerTests`: 18/18 passing on roslyn4.8, 4.14, 5.0, 5.6 and 5.9
- `dotnet run --project src/DocumentationGenerator`: exit code 0, no markdown change (the docs surface rule titles, not message formats)