### PR TITLE
Report MA0147 on async void method groups

### DIFF
--- a/docs/Rules/MA0147.md
+++ b/docs/Rules/MA0147.md
@@ -8,5 +8,9 @@ Foo(() => {}); // ok
 
 Foo(async () => {}); // non-compliant as the delegate is not expecting an async method
 
+Foo(Handler); // non-compliant as the delegate is not expecting an async method
+
+async void Handler() { }
+
 void Foo(System.Action action) => throw null;
 ````

--- a/src/Meziantou.Analyzer/Rules/DoNotUseAsyncDelegateForSyncDelegateAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotUseAsyncDelegateForSyncDelegateAnalyzer.cs
@@ -40,7 +40,14 @@ public sealed class DoNotUseAsyncDelegateForSyncDelegateAnalyzer : DiagnosticAna
             return;
         }
 
-        if (operation.Target is IAnonymousFunctionOperation { Symbol.IsAsync: true })
+        var isAsyncVoid = operation.Target switch
+        {
+            IAnonymousFunctionOperation { Symbol.IsAsync: true } => true,
+            IMethodReferenceOperation { Method: { IsAsync: true, ReturnsVoid: true } } => true,
+            _ => false,
+        };
+
+        if (isAsyncVoid)
         {
             context.ReportDiagnostic(Rule, operation);
         }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotUseAsyncDelegateForSyncDelegateAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotUseAsyncDelegateForSyncDelegateAnalyzerTests.cs
@@ -130,6 +130,66 @@ public sealed class DoNotUseAsyncDelegateForSyncDelegateAnalyzerTests
     }
 
     [Fact]
+    public Task Action_SyncMethodGroup()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            A(Handler);
+
+            void A(System.Action a) => throw null;
+            void Handler() { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Action_AsyncVoidMethodGroup()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            A({|MA0147:Handler|});
+
+            void A(System.Action a) => throw null;
+            async void Handler() { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task FuncTask_AsyncMethodGroup()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            A(Handler);
+
+            void A(System.Func<System.Threading.Tasks.Task> a) => throw null;
+            async System.Threading.Tasks.Task Handler() { }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Event_AsyncVoidMethodGroup()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            Sample.A += Sample.Handler;
+            Sample.A -= Sample.Handler;
+
+            class Sample
+            {
+                public static event System.EventHandler A;
+                public static async void Handler(object sender, System.EventArgs e) { }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task Event_AsyncVoid()
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

`MA0147` (Avoid async void method for delegate) only matched `IAnonymousFunctionOperation`, so it reported the lambda form but said nothing about an `async void` **method group** converted to a void-returning delegate:

```csharp
class Sample
{
    async void Handler() => await Task.Delay(1);

    void M()
    {
        Action a1 = async () => await Task.Delay(1);  // MA0147 reported
        Action a2 = Handler;                          // no diagnostic (before this change)
    }
}
```

The target check in `DoNotUseAsyncDelegateForSyncDelegateAnalyzer` is now a switch that also matches `IMethodReferenceOperation` when the referenced method is both async and void-returning:

```csharp
var isAsyncVoid = operation.Target switch
{
    IAnonymousFunctionOperation { Symbol.IsAsync: true } => true,
    IMethodReferenceOperation { Method: { IsAsync: true, ReturnsVoid: true } } => true,
    _ => false,
};
```

## Why

Both forms have the same problem: the exception is lost and the caller cannot observe completion. The method-group form was a false negative.

## Notes for the reviewer

- The `ReturnsVoid` check on the method reference is what keeps `async Task` method groups quiet. The enclosing `DelegateInvokeMethod.ReturnsVoid` guard alone is about the *delegate* type, not the target's own return type.
- The existing `operation.Parent is IEventAssignmentOperation` exclusion already covers the legitimate `someEvent += Handler;` case for method groups too; there is a new test asserting that.
- This widens the rule for existing users. Non-event callback registrations that intentionally pass an `async void` method group (a fire-and-forget timer or message-pump callback, say) will now warn where they did not before. That is the intended behavior of the rule, just newly reachable.

## Tests

Four tests added to `DoNotUseAsyncDelegateForSyncDelegateAnalyzerTests`:

- `Action_AsyncVoidMethodGroup` — reports (the new coverage)
- `Action_SyncMethodGroup` — no diagnostic
- `FuncTask_AsyncMethodGroup` — no diagnostic, guards against flagging `async Task` method groups
- `Event_AsyncVoidMethodGroup` — no diagnostic

All five Roslyn versions pass (14 tests each: 4.8, 4.14, 5.0, 5.6, 5.9). `dotnet run --project src/DocumentationGenerator` exits 0 with no further markdown changes.

`docs/Rules/MA0147.md` gains the method-group non-compliant example.