### PR TITLE
Report relational and generic math NaN comparisons in MA0082

### DIFF
--- a/docs/Rules/MA0082.md
+++ b/docs/Rules/MA0082.md
@@ -7,4 +7,18 @@ Sources: [DoNotNaNInComparisonsAnalyzer.cs](https://github.com/meziantou/Meziant
 if (a == double.NaN) // non-compliant as it always returns false, should be double.IsNaN(a)
 if (a == float.NaN) // non-compliant as it always returns false, should be float.IsNaN(a)
 if (a == Half.NaN) // non-compliant as it always returns false, should be Half.IsNaN(a)
+
+// The relational operators are also always false when one of the operands is NaN
+if (a < double.NaN) // non-compliant as it always returns false
+if (a <= float.NaN) // non-compliant as it always returns false
+if (a > Half.NaN) // non-compliant as it always returns false
+if (a >= double.NaN) // non-compliant as it always returns false
+
+// Generic math: T.NaN resolves to IFloatingPointIeee754<TSelf>.NaN
+static bool IsNaN<T>(T a) where T : IFloatingPointIeee754<T>
+{
+    return a == T.NaN; // non-compliant as it always returns false, should be T.IsNaN(a)
+}
 ````
+
+The code fix is only provided for `==` and `!=`, as `double.IsNaN(a)` is not equivalent to a relational comparison with `NaN`, which is always `false`.

--- a/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotNaNInComparisonsFixer.cs
+++ b/src/Meziantou.Analyzer.CodeFixers/Rules/DoNotNaNInComparisonsFixer.cs
@@ -18,8 +18,6 @@ public sealed class DoNotNaNInComparisonsFixer : CodeFixProvider
         if (semanticModel is null)
             return;
 
-        var halfTypeSymbol = semanticModel.Compilation.GetBestTypeByMetadataName("System.Half");
-
         var binaryExpression = nodeToFix.FirstAncestorOrSelf<BinaryExpressionSyntax>();
         if (binaryExpression is null)
             return;
@@ -28,8 +26,13 @@ public sealed class DoNotNaNInComparisonsFixer : CodeFixProvider
         if (binaryOperation is null)
             return;
 
-        var leftIsNaN = TryGetNaNType(binaryOperation.LeftOperand, halfTypeSymbol, out _, out var leftSyntax);
-        var rightIsNaN = TryGetNaNType(binaryOperation.RightOperand, halfTypeSymbol, out _, out var rightSyntax);
+        // Only the equality comparisons can be rewritten to IsNaN.
+        // The relational comparisons are always false, so there is no equivalent expression to suggest.
+        if (binaryOperation.OperatorKind is not (BinaryOperatorKind.Equals or BinaryOperatorKind.NotEquals))
+            return;
+
+        var leftIsNaN = TryGetNaNType(binaryOperation.LeftOperand, semanticModel.Compilation, out _, out var leftSyntax);
+        var rightIsNaN = TryGetNaNType(binaryOperation.RightOperand, semanticModel.Compilation, out _, out var rightSyntax);
 
         // NaN == NaN is false and NaN != NaN is true, whereas IsNaN(NaN) is true.
         // Replacing the comparison would change the behavior of the code, so there is nothing to fix.
@@ -61,24 +64,17 @@ public sealed class DoNotNaNInComparisonsFixer : CodeFixProvider
     private static async Task<Document> FixComparison(Document document, IBinaryOperation binaryOperation, IOperation nanOperand, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var halfTypeSymbol = editor.SemanticModel.Compilation.GetBestTypeByMetadataName("System.Half");
-        if (!TryGetReplacementExpression(editor.Generator, binaryOperation, nanOperand, halfTypeSymbol, out var replacement))
+        if (!TryGetReplacementExpression(editor.Generator, binaryOperation, nanOperand, editor.SemanticModel.Compilation, out var replacement))
             return document;
 
         editor.ReplaceNode(binaryOperation.Syntax, replacement.WithTriviaFrom(binaryOperation.Syntax));
         return editor.GetChangedDocument();
     }
 
-    private static bool TryGetReplacementExpression(SyntaxGenerator generator, IBinaryOperation binaryOperation, IOperation nanOperand, INamedTypeSymbol? halfTypeSymbol, out ExpressionSyntax replacement)
+    private static bool TryGetReplacementExpression(SyntaxGenerator generator, IBinaryOperation binaryOperation, IOperation nanOperand, Compilation compilation, out ExpressionSyntax replacement)
     {
-        if (binaryOperation.OperatorKind is not (BinaryOperatorKind.Equals or BinaryOperatorKind.NotEquals))
-        {
-            replacement = null!;
-            return false;
-        }
-
-        var leftIsNaN = TryGetNaNType(binaryOperation.LeftOperand, halfTypeSymbol, out var leftType, out _);
-        var rightIsNaN = TryGetNaNType(binaryOperation.RightOperand, halfTypeSymbol, out var rightType, out _);
+        var leftIsNaN = TryGetNaNType(binaryOperation.LeftOperand, compilation, out var leftType, out _);
+        var rightIsNaN = TryGetNaNType(binaryOperation.RightOperand, compilation, out var rightType, out _);
         if (!leftIsNaN && !rightIsNaN)
         {
             replacement = null!;
@@ -118,7 +114,7 @@ public sealed class DoNotNaNInComparisonsFixer : CodeFixProvider
         return true;
     }
 
-    private static bool TryGetNaNType(IOperation operation, INamedTypeSymbol? halfTypeSymbol, out ITypeSymbol? typeSymbol, out ExpressionSyntax? expression)
+    private static bool TryGetNaNType(IOperation operation, Compilation compilation, out ITypeSymbol? typeSymbol, out ExpressionSyntax? expression)
     {
         while (operation is IConversionOperation conversionOperation)
         {
@@ -135,9 +131,19 @@ public sealed class DoNotNaNInComparisonsFixer : CodeFixProvider
                 return true;
             }
 
-            if (halfTypeSymbol is not null && containingType.IsEqualTo(halfTypeSymbol))
+            if (compilation.GetBestTypeByMetadataName("System.Half") is { } halfTypeSymbol && containingType.IsEqualTo(halfTypeSymbol))
             {
                 typeSymbol = containingType;
+                expression = memberReference.Syntax as ExpressionSyntax;
+                return true;
+            }
+
+            // Generic math: T.NaN where T is constrained to IFloatingPointIeee754<T>. The member is the one of the
+            // interface, so the type to call IsNaN on is its type argument, which is the type written in the code.
+            if (containingType is { TypeArguments: [{ } selfType] } &&
+                containingType.OriginalDefinition.IsEqualTo(compilation.GetBestTypeByMetadataName("System.Numerics.IFloatingPointIeee754`1")))
+            {
+                typeSymbol = selfType;
                 expression = memberReference.Syntax as ExpressionSyntax;
                 return true;
             }

--- a/src/Meziantou.Analyzer/Rules/DoNotNaNInComparisonsAnalyzer.cs
+++ b/src/Meziantou.Analyzer/Rules/DoNotNaNInComparisonsAnalyzer.cs
@@ -32,11 +32,14 @@ public sealed class DoNotNaNInComparisonsAnalyzer : DiagnosticAnalyzer
         public ISymbol? DoubleNaN { get; } = compilation.GetBestTypeByMetadataName("System.Double")?.GetMembers("NaN").FirstOrDefault();
         public ISymbol? SingleNaN { get; } = compilation.GetBestTypeByMetadataName("System.Single")?.GetMembers("NaN").FirstOrDefault();
         public ISymbol? HalfNaN { get; } = compilation.GetBestTypeByMetadataName("System.Half")?.GetMembers("NaN").FirstOrDefault();
+        public INamedTypeSymbol? FloatingPointIeee754 { get; } = compilation.GetBestTypeByMetadataName("System.Numerics.IFloatingPointIeee754`1");
 
         public void AnalyzeBinaryOperator(OperationAnalysisContext context)
         {
             var operation = (IBinaryOperation)context.Operation;
-            if (operation.OperatorKind is BinaryOperatorKind.Equals or BinaryOperatorKind.NotEquals)
+            if (operation.OperatorKind is BinaryOperatorKind.Equals or BinaryOperatorKind.NotEquals
+                or BinaryOperatorKind.LessThan or BinaryOperatorKind.LessThanOrEqual
+                or BinaryOperatorKind.GreaterThan or BinaryOperatorKind.GreaterThanOrEqual)
             {
                 AnalyzeOperand(context, operation.LeftOperand);
                 AnalyzeOperand(context, operation.RightOperand);
@@ -64,7 +67,21 @@ public sealed class DoNotNaNInComparisonsAnalyzer : DiagnosticAnalyzer
                 {
                     context.ReportDiagnostic(Rule, operation, "System.Half");
                 }
+                else if (GetIeee754NaNType(memberReference.Member) is { } type)
+                {
+                    // Generic math: T.NaN where T is constrained to IFloatingPointIeee754<T>
+                    context.ReportDiagnostic(Rule, operation, type.ToDisplayString());
+                }
             }
+        }
+
+        private ITypeSymbol? GetIeee754NaNType(ISymbol member)
+        {
+            if (member is { Name: "NaN", ContainingType: { TypeArguments: [{ } selfType] } containingType } &&
+                containingType.OriginalDefinition.IsEqualTo(FloatingPointIeee754))
+                return selfType;
+
+            return null;
         }
     }
 }

--- a/tests/Meziantou.Analyzer.Test/Rules/DoNotNaNInComparisonsAnalyzerTests.cs
+++ b/tests/Meziantou.Analyzer.Test/Rules/DoNotNaNInComparisonsAnalyzerTests.cs
@@ -23,6 +23,11 @@ public sealed class DoNotNaNInComparisonsAnalyzerTests
                     _ = 0d != {|MA0082:double.NaN|};
                     _ = {|MA0082:double.NaN|} == 0d;
                     _ = {|MA0082:double.NaN|} != 0d;
+                    _ = 0d < {|MA0082:double.NaN|};
+                    _ = 0d <= {|MA0082:double.NaN|};
+                    _ = 0d > {|MA0082:double.NaN|};
+                    _ = 0d >= {|MA0082:double.NaN|};
+                    _ = {|MA0082:double.NaN|} < 0d;
 
                     _ = 1f == 0f;
                     _ = 1f != 0f;
@@ -42,6 +47,97 @@ public sealed class DoNotNaNInComparisonsAnalyzerTests
                 }
             }
             """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Comparisons_GenericMath_CodeFix()
+    {
+        var test = CreateTest();
+        test.TestCode = """
+            using System.Numerics;
+            class Test
+            {
+                void A<T>(T value) where T : IFloatingPointIeee754<T>
+                {
+                    _ = value == {|MA0082:T.NaN|};
+                }
+
+                void B<T>(T value) where T : IBinaryFloatingPointIeee754<T>
+                {
+                    _ = {|MA0082:T.NaN|} != value;
+                }
+            }
+            """;
+        test.FixedCode = """
+            using System.Numerics;
+            class Test
+            {
+                void A<T>(T value) where T : IFloatingPointIeee754<T>
+                {
+                    _ = T.IsNaN(value);
+                }
+
+                void B<T>(T value) where T : IBinaryFloatingPointIeee754<T>
+                {
+                    _ = !T.IsNaN(value);
+                }
+            }
+            """;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Comparisons_GenericMath_BothOperandsAreNaN_NoCodeFix()
+    {
+        const string Source = """
+            using System.Numerics;
+            class Test
+            {
+                void A<T>() where T : IFloatingPointIeee754<T>
+                {
+                    _ = {|MA0082:T.NaN|} == {|MA0082:T.NaN|};
+                }
+            }
+            """;
+
+        var test = CreateTest();
+        test.TestCode = Source;
+        test.FixedCode = Source;
+
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task Comparisons_RelationalOperators_NoCodeFix()
+    {
+        const string Source = """
+            using System;
+            class Test
+            {
+                void A(double doubleValue, float floatValue, Half halfValue)
+                {
+                    _ = doubleValue < {|MA0082:double.NaN|};
+                    _ = doubleValue <= {|MA0082:double.NaN|};
+                    _ = doubleValue > {|MA0082:double.NaN|};
+                    _ = doubleValue >= {|MA0082:double.NaN|};
+                    _ = {|MA0082:float.NaN|} < floatValue;
+                    _ = halfValue >= {|MA0082:Half.NaN|};
+                }
+
+                void B<T>(T value) where T : System.Numerics.IFloatingPointIeee754<T>
+                {
+                    _ = value < {|MA0082:T.NaN|};
+                    _ = value >= {|MA0082:T.NaN|};
+                }
+            }
+            """;
+
+        var test = CreateTest();
+        test.TestCode = Source;
+        test.FixedCode = Source;
 
         return test.RunAsync();
     }


### PR DESCRIPTION
## Summary

MA0082 ("NaN should not be used in comparisons") had two false negatives:

1. **Relational operators.** Only `==` and `!=` were checked, but `<`, `<=`, `>` and `>=` against `NaN` are also always `false` by IEEE-754 and just as likely to be a bug.
2. **Generic math.** `T.NaN` where `T : IFloatingPointIeee754<T>` was not detected, since the analyzer only matched `double.NaN`, `float.NaN` and `Half.NaN`.

```csharp
bool A(double d) => d < double.NaN;   // now reported
bool B<T>(T v) where T : IFloatingPointIeee754<T> => v == T.NaN; // now reported
```

## Changes

**Analyzer**
- Adds `LessThan`, `LessThanOrEqual`, `GreaterThan` and `GreaterThanOrEqual` to the checked operator kinds.
- Reports a `NaN` member whose containing type's original definition is `System.Numerics.IFloatingPointIeee754<TSelf>`. `T.NaN` always binds to the declaring interface, so derived interfaces such as `IBinaryFloatingPointIeee754<T>` are covered too. The message uses the type argument (`T.NaN should not be used in comparisons`).
- On target frameworks without `IFloatingPointIeee754<>`, the symbol lookup returns null and nothing is reported.

**Code fixer**
- The "Use IsNaN" fix is only registered for `==` and `!=`. `IsNaN(x)` is not an equivalent replacement for `x < NaN`, which is a constant `false`. The operator check was previously inside the fix action (making it a no-op after being shown); it now runs before `RegisterCodeFix`, per the repo's validate-before-registering guideline.
- `value == T.NaN` → `T.IsNaN(value)`, `T.NaN != value` → `!T.IsNaN(value)`. The type used for `IsNaN` is the interface's type argument; `IsNaN` comes from `INumberBase<TSelf>`, which `IFloatingPointIeee754<TSelf>` inherits.
- `TryGetNaNType` now takes the `Compilation` rather than a pre-resolved `System.Half` symbol.

**Docs** — `docs/Rules/MA0082.md` gains relational and generic math examples, plus a note that the fix only applies to `==`/`!=`.

## Reviewer notes

- MA0082 is an enabled-by-default warning, so projects comparing against `NaN` with relational operators or `T.NaN` will get new warnings after upgrading.
- The generic math fix and "no fix" cases are in separate tests: the testing library drops markup for fixable diagnostic ids from the fixed state's expectations, so a single test can't hold both a fixed line and a remaining MA0082 diagnostic.

## Testing

- `dotnet build`: 0 warnings, 0 errors, all Roslyn versions.
- `DoNotNaNInComparisonsAnalyzerTests`: 8/8 pass on roslyn4.8, 4.14, 5.0, 5.6 and 5.9.
- Full suite on roslyn5.9: 4597 passed, 0 failed.
- `dotnet run --project src/DocumentationGenerator`: no further markdown changes.
