### PR TITLE
Clarify the MA0095 comment about the Equals(object) lookup

### DIFF
--- a/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/EqualityShouldBeCorrectlyImplementedAnalyzer.cs
@@ -134,8 +134,9 @@ public sealed partial class EqualityShouldBeCorrectlyImplementedAnalyzer : Diagn
             }
 
             // IEquatable<T> without Equals(object)
-            // Only report if directly implemented (not inherited via CRTP - Curiously Recurring Template Pattern)
-            // Check the entire type hierarchy for an Equals(object) override
+            // Only report when IEquatable<T> is implemented by this type (not inherited via CRTP - Curiously
+            // Recurring Template Pattern), and when this type does not itself override Equals(object): inheriting
+            // the base override would make object.Equals disagree with the new IEquatable<T> semantics.
             if (directlyImplementIEquatableOfT && !symbol.GetMembers().OfType<IMethodSymbol>().Any(IsEqualsMethodOverride))
             {
                 context.ReportDiagnostic(OverrideEqualsObjectRule, symbol);


### PR DESCRIPTION
## What changed

The comment above the MA0095 check in `EqualityShouldBeCorrectlyImplementedAnalyzer` said:

> Check the entire type hierarchy for an `Equals(object)` override

but the code calls `symbol.GetMembers()`, which only returns the members **declared by the type itself** — a base-type override is not visible there. The comment now states what the code does and why.

## Why

The behavior is correct and intentional: a type that introduces new equality semantics through `IEquatable<T>` must override `Equals(object)` itself, otherwise `object.Equals` (inherited from the base) and `IEquatable<T>.Equals` would disagree. This exact shape is listed as non-compliant in [docs/Rules/MA0095.md](docs/Rules/MA0095.md). Only the comment was misleading — it suggested a bug where there is none, and could prompt a "fix" that breaks the rule.

## Notes for reviewers

- Comment-only change; no behavior change.
- No new test needed: `InheritedIEquatable_WithDirectImplementationToo_ShouldTrigger` already locks in the scenario (base overrides `Equals(object)`, derived implements `IEquatable<Derived>` → MA0095 reported).
- Verified: `Meziantou.Analyzer.roslyn5.9` builds with 0 warnings, the 46 `EqualityShouldBeCorrectlyImplementedAnalyzerTests` tests pass, and `dotnet run --project src/DocumentationGenerator` exits 0 with no markdown changes.