### PR TITLE
Report MA0051 on expression bodies of properties, indexers, and operators

### DIFF
--- a/docs/Rules/MA0051.md
+++ b/docs/Rules/MA0051.md
@@ -5,6 +5,8 @@ Source: [MethodShouldNotBeTooLongAnalyzer.cs](https://github.com/meziantou/Mezia
 
 Long methods are harder to understand. You should refactor them when possible.
 
+The rule reports methods, local functions, constructors, destructors, operators, conversion operators, and the accessors and expression bodies of properties, indexers, and events.
+
 You can configure the rule using an `.editorconfig` file:
 
 ````editorconfig

--- a/src/Meziantou.Analyzer/Rules/MethodShouldNotBeTooLongAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/MethodShouldNotBeTooLongAnalyzer.cs
@@ -31,6 +31,10 @@ public sealed class MethodShouldNotBeTooLongAnalyzer : DiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
         context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.LocalFunctionStatement);
         context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.PropertyDeclaration);
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.IndexerDeclaration);
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.EventDeclaration);
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.OperatorDeclaration);
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.ConversionOperatorDeclaration);
         context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.ConstructorDeclaration);
         context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.DestructorDeclaration);
     }
@@ -50,15 +54,27 @@ public sealed class MethodShouldNotBeTooLongAnalyzer : DiagnosticAnalyzer
                 break;
 
             case PropertyDeclarationSyntax node:
-                if (node.AccessorList is not null)
-                {
-                    foreach (var accessor in node.AccessorList.Accessors)
-                    {
-                        AnalyzeNode(context, accessor.Body, accessor.Keyword);
-                        AnalyzeNode(context, accessor.ExpressionBody, accessor.Keyword);
-                    }
-                }
+                AnalyzeNode(context, node.ExpressionBody, node.Identifier);
+                AnalyzeAccessors(context, node.AccessorList);
+                break;
 
+            case IndexerDeclarationSyntax node:
+                AnalyzeNode(context, node.ExpressionBody, node.ThisKeyword);
+                AnalyzeAccessors(context, node.AccessorList);
+                break;
+
+            case EventDeclarationSyntax node:
+                AnalyzeAccessors(context, node.AccessorList);
+                break;
+
+            case OperatorDeclarationSyntax node:
+                AnalyzeNode(context, node.Body, node.OperatorToken);
+                AnalyzeNode(context, node.ExpressionBody, node.OperatorToken);
+                break;
+
+            case ConversionOperatorDeclarationSyntax node:
+                AnalyzeNode(context, node.Body, node.ImplicitOrExplicitKeyword);
+                AnalyzeNode(context, node.ExpressionBody, node.ImplicitOrExplicitKeyword);
                 break;
 
             case ConstructorDeclarationSyntax node:
@@ -70,6 +86,18 @@ public sealed class MethodShouldNotBeTooLongAnalyzer : DiagnosticAnalyzer
                 AnalyzeNode(context, node.Body, node.Identifier);
                 AnalyzeNode(context, node.ExpressionBody, node.Identifier);
                 break;
+        }
+    }
+
+    private static void AnalyzeAccessors(SyntaxNodeAnalysisContext context, AccessorListSyntax? accessorList)
+    {
+        if (accessorList is null)
+            return;
+
+        foreach (var accessor in accessorList.Accessors)
+        {
+            AnalyzeNode(context, accessor.Body, accessor.Keyword);
+            AnalyzeNode(context, accessor.ExpressionBody, accessor.Keyword);
         }
     }
 

--- a/tests/Meziantou.Analyzer.Test/Rules/MethodShouldNotBeTooLongAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/MethodShouldNotBeTooLongAnalyzerTests.cs
@@ -286,6 +286,166 @@ public sealed class MethodShouldNotBeTooLongAnalyzerTests
     }
 
     [Fact]
+    public Task TooLongProperty_ExpressionBody_Lines()
+    {
+        var test = CreateTest(("MA0051.maximum_lines_per_method", "1"));
+        test.TestCode = """
+            public class Test
+            {
+                int {|MA0051:Property|} => 0 +
+                    1 +
+                    2;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ValidProperty_ExpressionBody_Lines()
+    {
+        var test = CreateTest(("MA0051.maximum_lines_per_method", "2"));
+        test.TestCode = """
+            public class Test
+            {
+                int Property => 0 +
+                    1 +
+                    2;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongIndexer_ExpressionBody_Lines()
+    {
+        var test = CreateTest(("MA0051.maximum_lines_per_method", "1"));
+        test.TestCode = """
+            public class Test
+            {
+                int {|MA0051:this|}[int index] => 0 +
+                    1 +
+                    2;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongIndexerAccessors_Statements()
+    {
+        var test = CreateTest(("MA0051.maximum_statements_per_method", "2"));
+        test.TestCode = """
+            public class Test
+            {
+                int this[int index]
+                {
+                    {|MA0051:get|}
+                    {
+                        var a = 0;var b = 0;
+                        return a + b;
+                    }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongEventAccessors_Statements()
+    {
+        var test = CreateTest(("MA0051.maximum_statements_per_method", "2"));
+        test.TestCode = """
+            using System;
+            public class Test
+            {
+                event EventHandler Sample
+                {
+                    {|MA0051:add|}
+                    {
+                        var a = 0;var b = 0;
+                        _ = a + b;
+                    }
+                    remove { }
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongOperator_Statements()
+    {
+        var test = CreateTest(("MA0051.maximum_statements_per_method", "2"));
+        test.TestCode = """
+            public class Test
+            {
+                public static Test operator {|MA0051:+|}(Test a, Test b)
+                {
+                    var c = 0;var d = 0;var e = 0;
+                    return null;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongOperator_ExpressionBody_Lines()
+    {
+        var test = CreateTest(("MA0051.maximum_lines_per_method", "1"));
+        test.TestCode = """
+            public class Test
+            {
+                public static int operator {|MA0051:+|}(Test a, Test b) => 0 +
+                    1 +
+                    2;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongConversionOperator_ExpressionBody_Lines()
+    {
+        var test = CreateTest(("MA0051.maximum_lines_per_method", "1"));
+        test.TestCode = """
+            public class Test
+            {
+                public static {|MA0051:implicit|} operator int(Test a) => 0 +
+                    1 +
+                    2;
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TooLongConversionOperator_Statements()
+    {
+        var test = CreateTest(("MA0051.maximum_statements_per_method", "2"));
+        test.TestCode = """
+            public class Test
+            {
+                public static {|MA0051:explicit|} operator int(Test a)
+                {
+                    var b = 0;var c = 0;
+                    return b + c;
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
     public Task TooLongConstructor_Statements()
     {
         var test = CreateTest(("MA0051.maximum_statements_per_method", "2"));


### PR DESCRIPTION
## What

MA0051 (*Method is too long*) never reported some member bodies:

- `PropertyDeclarationSyntax.ExpressionBody` was never passed to the analysis. Only the accessor list was inspected, so `int P => /* 80 lines */;` was invisible to the rule while the very same body on a method was reported.
- `IndexerDeclaration`, `OperatorDeclaration`, `ConversionOperatorDeclaration` and `EventDeclaration` were not registered in `Initialize`, so no body on those members was counted at all.

## Changes

- `PropertyDeclarationSyntax`: analyze `node.ExpressionBody`, reported on the property identifier.
- Register and handle the missing member kinds:
  - indexers — expression body reported on `this`, plus the accessors;
  - operators — reported on the operator token (`+`, `-`, …);
  - conversion operators — reported on the `implicit` / `explicit` keyword;
  - events — the `add` / `remove` accessors.
- Extract the accessor loop into an `AnalyzeAccessors` helper shared by properties, indexers, and events.
- Document the members covered by the rule in `docs/Rules/MA0051.md`.

## Notes for reviewers

- This turns previously silent code into warnings, so a project with a long expression-bodied property or operator can start seeing MA0051 where it did not before. That is the intent: the rule already reported the identical body on a method.
- The reported location for each new member kind is the closest analogue of the method identifier, so the squiggle lands on the member name rather than the whole body.

## Testing

- 9 new tests in `MethodShouldNotBeTooLongAnalyzerTests` covering property expression bodies (reporting and non-reporting), indexer expression bodies and accessors, event accessors, and operator / conversion-operator block and expression bodies.
- `dotnet build`: succeeds, 0 warnings.
- `MethodShouldNotBeTooLongAnalyzerTests`: 24/24 pass on Roslyn 4.8, 4.14, 5.0, 5.6 and 5.9 (15 tests before the change).
- `dotnet run --project src/DocumentationGenerator`: exits 0, no generated markdown changed.