### PR TITLE
Report the contextual keywords in MA0154

### DIFF
--- a/docs/Rules/MA0154.md
+++ b/docs/Rules/MA0154.md
@@ -15,6 +15,8 @@ public class Sample { }
 public class Sample { }
 ```
 
+The rule recognizes the C# reserved keywords, and the contextual keywords and type keywords that are unlikely to be used as an identifier (`async`, `await`, `dynamic`, `init`, `nameof`, `nint`, `nuint`, `partial`, `record`, `required`, `scoped`, `var`). Contextual keywords such as `value`, `from`, `get` or `set` are not reported as they are commonly used as plain words or identifiers.
+
 If the content is not a C# keyword, you can add a `language` attribute to the element to indicate the language of the code. Any attribute on the element disables the rule.
 
 ```c#

--- a/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/UseLangwordInXmlCommentAnalyzer.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Linq.Expressions;
 
 namespace Meziantou.Analyzer.Rules;
 
@@ -8,10 +7,14 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
 {
     private static readonly ObjectPool<PooledQueue<SyntaxNode>> NodeQueuePool = ObjectPool.CreateQueuePool<SyntaxNode>();
 
+    // Reserved keywords, plus the contextual keywords and the type keywords that are unlikely to be used as an identifier.
+    // Contextual keywords such as "value", "from", "select", "add", "remove", "get" or "set" are excluded as they are commonly used as plain words or identifiers.
     private static readonly HashSet<string> CSharpKeywords = new(StringComparer.Ordinal)
     {
         "abstract",
         "as",
+        "async",
+        "await",
         "base",
         "bool",
         "break",
@@ -28,6 +31,7 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
         "delegate",
         "do",
         "double",
+        "dynamic",
         "else",
         "enum",
         "event",
@@ -43,27 +47,35 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
         "if",
         "implicit",
         "in",
+        "init",
         "int",
         "interface",
         "internal",
         "is",
         "lock",
         "long",
+        "nameof",
         "namespace",
         "new",
+        "nint",
+        "nuint",
         "null",
         "object",
         "operator",
         "out",
         "override",
         "params",
+        "partial",
         "private",
         "protected",
         "public",
         "readonly",
+        "record",
         "ref",
+        "required",
         "return",
         "sbyte",
+        "scoped",
         "sealed",
         "short",
         "sizeof",
@@ -83,6 +95,7 @@ public sealed class UseLangwordInXmlCommentAnalyzer : DiagnosticAnalyzer
         "unsafe",
         "ushort",
         "using",
+        "var",
         "virtual",
         "void",
         "volatile",

--- a/tests/Meziantou.Analyzer.Test/Rules/UseLangwordInXmlCommentAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/UseLangwordInXmlCommentAnalyzerTests.cs
@@ -17,6 +17,18 @@ public sealed class UseLangwordInXmlCommentAnalyzerTests
     [InlineData("{|MA0154:<c>void</c>|}", "<see langword=\"void\"/>")]
     [InlineData("{|MA0154:<code>void</code>|}", "<see langword=\"void\"/>")]
     [InlineData("{|MA0154:<code>null</code>|}", "<see langword=\"null\"/>")]
+    [InlineData("{|MA0154:<c>async</c>|}", "<see langword=\"async\"/>")]
+    [InlineData("{|MA0154:<c>await</c>|}", "<see langword=\"await\"/>")]
+    [InlineData("{|MA0154:<c>dynamic</c>|}", "<see langword=\"dynamic\"/>")]
+    [InlineData("{|MA0154:<c>init</c>|}", "<see langword=\"init\"/>")]
+    [InlineData("{|MA0154:<c>nameof</c>|}", "<see langword=\"nameof\"/>")]
+    [InlineData("{|MA0154:<c>nint</c>|}", "<see langword=\"nint\"/>")]
+    [InlineData("{|MA0154:<c>nuint</c>|}", "<see langword=\"nuint\"/>")]
+    [InlineData("{|MA0154:<c>partial</c>|}", "<see langword=\"partial\"/>")]
+    [InlineData("{|MA0154:<c>record</c>|}", "<see langword=\"record\"/>")]
+    [InlineData("{|MA0154:<c>required</c>|}", "<see langword=\"required\"/>")]
+    [InlineData("{|MA0154:<c>scoped</c>|}", "<see langword=\"scoped\"/>")]
+    [InlineData("{|MA0154:<c>var</c>|}", "<see langword=\"var\"/>")]
     public Task ValidateSummary_Invalid(string comment, string fix)
     {
         var test = CreateTest();
@@ -102,6 +114,11 @@ public sealed class UseLangwordInXmlCommentAnalyzerTests
     [InlineData("{|MA0219:<c>test</c>|}")]
     [InlineData("{|MA0219:<code>test</code>|}")]
     [InlineData("""{|MA0219:<c title="sample">test</c>|}""")]
+    // Contextual keywords that are commonly used as identifiers or plain words are not reported as keywords
+    [InlineData("{|MA0219:<c>value</c>|}")]
+    [InlineData("{|MA0219:<c>from</c>|}")]
+    [InlineData("{|MA0219:<c>get</c>|}")]
+    [InlineData("{|MA0219:<c>set</c>|}")]
     public Task MissingLanguageAttribute(string comment)
     {
         var test = CreateTest();


### PR DESCRIPTION
## What

MA0154 (*Use langword in XML comment*) matched its `<c>`/`<code>` content against a hand-maintained list of the 77 C# reserved keywords. Keywords added to the language since C# 1.0 were missing, so `<c>await</c>`, `<c>nint</c>` or `<c>record</c>` were never reported, while `<c>int</c>` was.

The following are now reported: `async`, `await`, `dynamic`, `init`, `nameof`, `nint`, `nuint`, `partial`, `record`, `required`, `scoped`, `var`.

The unused `using System.Linq.Expressions;` in the analyzer is also removed.

## Why the list stays hard-coded

Deriving the set from `SyntaxFacts.GetKeywordKinds()` / `GetContextualKeywordKinds()` looks tempting, but:

- `nint` and `nuint` have no keyword kind — they are parsed as identifiers — so the main reported gap would remain.
- The contextual keyword kinds differ between the five supported Roslyn versions, which would make the rule report different diagnostics depending on the Roslyn version in use.
- The contextual keywords that are also ordinary identifiers (`value`, `from`, `select`, `add`, `remove`, `get`, `set`) would have to be subtracted by hand anyway to avoid false positives on things like `<c>value</c>`, so the maintenance burden does not actually go away.

Those ambiguous ones are therefore deliberately excluded; a comment in the analyzer says so.

## Tests

- One `ValidateSummary_Invalid` case per new keyword, checking both the diagnostic and the code fix output.
- Four `MissingLanguageAttribute` cases asserting `<c>value</c>`, `<c>from</c>`, `<c>get</c>` and `<c>set</c>` still report MA0219 and not MA0154.

`UseLangwordInXmlCommentAnalyzerTests` runs 42 tests (up from 25), all passing on `roslyn5.9` and `roslyn4.8`. `dotnet run --project src/DocumentationGenerator` exits 0, so no generated markdown changed; `docs/Rules/MA0154.md` is updated by hand to document which keywords are recognized and which are not.