### PR TITLE
Report MA0206 on record struct and interface declarations

### DIFF
--- a/docs/Rules/MA0206.md
+++ b/docs/Rules/MA0206.md
@@ -5,22 +5,26 @@ Sources: [RemoveUnnecessaryBracesInTypeDeclarationAnalyzer.cs](https://github.co
 
 This rule reports empty braces in type declarations that can be replaced with a semicolon.
 
-The rule applies to records and to C# 12 class/struct declarations when the type body contains no members, comments, or directives.
+The rule applies to records (including record structs) and to C# 12 class, struct, and interface declarations when the type body contains no members, comments, or directives.
 
 ## Non-compliant code
 
 ````csharp
 public record Foo(string Value1, string Value2) { }
+public record struct Point(int X, int Y) { }
 
 public class Bar(string Value1, string Value2) { }
 public class Baz { }
+public interface IQux { }
 ````
 
 ## Compliant code
 
 ````csharp
 public record Foo(string Value1, string Value2);
+public record struct Point(int X, int Y);
 
 public class Bar(string Value1, string Value2);
 public class Baz;
+public interface IQux;
 ````

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryBracesInTypeDeclarationFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/RemoveUnnecessaryBracesInTypeDeclarationFixer.cs
@@ -63,7 +63,7 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationFixer : CodeFixProvi
         if (!typeDeclaration.GetCSharpLanguageVersion().IsCSharp12OrGreater())
             return false;
 
-        if (typeDeclaration is ClassDeclarationSyntax or StructDeclarationSyntax)
+        if (typeDeclaration is ClassDeclarationSyntax or StructDeclarationSyntax or InterfaceDeclarationSyntax)
             return true;
 
         return false;

--- a/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzer.cs
@@ -23,9 +23,13 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzer : Diagnosti
         context.EnableConcurrentExecution();
         context.ConfigureAnalysisOfGeneratedCode(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterSyntaxNodeAction(AnalyzeTypeDeclaration, SyntaxKind.RecordDeclaration);
-        context.RegisterSyntaxNodeAction(AnalyzeTypeDeclaration, SyntaxKind.ClassDeclaration);
-        context.RegisterSyntaxNodeAction(AnalyzeTypeDeclaration, SyntaxKind.StructDeclaration);
+        context.RegisterSyntaxNodeAction(
+            AnalyzeTypeDeclaration,
+            SyntaxKind.RecordDeclaration,
+            SyntaxKind.RecordStructDeclaration,
+            SyntaxKind.ClassDeclaration,
+            SyntaxKind.StructDeclaration,
+            SyntaxKind.InterfaceDeclaration);
     }
 
     private static void AnalyzeTypeDeclaration(SyntaxNodeAnalysisContext context)
@@ -59,7 +63,7 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzer : Diagnosti
         if (!languageVersion.IsCSharp12OrGreater())
             return false;
 
-        if (typeDeclaration is ClassDeclarationSyntax or StructDeclarationSyntax)
+        if (typeDeclaration is ClassDeclarationSyntax or StructDeclarationSyntax or InterfaceDeclarationSyntax)
             return true;
 
         return false;

--- a/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Meziantou.Analyzer.Test.Harness.CSharpCodeFixTest<
     Meziantou.Analyzer.Rules.RemoveUnnecessaryBracesInTypeDeclarationAnalyzer,
@@ -122,6 +123,104 @@ public sealed class RemoveUnnecessaryBracesInTypeDeclarationAnalyzerTests
             """;
         test.FixedCode = """
             public struct Foo(string Value1, string Value2);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RecordStructPrimaryConstructor_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public record struct Foo(string Value1, string Value2) {|MA0206:{|}}
+            """;
+        test.FixedCode = """
+            public record struct Foo(string Value1, string Value2);
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ReadOnlyRecordStructWithoutParameterList_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public readonly record struct Foo {|MA0206:{|}}
+            """;
+        test.FixedCode = """
+            public readonly record struct Foo;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RecordStruct_WithMember()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public record struct Foo(string Value1)
+            {
+                public string Value2 { get; init; }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Interface_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public interface IFoo {|MA0206:{|}}
+            """;
+        test.FixedCode = """
+            public interface IFoo;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Interface_WithBaseList_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public interface IBase;
+            public interface IFoo : IBase {|MA0206:{|}}
+            """;
+        test.FixedCode = """
+            public interface IBase;
+            public interface IFoo : IBase;
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Interface_WithMember()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            public interface IFoo
+            {
+                void Bar();
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Interface_CSharp11()
+    {
+        var test = CreateTest();
+        test.LanguageVersion = LanguageVersion.CSharp11;
+        test.TestCode = """
+            public interface IFoo { }
             """;
 
         return test.RunAsync();


### PR DESCRIPTION
## What

MA0206 (*Remove unnecessary braces in type declaration*) never reported on `record struct` or `interface` declarations. Both now produce a diagnostic and a code fix.

```csharp
record R(int A) { }         // reported before and after
record struct RS(int A) { } // only reported after this change
interface IFoo { }          // only reported after this change
```

## Why

`RemoveUnnecessaryBracesInTypeDeclarationAnalyzer` registered its action on `SyntaxKind.RecordDeclaration`, `ClassDeclaration` and `StructDeclaration`. A `record struct` produces a `RecordDeclarationSyntax` whose *kind* is `SyntaxKind.RecordStructDeclaration` — not `RecordDeclaration` (which covers `record` and `record class`) and not `StructDeclaration` — so the node was never visited. `CanUseSemicolonTypeDeclaration` already returns `true` for any `RecordDeclarationSyntax`, so the code was clearly written expecting record structs to arrive; this was a gap, not a scope decision.

Interfaces were simply missing from the registration. `interface IFoo;` is valid since C# 12, so the rule applies there too.

## How

- The action is registered on the five kinds in a single `RegisterSyntaxNodeAction` call (adding `RecordStructDeclaration` and `InterfaceDeclaration`).
- `CanUseSemicolonTypeDeclaration` accepts `InterfaceDeclarationSyntax` in its C# 12-gated arm, in both the analyzer and the code fixer. Record structs need no change there: they already fall into the `RecordDeclarationSyntax` arm.
- `docs/Rules/MA0206.md` scope sentence and samples updated.

## Notes for reviewers

The language gates were checked against the compiler rather than assumed. `interface IFoo;`, `interface IFoo : IBase;`, `record struct RS;` and `readonly record struct RRS(int A);` all compile under C# 12; `interface IFoo;` fails under C# 11 with CS9058. So the interface arm needs the C# 12 guard, and record structs correctly need none — a `record struct` only parses on a language version that supports it.

7 tests added to the existing test class: record struct with a primary constructor (code fix), `readonly record struct` without a parameter list, record struct with a member (no diagnostic), interface (code fix), interface with a base list (code fix), interface with a member (no diagnostic), and an interface under `LanguageVersion.CSharp11` pinning the version gate (no diagnostic).

All 18 tests in the class pass on every supported Roslyn version (4.8, 4.14, 5.0, 5.6, 5.9) — 11 pre-existing plus the 7 new, so the count confirms the new tests ran. `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes.

No entry was added to `docs/comparison-with-other-analyzers.md`: MA0206 is absent from it today, and this widens an existing rule's scope rather than establishing a new equivalence with an external rule.